### PR TITLE
feat(element-templates): Named property binding for execution listeners

### DIFF
--- a/src/element-templates/CreateHelper.js
+++ b/src/element-templates/CreateHelper.js
@@ -150,28 +150,27 @@ export function createCamundaOut(binding, value, bpmnFactory) {
  *
  * @return {ModdleElement}
  */
-export function createCamundaExecutionListenerScript(binding, value, bpmnFactory) {
+export function createCamundaExecutionListener(binding, value, bpmnFactory) {
   const {
     event,
+    name,
     scriptFormat
   } = binding;
 
-  let parameterValue,
-      parameterDefinition;
-
   if (scriptFormat) {
-    parameterDefinition = bpmnFactory.create('camunda:Script', {
-      scriptFormat,
-      value
+    return bpmnFactory.create('camunda:ExecutionListener', {
+      event,
+      script: bpmnFactory.create('camunda:Script', {
+        scriptFormat,
+        value
+      })
     });
-  } else {
-    parameterValue = value;
   }
 
+  const boundPropertyName = name || 'value';
   return bpmnFactory.create('camunda:ExecutionListener', {
     event,
-    value: parameterValue,
-    script: parameterDefinition
+    [boundPropertyName]: value
   });
 }
 

--- a/src/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -14,7 +14,7 @@ import {
 import handleLegacyScopes from '../util/handleLegacyScopes';
 
 import {
-  createCamundaExecutionListenerScript,
+  createCamundaExecutionListener,
   createCamundaFieldInjection,
   createCamundaIn,
   createCamundaInWithBusinessKey,
@@ -253,7 +253,7 @@ export default class ChangeElementTemplateHandler {
       const newBinding = newProperty.binding,
             propertyValue = newProperty.value;
 
-      return createCamundaExecutionListenerScript(newBinding, propertyValue, bpmnFactory);
+      return createCamundaExecutionListener(newBinding, propertyValue, bpmnFactory);
     });
 
     commandStack.execute('element.updateModdleProperties', {

--- a/test/spec/element-templates/CreateHelper.spec.js
+++ b/test/spec/element-templates/CreateHelper.spec.js
@@ -15,7 +15,7 @@ import camundaModdlePackage from 'camunda-bpmn-moddle/resources/camunda';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  createCamundaExecutionListenerScript,
+  createCamundaExecutionListener,
   createCamundaIn,
   createCamundaInWithBusinessKey,
   createCamundaOut,
@@ -471,7 +471,7 @@ describe('provider/element-templates - CreateHelper', function() {
       };
 
       // when
-      const listener = createCamundaExecutionListenerScript(binding, 'println execution.eventName', bpmnFactory);
+      const listener = createCamundaExecutionListener(binding, 'println execution.eventName', bpmnFactory);
 
       // then
       expect(listener).to.jsonEqual({
@@ -482,6 +482,26 @@ describe('provider/element-templates - CreateHelper', function() {
           scriptFormat: 'groovy',
           value: 'println execution.eventName'
         }
+      });
+    }));
+
+    it('should bind value to configured property', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        name: 'class'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, 'path.to.my.class', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        class: 'path.to.my.class'
       });
     }));
 


### PR DESCRIPTION
Before this change we only evaluated the special case for scripts. For everything else we always used the value property. But for some cases e. g. class-based execution listeners we need actually need to set the "class" attribute instead. Also, this align with the json schema definition.

Closes #13 
