### PR TITLE
fix(elementTemplates): allow removing on root elements 

### DIFF
--- a/src/cloud-element-templates/cmd/index.js
+++ b/src/cloud-element-templates/cmd/index.js
@@ -1,9 +1,15 @@
 import ChangeElementTemplateHandler from './ChangeElementTemplateHandler';
+import RemoveElementTemplateHandler from '../../element-templates/cmd/RemoveElementTemplateHandler';
 
 function registerHandlers(commandStack, elementTemplates, eventBus) {
   commandStack.registerHandler(
     'propertiesPanel.zeebe.changeTemplate',
     ChangeElementTemplateHandler
+  );
+
+  commandStack.registerHandler(
+    'propertiesPanel.removeTemplate',
+    RemoveElementTemplateHandler
   );
 
   // apply default element templates on shape creation

--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -234,11 +234,16 @@ export default class ElementTemplates {
 
     const newBusinessObject = createBlankBusinessObject(element, this._injector);
 
-    return replace.replaceElement(element, {
-      type: type,
-      businessObject: newBusinessObject,
-      eventDefinitionType: eventDefinitionType
-    });
+    return replace.replaceElement(element,
+      {
+        type: type,
+        businessObject: newBusinessObject,
+        eventDefinitionType: eventDefinitionType,
+      },
+      {
+        createElementsBehavior: false
+      }
+    );
   }
 
   /**

--- a/src/element-templates/cmd/RemoveElementTemplateHandler.js
+++ b/src/element-templates/cmd/RemoveElementTemplateHandler.js
@@ -1,0 +1,147 @@
+import { getLabel, setLabel } from 'bpmn-js/lib/features/label-editing/LabelUtil';
+import { getShapeIdFromPlane, isPlane } from 'bpmn-js/lib/util/DrilldownUtil';
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+
+export default class RemoveElementTemplateHandler {
+  constructor(
+      modeling,
+      elementFactory,
+      elementRegistry,
+      canvas,
+      bpmnFactory,
+      replace,
+      commandStack
+  ) {
+    this._modeling = modeling;
+    this._elementFactory = elementFactory;
+    this._elementRegistry = elementRegistry;
+    this._canvas = canvas;
+    this._bpmnFactory = bpmnFactory;
+    this._replace = replace;
+    this._commandStack = commandStack;
+  }
+
+  preExecute(context) {
+    const {
+      element
+    } = context;
+
+    if (element.parent) {
+      context.newElement = this._removeTemplate(element);
+    } else {
+      context.newElement = this._removeRootTemplate(element);
+    }
+  }
+
+  _removeTemplate(element) {
+    const replace = this._replace;
+
+    const businessObject = getBusinessObject(element);
+
+    const type = businessObject.$type,
+          eventDefinitionType = this._getEventDefinitionType(businessObject);
+
+    const newBusinessObject = this._createBlankBusinessObject(element);
+
+    return replace.replaceElement(element,
+      {
+        type: type,
+        businessObject: newBusinessObject,
+        eventDefinitionType: eventDefinitionType,
+      },
+      {
+        createElementsBehavior: false
+      }
+    );
+  }
+
+  /**
+   * Remove template from a given element.
+   *
+   * @param {djs.model.Base} element
+   *
+   * @return {djs.model.Base} the updated element
+   */
+  _removeRootTemplate(element) {
+    var modeling = this._modeling,
+        elementFactory = this._elementFactory,
+        elementRegistry = this._elementRegistry,
+        canvas = this._canvas;
+
+    // We are inside a collapsed subprocess, move up to the parent before replacing the collapsed object
+    if (isPlane(element)) {
+      const shapeId = getShapeIdFromPlane(element);
+      const shape = elementRegistry.get(shapeId);
+
+      if (shape && shape !== element) {
+        canvas.setRootElement(canvas.findRoot(shape));
+        return this._removeTemplate(shape);
+      }
+    }
+
+    const businessObject = getBusinessObject(element);
+
+    const type = businessObject.$type;
+
+    const newBusinessObject = this._createBlankBusinessObject(element);
+
+    const newRoot = elementFactory.create('root', {
+      type: type,
+      businessObject: newBusinessObject
+    });
+
+    this._commandStack.execute('canvas.updateRoot', {
+      newRoot: newRoot,
+      oldRoot: element
+    });
+
+    modeling.moveElements(element.children, { x: 0, y: 0 }, newRoot);
+
+    return newRoot;
+  }
+
+  _getEventDefinitionType(businessObject) {
+    if (!businessObject.eventDefinitions) {
+      return null;
+    }
+
+    const eventDefinition = businessObject.eventDefinitions[ 0 ];
+
+    if (!eventDefinition) {
+      return null;
+    }
+
+    return eventDefinition.$type;
+  }
+
+  _createBlankBusinessObject(element) {
+    const bpmnFactory = this._bpmnFactory;
+
+    const bo = getBusinessObject(element),
+          newBo = bpmnFactory.create(bo.$type),
+          label = getLabel(element);
+
+    if (!label) {
+      return newBo;
+    }
+
+    if (is(element, 'bpmn:Group')) {
+      newBo.categoryValueRef = bpmnFactory.create('bpmn:CategoryValue');
+    }
+
+    setLabel({ businessObject: newBo }, label);
+
+    return newBo;
+  }
+}
+
+
+RemoveElementTemplateHandler.$inject = [
+  'modeling',
+  'elementFactory',
+  'elementRegistry',
+  'canvas',
+  'bpmnFactory',
+  'replace',
+  'commandStack'
+];

