### PR TITLE
Support `camunda:executionListener` with `implementationType` property binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `DEPS`: update to `@bpmn-io/element-templates-validator@1.2.0`
+
 ## 1.4.0
 
 * `FEAT`: visually show deprecated templates ([#11](https://github.com/bpmn-io/bpmn-js-element-templates/issues/11))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^1.0.0",
+        "@bpmn-io/element-templates-validator": "^1.2.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "bpmnlint": "^8.3.2",
         "classnames": "^2.3.1",
@@ -581,20 +581,20 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.0.0.tgz",
-      "integrity": "sha512-v8AJk1WjTZpS3am8aAPnjm26/v5PdMJvyacEW1I1sFrIx99/FO4QLfAuk0qdkwvIUmzpR6xB4kuF3o+k4dBzYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.2.0.tgz",
+      "integrity": "sha512-biRZpyp/VyYZdlR569S9PmMDsX4qUXiNayiImAWitVvBfGOFCVrAdPNU1QKFzf1zicFb3FD2FXtPyj7Y1v9cQg==",
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.13.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.11.0",
+        "@camunda/element-templates-json-schema": "^0.15.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.13.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       }
     },
     "node_modules/@bpmn-io/element-templates-validator/node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.13.0.tgz",
-      "integrity": "sha512-G6FMLRL/AAFlnBoMye2qpit3KucEDR7Ga1lmDiAEsMdAMcULEF0Vp6ehmhomU7GrCCsgj40jkkfuS2br+kn21g=="
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.15.0.tgz",
+      "integrity": "sha512-z8JDLbftmJApH8vLolYt9A1eILzjQZ71tbqaHuGWKZIrllj9Tu4LlJtgKodm7EJs/N4e4VucnI7ZMX1rQjxFJg=="
     },
     "node_modules/@bpmn-io/extract-process-variables": {
       "version": "0.8.0",
@@ -747,9 +747,9 @@
       "dev": true
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.11.0.tgz",
-      "integrity": "sha512-o7M7xWL9dCrZHAYwr3Q51kopjjd4HSq9G84mBukU6+JirHnSD6hw51mE6z5njJha1u0mOWPBM3m/iR9t9WrjnA=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.13.0.tgz",
+      "integrity": "sha512-olX2tIbdLYpGQEC1WKeSK4HrWkzopXBpyGs7KWBUIzKAxSI/b2oVNZw8sj8kN+8gxQsVkpff+EQEplrl6SdFkA=="
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.9.0",
@@ -10205,20 +10205,20 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.0.0.tgz",
-      "integrity": "sha512-v8AJk1WjTZpS3am8aAPnjm26/v5PdMJvyacEW1I1sFrIx99/FO4QLfAuk0qdkwvIUmzpR6xB4kuF3o+k4dBzYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.2.0.tgz",
+      "integrity": "sha512-biRZpyp/VyYZdlR569S9PmMDsX4qUXiNayiImAWitVvBfGOFCVrAdPNU1QKFzf1zicFb3FD2FXtPyj7Y1v9cQg==",
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.13.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.11.0",
+        "@camunda/element-templates-json-schema": "^0.15.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.13.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       },
       "dependencies": {
         "@camunda/element-templates-json-schema": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.13.0.tgz",
-          "integrity": "sha512-G6FMLRL/AAFlnBoMye2qpit3KucEDR7Ga1lmDiAEsMdAMcULEF0Vp6ehmhomU7GrCCsgj40jkkfuS2br+kn21g=="
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.15.0.tgz",
+          "integrity": "sha512-z8JDLbftmJApH8vLolYt9A1eILzjQZ71tbqaHuGWKZIrllj9Tu4LlJtgKodm7EJs/N4e4VucnI7ZMX1rQjxFJg=="
         }
       }
     },
