### PR TITLE
fix(Condition): use update logic for applying conditions

### DIFF
--- a/src/cloud-element-templates/Helper.js
+++ b/src/cloud-element-templates/Helper.js
@@ -143,6 +143,10 @@ export function findMessage(businessObject) {
     businessObject = eventDefinitions[0];
   }
 
+  if (!businessObject) {
+    return;
+  }
+
   return businessObject.get('messageRef');
 }
 

--- a/src/cloud-element-templates/util/rootElementUtil.js
+++ b/src/cloud-element-templates/util/rootElementUtil.js
@@ -36,6 +36,11 @@ export function removeMessage(element, injector) {
 
   const bo = getReferringElement(element);
 
+  // Event does not have an event definition
+  if (!bo) {
+    return;
+  }
+
   const message = findMessage(bo);
 
   if (!message) {

--- a/test/spec/cloud-element-templates/ElementTemplateConditionChecker.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplateConditionChecker.spec.js
@@ -21,6 +21,8 @@ import messageDiagramXML from './fixtures/condition-message.bpmn';
 import messageCorrelationDiagramXML from './fixtures/message-correlation-key.bpmn';
 
 import template from './fixtures/condition.json';
+import updateTemplates from './fixtures/condition-update.json';
+
 import messageTemplates from './fixtures/condition-message.json';
 import messageCorrelationTemplate from './fixtures/message-correlation-key.json';
 
@@ -78,8 +80,8 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         // then
         expect(businessObject.get('customProperty')).to.exist;
 
-        expect(businessObject.get('noDefaultProperty')).to.exist;
-        expect(businessObject.get('noDefaultProperty')).to.equal('');
+        // empty values are not persisted in XML
+        expect(businessObject.get('noDefaultProperty')).not.to.exist;
 
         expect(businessObject.get('isActiveCondition')).to.exist;
         expect(businessObject.get('isActiveCondition')).to.equal('otherProperty visible');
@@ -1188,6 +1190,44 @@ describe('provider/cloud-element-templates - ElementTemplatesConditionChecker', 
         expect(rootElements).to.have.lengthOf(initialRootElements.length);
       })
     );
+  });
+
+
+  describe('update template', function() {
+
+    it('should keep property value when condition property is still active', inject(function(elementRegistry, modeling) {
+
+      // given
+      const element = elementRegistry.get('Task_1');
+      changeTemplate(element, updateTemplates[0]);
+
+      modeling.updateProperties(element, {
+        name: 'foo'
+      });
+
+      const businessObject = getBusinessObject(element);
+
+      // assume
+      expect(businessObject.get('customProperty')).to.exist;
+      expect(businessObject.get('customProperty')).to.eql('defaultValue');
+
+
+      // when
+      modeling.updateProperties(element, {
+        customProperty: 'customValue'
+      });
+
+      // assume
+      expect(businessObject.get('customProperty')).to.eql('customValue');
+
+      // when
+      changeTemplate(element, updateTemplates[1], updateTemplates[0]);
+
+      // then
+      expect(businessObject.get('customProperty')).to.eql('customValue');
+
+    }));
+
   });
 });
 

--- a/test/spec/cloud-element-templates/fixtures/condition-update.json
+++ b/test/spec/cloud-element-templates/fixtures/condition-update.json
@@ -1,0 +1,75 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Condition",
+    "id": "example.com.condition",
+    "version": "1",
+    "description": "A conditional template.",
+    "appliesTo": ["bpmn:Task"],
+    "properties": [
+      {
+        "id": "nameProp",
+        "label": "name",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "id": "otherProperty",
+        "label": "property",
+        "type": "String",
+        "value": "defaultValue",
+        "binding": {
+          "type": "property",
+          "name": "customProperty"
+        },
+        "condition": {
+          "type": "simple",
+          "property": "nameProp",
+          "oneOf": [
+            "foo"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Condition",
+    "version": "2",
+    "id": "example.com.condition",
+    "description": "A conditional template.",
+    "appliesTo": ["bpmn:Task"],
+    "properties": [
+      {
+        "id": "nameProp",
+        "label": "name",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "id": "otherProperty",
+        "label": "property",
+        "type": "String",
+        "value": "defaultValue",
+        "binding": {
+          "type": "property",
+          "name": "customProperty"
+        },
+        "condition": {
+          "type": "simple",
+          "property": "nameProp",
+          "oneOf": [
+            "foo",
+            "bar"
+          ]
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
fixes #32

- We re-use the upgrade logic for applying conditions
- Unused properties are removed for `property` and `Message` bindings

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