--- a/src/element-templates/cmd/index.js
+++ b/src/element-templates/cmd/index.js
@@ -1,9 +1,15 @@
 import ChangeElementTemplateHandler from './ChangeElementTemplateHandler';
+import RemoveElementTemplateHandler from './RemoveElementTemplateHandler';
 
 function registerHandlers(commandStack, elementTemplates, eventBus) {
   commandStack.registerHandler(
     'propertiesPanel.camunda.changeTemplate',
     ChangeElementTemplateHandler
+  );
+
+  commandStack.registerHandler(
+    'propertiesPanel.removeTemplate',
+    RemoveElementTemplateHandler
   );
 
   // apply default element templates on shape creation

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -20,8 +20,7 @@ import Modeler from 'bpmn-js/lib/Modeler';
 import {
   BpmnPropertiesPanelModule,
   BpmnPropertiesProviderModule,
-  ZeebePropertiesProviderModule,
-  ElementTemplatesPropertiesProviderModule
+  ZeebePropertiesProviderModule
 } from 'bpmn-js-properties-panel';
 
 import LintingModule from '@camunda/linting/modeler';
@@ -38,6 +37,7 @@ import CamundaModdle from 'camunda-bpmn-moddle/resources/camunda';
 import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import CloudElementTemplatesPropertiesProviderModule from 'src/cloud-element-templates';
+import ElementTemplatesPropertiesProviderModule from 'src/element-templates';
 
 import { ElementTemplateLinterPlugin } from 'src/cloud-element-templates/LinterPlugin';
 
@@ -295,6 +295,15 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
         elementTemplates
       }
     );
+
+    const modeler = result.modeler;
+    const bpmnjs = modeler.get('bpmnjs');
+    const propertiesPanelParent = domify('<div class="properties-panel-container"></div>');
+
+    bpmnjs._container.appendChild(propertiesPanelParent);
+
+    modeler.get('propertiesPanel').attachTo(propertiesPanelParent);
+
 
     // then
     expect(result.error).not.to.exist;

--- a/test/spec/cloud-element-templates/ElementTemplates.bpmn
+++ b/test/spec/cloud-element-templates/ElementTemplates.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
-  <bpmn:process id="Process_1" isExecutable="true">
+  <bpmn:process id="Process_1" isExecutable="true" zeebe:modelerTemplate="process-template" zeebe:modelerTemplateVersion="1">
     <bpmn:task id="Task_1" name="foo" zeebe:modelerTemplate="foo" />
     <bpmn:task id="Task_2" name="icon" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg xmlns=&#39;http://www.w3.org/2000/svg&#39; height=&#39;100&#39; width=&#39;100&#39;%3E%3Ccircle cx=&#39;50&#39; cy=&#39;50&#39; r=&#39;40&#39; stroke=&#39;black&#39; stroke-width=&#39;3&#39; fill=&#39;red&#39; /%3E%3C/svg%3E" />
     <bpmn:task id="Task_3" />
@@ -30,6 +30,11 @@
     <bpmn:intermediateCatchEvent id="MessageEvent" zeebe:modelerTemplate="updateTemplate" zeebe:modelerTemplateVersion="1">
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ki3umf" messageRef="Message_0zwscdd" />
     </bpmn:intermediateCatchEvent>