@@ -10367,9 +10367,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.11.0.tgz",
-      "integrity": "sha512-o7M7xWL9dCrZHAYwr3Q51kopjjd4HSq9G84mBukU6+JirHnSD6hw51mE6z5njJha1u0mOWPBM3m/iR9t9WrjnA=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.13.0.tgz",
+      "integrity": "sha512-olX2tIbdLYpGQEC1WKeSK4HrWkzopXBpyGs7KWBUIzKAxSI/b2oVNZw8sj8kN+8gxQsVkpff+EQEplrl6SdFkA=="
     },
     "@codemirror/autocomplete": {
       "version": "6.9.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^1.0.0",
+    "@bpmn-io/element-templates-validator": "^1.2.0",
     "@bpmn-io/extract-process-variables": "^0.8.0",
     "bpmnlint": "^8.3.2",
     "classnames": "^2.3.1",

--- a/src/element-templates/CreateHelper.js
+++ b/src/element-templates/CreateHelper.js
@@ -153,11 +153,12 @@ export function createCamundaOut(binding, value, bpmnFactory) {
 export function createCamundaExecutionListener(binding, value, bpmnFactory) {
   const {
     event,
-    name,
+    implementationType,
     scriptFormat
   } = binding;
 
-  if (scriptFormat) {
+  // To guarantee backwards compatibility scriptFormat is taken into account and has precedence before any other type
+  if (implementationType === 'script' || scriptFormat) {
     return bpmnFactory.create('camunda:ExecutionListener', {
       event,
       script: bpmnFactory.create('camunda:Script', {
@@ -167,10 +168,9 @@ export function createCamundaExecutionListener(binding, value, bpmnFactory) {
     });
   }
 
-  const boundPropertyName = name || 'value';
   return bpmnFactory.create('camunda:ExecutionListener', {
     event,
-    [boundPropertyName]: value
+    [implementationType]: value
   });
 }
 

--- a/src/element-templates/CreateHelper.js
+++ b/src/element-templates/CreateHelper.js
@@ -150,28 +150,27 @@ export function createCamundaOut(binding, value, bpmnFactory) {
  *
  * @return {ModdleElement}
  */
-export function createCamundaExecutionListenerScript(binding, value, bpmnFactory) {
+export function createCamundaExecutionListener(binding, value, bpmnFactory) {
   const {
     event,
+    name,
     scriptFormat
   } = binding;
 
-  let parameterValue,
-      parameterDefinition;
-
   if (scriptFormat) {
-    parameterDefinition = bpmnFactory.create('camunda:Script', {
-      scriptFormat,
-      value
+    return bpmnFactory.create('camunda:ExecutionListener', {
+      event,
+      script: bpmnFactory.create('camunda:Script', {
+        scriptFormat,
+        value
+      })
     });
-  } else {
-    parameterValue = value;
   }
 
+  const boundPropertyName = name || 'value';
   return bpmnFactory.create('camunda:ExecutionListener', {
     event,
-    value: parameterValue,
-    script: parameterDefinition
+    [boundPropertyName]: value
   });
 }
 

--- a/src/element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/element-templates/cmd/ChangeElementTemplateHandler.js
@@ -14,7 +14,7 @@ import {
 import handleLegacyScopes from '../util/handleLegacyScopes';
 
 import {
-  createCamundaExecutionListenerScript,
+  createCamundaExecutionListener,
   createCamundaFieldInjection,
   createCamundaIn,
   createCamundaInWithBusinessKey,
@@ -253,7 +253,7 @@ export default class ChangeElementTemplateHandler {
       const newBinding = newProperty.binding,
             propertyValue = newProperty.value;
 
-      return createCamundaExecutionListenerScript(newBinding, propertyValue, bpmnFactory);
+      return createCamundaExecutionListener(newBinding, propertyValue, bpmnFactory);
     });
 
     commandStack.execute('element.updateModdleProperties', {

--- a/test/spec/element-templates/CreateHelper.spec.js
+++ b/test/spec/element-templates/CreateHelper.spec.js
@@ -15,7 +15,7 @@ import camundaModdlePackage from 'camunda-bpmn-moddle/resources/camunda';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
-  createCamundaExecutionListenerScript,
+  createCamundaExecutionListener,
   createCamundaIn,
   createCamundaInWithBusinessKey,
   createCamundaOut,
@@ -471,7 +471,7 @@ describe('provider/element-templates - CreateHelper', function() {
       };
 
       // when
-      const listener = createCamundaExecutionListenerScript(binding, 'println execution.eventName', bpmnFactory);
+      const listener = createCamundaExecutionListener(binding, 'println execution.eventName', bpmnFactory);
 
       // then
       expect(listener).to.jsonEqual({
@@ -482,6 +482,26 @@ describe('provider/element-templates - CreateHelper', function() {
           scriptFormat: 'groovy',
           value: 'println execution.eventName'
         }
+      });
+    }));
+
+    it('should bind value to configured property', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        name: 'class'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, 'path.to.my.class', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        class: 'path.to.my.class'
       });
     }));
 

--- a/test/spec/element-templates/CreateHelper.spec.js
+++ b/test/spec/element-templates/CreateHelper.spec.js
@@ -461,7 +461,7 @@ describe('provider/element-templates - CreateHelper', function() {
 
   describe('createExecutionListener', function() {
 
-    it('should create script', inject(function(bpmnFactory) {
+    it('should create script without explicit implementation type', inject(function(bpmnFactory) {
 
       // given
       const binding = {
@@ -485,13 +485,63 @@ describe('provider/element-templates - CreateHelper', function() {
       });
     }));
 
-    it('should bind value to configured property', inject(function(bpmnFactory) {
+    it('should create script with implementation type script', inject(function(bpmnFactory) {
 
       // given
       const binding = {
         type: 'camunda:executionListener',
         event: 'end',
-        name: 'class'
+        implementationType: 'script',
+        scriptFormat: 'groovy'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, 'println execution.eventName', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        script: {
+          $type: 'camunda:Script',
+          scriptFormat: 'groovy',
+          value: 'println execution.eventName'
+        }
+      });
+    }));
+
+    it('should create script with with script format ignoring the implementation type for backwards compatibility', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        implementationType: 'class',
+        scriptFormat: 'groovy'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, 'println execution.eventName', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        script: {
+          $type: 'camunda:Script',
+          scriptFormat: 'groovy',
+          value: 'println execution.eventName'
+        }
+      });
+    }));
+
+    it('should create class-based execution listener', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        implementationType: 'class'
       };
 
       // when
@@ -502,6 +552,46 @@ describe('provider/element-templates - CreateHelper', function() {
         $type: 'camunda:ExecutionListener',
         event: 'end',
         class: 'path.to.my.class'
+      });
+    }));
+
+    it('should create expression-based execution listener', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        implementationType: 'expression'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, '${expression}', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        expression: '${expression}'
+      });
+    }));
+
+    it('should create delegateExpression-based execution listener', inject(function(bpmnFactory) {
+
+      // given
+      const binding = {
+        type: 'camunda:executionListener',
+        event: 'end',
+        implementationType: 'delegateExpression'
+      };
+
+      // when
+      const listener = createCamundaExecutionListener(binding, '${delegate}', bpmnFactory);
+
+      // then
+      expect(listener).to.jsonEqual({
+        $type: 'camunda:ExecutionListener',
+        event: 'end',
+        delegateExpression: '${delegate}'
       });
     }));
 


### PR DESCRIPTION
Before this change we only evaluated the special case for scripts. For everything else we always used the value property. But for some cases e. g. class-based execution listeners we need actually need to set the "class" attribute instead. Also, this align with the json schema definition.

Closes https://github.com/bpmn-io/bpmn-js-element-templates/issues/13

Note: I had to reopen, because I deleted my fork when cleaning up my repos... Forgot about the open pull request. See #15 