+    <bpmn:subProcess id="SubProcess_1" zeebe:modelerTemplate="processFefaults-c8" zeebe:modelerTemplateVersion="1">
+      <bpmn:extensionElements />
+      <bpmn:startEvent id="Event_0zbvlz6" />
+    </bpmn:subProcess>
+    <bpmn:exclusiveGateway id="Gateway_1" />
     <bpmn:group id="Group_1" categoryValueRef="CategoryValue_025ggwq" />
     <bpmn:textAnnotation id="TextAnnotation_1">
       <bpmn:text>Text Annotation</bpmn:text>
@@ -80,6 +85,12 @@
       <bpmndi:BPMNShape id="Event_0rxdmt7_di" bpmnElement="MessageEvent">
         <dc:Bounds x="252" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_04x2ssk_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="175" y="70" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sitnpj_di" bpmnElement="SubProcess_1" isExpanded="false">
+        <dc:Bounds x="390" y="520" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
         <dc:Bounds x="550" y="160" width="300" height="300" />
         <bpmndi:BPMNLabel>
@@ -94,6 +105,13 @@
         <di:waypoint x="840" y="160" />
         <di:waypoint x="886" y="110" />
       </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0h3d15h">
+    <bpmndi:BPMNPlane id="BPMNPlane_125hxtj" bpmnElement="SubProcess_1">
+      <bpmndi:BPMNShape id="Event_0zbvlz6_di" bpmnElement="Event_0zbvlz6">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -168,7 +168,9 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         [ 'foo', 3 ],
         [ 'bar', 1 ],
         [ 'bar', 2 ],
-        [ 'baz' ]
+        [ 'baz' ],
+        [ 'process-template', 1 ],
+        [ 'subprocess-template', 1 ]
       ]);
     }));
 
@@ -234,7 +236,9 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         [ 'default', 1 ],
         [ 'foo', 3 ],
         [ 'bar', 2 ],
-        [ 'baz' ]
+        [ 'baz' ],
+        [ 'process-template', 1 ],
+        [ 'subprocess-template', 1 ]
       ]);
     }));
 
@@ -251,7 +255,9 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         [ 'default', 1 ],
         [ 'foo', 3 ],
         [ 'bar', 2 ],
-        [ 'baz' ]
+        [ 'baz' ],
+        [ 'process-template', 1 ],
+        [ 'subprocess-template', 1 ]
       ]);
     }));
 
@@ -882,6 +888,42 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should remove process template', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let process = elementRegistry.get('Process_1');
+      const children = [ ...process.children ];
+
+      // when
+      process = elementTemplates.removeTemplate(process);
+
+      // then
+      const processBo = getBusinessObject(process);
+
+      expect(processBo.modelerTemplate).not.to.exist;
+      expect(processBo.modelerTemplateVersion).not.to.exist;
+      expect(process.children.length).to.eql(children.length);
+    }));
+
+
+    it('should remove subprocess template (plane)', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let subprocess = elementRegistry.get('SubProcess_1');
+      let subprocessPlane = elementRegistry.get('SubProcess_1_plane');
+
+      // when
+      subprocess = elementTemplates.removeTemplate(subprocessPlane);
+
+      // then
+      const taskBo = getBusinessObject(subprocess);
+
+      expect(taskBo.modelerTemplate).not.to.exist;
+      expect(taskBo.modelerTemplateVersion).not.to.exist;
+      expect(taskBo.flowElements).to.have.length(1);
+    }));
+
+
     it('should fire elementTemplates.remove event', inject(function(elementRegistry, elementTemplates, eventBus) {
 
       // given
@@ -899,6 +941,7 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         element: task
       });
     }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -813,6 +813,22 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should remove default task template', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let task = elementRegistry.get('ServiceTask');
+
+      // when
+      task = elementTemplates.removeTemplate(task);
+
+      // then
+      const taskBo = getBusinessObject(task);
+
+      expect(taskBo.modelerTemplate).not.to.exist;
+      expect(taskBo.modelerTemplateVersion).not.to.exist;
+    }));
+
+
     it('should remove group template', inject(function(elementRegistry, elementTemplates) {
 
       // given

--- a/test/spec/cloud-element-templates/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplatesPropertiesProvider.spec.js
@@ -126,7 +126,7 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
       async function(elementRegistry, selection) {
 
         // given
-        const element = elementRegistry.get('Process_1');
+        const element = elementRegistry.get('Gateway_1');
 
         // when
         await act(() => {

--- a/test/spec/cloud-element-templates/fixtures/simple.json
+++ b/test/spec/cloud-element-templates/fixtures/simple.json
@@ -96,5 +96,21 @@
     "isDefault": true,
     "appliesTo": [ "bpmn:ServiceTask" ],
     "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "process-template",
+    "name": "Process Template",
+    "version": 1,
+    "appliesTo": [ "bpmn:Process" ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "subprocess-template",
+    "name": "Subprocess Template",
+    "version": 1,
+    "appliesTo": [ "bpmn:SubProcess" ],
+    "properties": []
   }
 ]

--- a/test/spec/element-templates/ElementTemplates.bpmn
+++ b/test/spec/element-templates/ElementTemplates.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
-  <bpmn:process id="Process_1" isExecutable="true">
+  <bpmn:process id="Process_1" isExecutable="true" camunda:modelerTemplate="process-template">
     <bpmn:task id="Task_1" name="Task 1" camunda:modelerTemplate="foo" />
     <bpmn:task id="Task_2" camunda:modelerTemplate="foo" camunda:modelerTemplateVersion="1" />
     <bpmn:task id="Task_3" />
@@ -12,6 +12,9 @@
       </bpmn:conditionalEventDefinition>
     </bpmn:startEvent>
     <bpmn:task id="Task_4" name="Task 4" camunda:modelerTemplate="foo" camunda:modelerTemplateVersion="1" camunda:asyncBefore="true" />
+    <bpmn:subProcess id="SubProcess_1" camunda:modelerTemplate="subprocess-template">
+      <bpmn:startEvent id="Event_1giqjyx" />
+    </bpmn:subProcess>
     <bpmn:group id="Group_1" categoryValueRef="CategoryValue_17hkdy6" camunda:modelerTemplate="qux" />
     <bpmn:textAnnotation id="TextAnnotation_1" camunda:modelerTemplate="qux">
       <bpmn:text>Text Annotation 1</bpmn:text>
@@ -48,6 +51,9 @@
         <dc:Bounds x="270" y="300" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="false">
+        <dc:Bounds x="390" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_1b78rp5_di" bpmnElement="Group_1">
         <dc:Bounds x="630" y="160" width="300" height="300" />
         <bpmndi:BPMNLabel>
@@ -62,6 +68,13 @@
         <di:waypoint x="920" y="160" />
         <di:waypoint x="966" y="110" />
       </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_01zdk2b">
+    <bpmndi:BPMNPlane id="BPMNPlane_0l1at01" bpmnElement="SubProcess_1">
+      <bpmndi:BPMNShape id="Event_1giqjyx_di" bpmnElement="Event_1giqjyx">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/element-templates/ElementTemplates.spec.js
+++ b/test/spec/element-templates/ElementTemplates.spec.js
@@ -175,7 +175,9 @@ describe('provider/element-templates - ElementTemplates', function() {
         [ 'bar', 2 ],
         [ 'baz' ],
         [ 'deprecated' ],
-        [ 'qux' ]
+        [ 'qux' ],
+        [ 'process-template' ],
+        [ 'subprocess-template' ]
       ]);
     }));
 
@@ -242,7 +244,9 @@ describe('provider/element-templates - ElementTemplates', function() {
         [ 'foo', 3 ],
         [ 'bar', 2 ],
         [ 'baz' ],
-        [ 'qux' ]
+        [ 'qux' ],
+        [ 'process-template' ],
+        [ 'subprocess-template' ]
       ]);
     }));
 
@@ -259,7 +263,9 @@ describe('provider/element-templates - ElementTemplates', function() {
         [ 'bar', 2 ],
         [ 'baz' ],
         [ 'deprecated' ],
-        [ 'qux' ]
+        [ 'qux' ],
+        [ 'process-template' ],
+        [ 'subprocess-template' ]
       ]);
     }));
 
@@ -489,6 +495,42 @@ describe('provider/element-templates - ElementTemplates', function() {
       expect(eventBo.modelerTemplateVersion).not.to.exist;
       expect(eventBo.eventDefinitions).to.have.length(1);
       expect(eventBo.asyncBefore).to.be.false;
+    }));
+
+
+    it('should remove process template', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let process = elementRegistry.get('Process_1');
+      const children = [ ...process.children ];
+
+      // when
+      process = elementTemplates.removeTemplate(process);
+
+      // then
+      const processBo = getBusinessObject(process);
+
+      expect(processBo.modelerTemplate).not.to.exist;
+      expect(processBo.modelerTemplateVersion).not.to.exist;
+      expect(process.children.length).to.eql(children.length);
+    }));
+
+
+    it('should remove subprocess template (plane)', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let subprocess = elementRegistry.get('SubProcess_1');
+      let subprocessPlane = elementRegistry.get('SubProcess_1_plane');
+
+      // when
+      subprocess = elementTemplates.removeTemplate(subprocessPlane);
+
+      // then
+      const taskBo = getBusinessObject(subprocess);
+
+      expect(taskBo.modelerTemplate).not.to.exist;
+      expect(taskBo.modelerTemplateVersion).not.to.exist;
+      expect(taskBo.flowElements).to.have.length(1);
     }));
 
   });

--- a/test/spec/element-templates/ElementTemplates.spec.js
+++ b/test/spec/element-templates/ElementTemplates.spec.js
@@ -421,6 +421,23 @@ describe('provider/element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should remove default task template', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let task = elementRegistry.get('ServiceTask');
+
+      // when
+      task = elementTemplates.removeTemplate(task);
+
+      // then
+      const taskBo = getBusinessObject(task);
+
+      expect(taskBo.modelerTemplate).not.to.exist;
+      expect(taskBo.modelerTemplateVersion).not.to.exist;
+      expect(taskBo.asyncBefore).to.be.false;
+    }));
+
+
     it('should remove group template', inject(function(elementRegistry, elementTemplates) {
 
       // given

--- a/test/spec/element-templates/ElementTemplatesPropertiesProvider.bpmn
+++ b/test/spec/element-templates/ElementTemplatesPropertiesProvider.bpmn
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="Task_1" camunda:modelerTemplate="foo" />
     <bpmn:task id="Task_2" camunda:modelerTemplate="foo" camunda:modelerTemplateVersion="1" />
     <bpmn:task id="Task_3" />
     <bpmn:task id="UnknownTemplateTask" camunda:modelerTemplate="unknown" />
     <bpmn:serviceTask id="ServiceTask" camunda:modelerTemplate="default" />
-    <bpmn:serviceTask id="ServiceTaskWithInputOutputError" camunda:type="external" camunda:topic="topic" camunda:modelerTemplate="input-output-error" camunda:modelerTemplateVersion="1">
+    <bpmn:serviceTask id="ServiceTaskWithInputOutputError" camunda:modelerTemplate="input-output-error" camunda:modelerTemplateVersion="1" camunda:type="external" camunda:topic="topic">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="input-1-name">input-1-value</camunda:inputParameter>
           <camunda:outputParameter name="output-1-value">output-1-source</camunda:outputParameter>
         </camunda:inputOutput>
-         <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_error-1" expression="error-expression" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_error-1" expression="error-expression" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1" />
   </bpmn:process>
   <bpmn:error id="Error_error-1" name="error-name" errorCode="error-code" camunda:errorMessage="error-message" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -36,6 +37,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTaskWithInputOutputError_di" bpmnElement="ServiceTaskWithInputOutputError">
         <dc:Bounds x="150" y="300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1l7vqgv_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="295" y="215" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/element-templates/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/ElementTemplatesPropertiesProvider.spec.js
@@ -83,7 +83,7 @@ describe('provider/element-templates - ElementTemplates', function() {
       async function(elementRegistry, selection) {
 
         // given
-        const element = elementRegistry.get('Process_1');
+        const element = elementRegistry.get('Gateway_1');
 
         // when
         await act(() => {

--- a/test/spec/element-templates/fixtures/simple.json
+++ b/test/spec/element-templates/fixtures/simple.json
@@ -66,10 +66,22 @@
     ],
     "properties": []
   },
-    {
+  {
     "id": "qux",
     "name":"Qux",
     "appliesTo": [ "bpmn:TextAnnotation" ],
+    "properties": []
+  },
+  {
+    "id": "process-template",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:Process" ],
+    "properties": []
+  },
+  {
+    "id": "subprocess-template",
+    "name":"Foo",
+    "appliesTo": [ "bpmn:SubProcess" ],
     "properties": []
   }
 ]


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3688

Limitations: we are switching planes when we do the operation for a collapsed subprocess. As we replace the element, we also recreate the plane.
While not the best UX, I did not find a satisfactory solution now. Let's keep it like this and revisit should this edge-case be encountered by our users.

![Recording 2023-07-26 at 14 44 04](https://github.com/bpmn-io/bpmn-js-element-templates/assets/21984219/9114cc89-d09b-4d0c-9ee0-7385c4f043d0)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
