### PR TITLE
feat: support `zeebe:calledElement` templating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^1.6.1",
+        "@bpmn-io/element-templates-validator": "^1.7.0",
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "bpmnlint": "^9.2.0",
         "classnames": "^2.3.1",
@@ -516,12 +516,12 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.6.1.tgz",
-      "integrity": "sha512-2HnpuQCw8BWupzKd5O9STThYdj+V3ekwq4xtc1H6fZr7NQt0glld9geJ+fHKBEVqIbPg3kX5h7mAeCNGsXGgVQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.7.0.tgz",
+      "integrity": "sha512-IBBUyb045OzXJUMN4Xs8FEL6wwykzqYRcAgoC3Krb2gb4d6mbnpe1b8LUutMpz3PYlomVgRXdTkL+zdGwbO7qQ==",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.16.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.16.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.17.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.16.1.tgz",
-      "integrity": "sha512-X9gd+d7Efd4IUGU1tpxe3JeEeOJDlS7yvZG1BfSnpuMyfabM9y9Z1oNbvNQVhurHjYxN9HXVB77Z0Xy4Mswllw=="
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.17.0.tgz",
+      "integrity": "sha512-iUGC1NdD/w9exO3Eap1d69EcH+uoff+YX1mswUJDqk6OqeDAfnHayClNdHR24VDctdHuwNrqOdGN+/1E/WsMow=="
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.10.2",
@@ -9461,12 +9461,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.6.1.tgz",
-      "integrity": "sha512-2HnpuQCw8BWupzKd5O9STThYdj+V3ekwq4xtc1H6fZr7NQt0glld9geJ+fHKBEVqIbPg3kX5h7mAeCNGsXGgVQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-1.7.0.tgz",
+      "integrity": "sha512-IBBUyb045OzXJUMN4Xs8FEL6wwykzqYRcAgoC3Krb2gb4d6mbnpe1b8LUutMpz3PYlomVgRXdTkL+zdGwbO7qQ==",
       "requires": {
         "@camunda/element-templates-json-schema": "^0.16.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.16.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.17.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -9568,9 +9568,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.16.1.tgz",
-      "integrity": "sha512-X9gd+d7Efd4IUGU1tpxe3JeEeOJDlS7yvZG1BfSnpuMyfabM9y9Z1oNbvNQVhurHjYxN9HXVB77Z0Xy4Mswllw=="
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.17.0.tgz",
+      "integrity": "sha512-iUGC1NdD/w9exO3Eap1d69EcH+uoff+YX1mswUJDqk6OqeDAfnHayClNdHR24VDctdHuwNrqOdGN+/1E/WsMow=="
     },
     "@codemirror/autocomplete": {
       "version": "6.10.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^1.6.1",
+    "@bpmn-io/element-templates-validator": "^1.7.0",
     "@bpmn-io/extract-process-variables": "^0.8.0",
     "bpmnlint": "^9.2.0",
     "classnames": "^2.3.1",

--- a/src/cloud-element-templates/CalledElementBehavior.js
+++ b/src/cloud-element-templates/CalledElementBehavior.js
@@ -1,0 +1,61 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import { findExtension } from './Helper';
+
+/**
+ * Enforces no variable propagation for templated call activities.
+ */
+export class CalledElementBehavior extends CommandInterceptor {
+
+  /**
+   * @param {*} eventBus
+   * @param {*} modeling
+   * @param {import('./ElementTemplates').default} elementTemplates
+   */
+  constructor(eventBus, modeling, elementTemplates) {
+    super(eventBus);
+
+    this._modeling = modeling;
+    this._elementTemplates = elementTemplates;
+
+    this.postExecuted([
+      'element.updateProperties', 'element.updateModdleProperties'
+    ], this._ensureNoPropagation, true, this);
+  }
+
+  _ensureNoPropagation(context) {
+    const { element } = context;
+
+    if (!this._elementTemplates.get(element)) {
+      return;
+    }
+
+    if (!is(element, 'bpmn:CallActivity')) {
+      return;
+    }
+
+    const calledElement = findExtension(element, 'zeebe:CalledElement');
+
+    if (!calledElement) {
+      return;
+    }
+
+    for (const property of [
+      'propagateAllChildVariables',
+      'propagateAllParentVariables'
+    ]) {
+      if (calledElement.get(property) !== false) {
+        this._modeling.updateModdleProperties(element, calledElement, {
+          [property]: false
+        });
+      }
+    }
+  }
+}
+
+CalledElementBehavior.$inject = [
+  'eventBus',
+  'modeling',
+  'elementTemplates'
+];

--- a/src/cloud-element-templates/CreateHelper.js
+++ b/src/cloud-element-templates/CreateHelper.js
@@ -98,6 +98,18 @@ export function createZeebeProperty(binding, value = '', bpmnFactory) {
 }
 
 /**
+ * Create a called element representing the given value.
+ *
+ * @param {object} attrs
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement}
+ */
+export function createCalledElement(attrs = {}, bpmnFactory) {
+  return bpmnFactory.create('zeebe:CalledElement', attrs);
+}
+
+/**
  * Retrieves whether an element should be updated for a given property.
  *
  * That matches once

--- a/src/cloud-element-templates/create/CalledElementBindingProvider.js
+++ b/src/cloud-element-templates/create/CalledElementBindingProvider.js
@@ -1,0 +1,36 @@
+import {
+  ensureExtension
+} from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+
+export class CalledElementBindingProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      binding
+    } = property;
+
+    const {
+      property: propertyName
+    } = binding;
+
+    const value = getDefaultValue(property);
+
+    const calledElement = ensureExtension(element, 'zeebe:CalledElement', bpmnFactory);
+
+    // TODO(@barmac): remove if we decide to support propagation in templates
+    ensureNoPropagation(calledElement);
+
+    calledElement.set(propertyName, value);
+  }
+}
+
+function ensureNoPropagation(calledElement) {
+  calledElement.set('propagateAllChildVariables', false);
+  calledElement.set('propagateAllParentVariables', false);
+}

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -12,6 +12,7 @@ import TaskHeaderBindingProvider from './TaskHeaderBindingProvider';
 import ZeebePropertiesProvider from './ZeebePropertiesProvider';
 import { MessagePropertyBindingProvider } from './MessagePropertyBindingProvider';
 import { MessageZeebeSubscriptionBindingProvider } from './MessageZeebeSubscriptionBindingProvider';
+import { CalledElementBindingProvider } from './CalledElementBindingProvider';
 
 import {
   MESSAGE_PROPERTY_TYPE,
@@ -22,7 +23,8 @@ import {
   ZEBBE_INPUT_TYPE,
   ZEEBE_OUTPUT_TYPE,
   ZEEBE_TASK_HEADER_TYPE,
-  ZEBBE_PROPERTY_TYPE
+  ZEBBE_PROPERTY_TYPE,
+  ZEEBE_CALLED_ELEMENT
 } from '../util/bindingTypes';
 
 import {
@@ -44,7 +46,8 @@ export default class TemplateElementFactory {
       [ZEEBE_OUTPUT_TYPE]: OutputBindingProvider,
       [ZEEBE_TASK_HEADER_TYPE]: TaskHeaderBindingProvider,
       [MESSAGE_PROPERTY_TYPE]: MessagePropertyBindingProvider,
-      [MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE]: MessageZeebeSubscriptionBindingProvider
+      [MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE]: MessageZeebeSubscriptionBindingProvider,
+      [ZEEBE_CALLED_ELEMENT]: CalledElementBindingProvider
     };
   }
 

--- a/src/cloud-element-templates/index.js
+++ b/src/cloud-element-templates/index.js
@@ -10,6 +10,7 @@ import ElementTemplatesPropertiesProvider from './ElementTemplatesPropertiesProv
 import UpdateTemplatePropertiesOrder from './UpdateTemplatePropertiesOrder';
 import { ReferencedElementBehavior } from './ReferencedElementBehavior';
 import { GeneratedValueBehavior } from './GeneratedValueBehavior';
+import { CalledElementBehavior } from './CalledElementBehavior';
 
 
 export default {
@@ -25,7 +26,8 @@ export default {
     'elementTemplatesConditionChecker',
     'generatedValueBehavior',
     'referencedElementBehavior',
-    'updateTemplatePropertiesOrder'
+    'updateTemplatePropertiesOrder',
+    'calledElementBehavior'
   ],
   elementTemplates: [ 'type', ElementTemplates ],
   elementTemplatesLoader: [ 'type', ElementTemplatesLoader ],
@@ -34,5 +36,6 @@ export default {
   elementTemplatesConditionChecker: [ 'type', ElementTemplatesConditionChecker ],
   generatedValueBehavior: [ 'type', GeneratedValueBehavior ],
   referencedElementBehavior: [ 'type', ReferencedElementBehavior ],
-  updateTemplatePropertiesOrder: [ 'type', UpdateTemplatePropertiesOrder ]
+  updateTemplatePropertiesOrder: [ 'type', UpdateTemplatePropertiesOrder ],
+  calledElementBehavior: [ 'type', CalledElementBehavior ]
 };

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -9,6 +9,7 @@ export const ZEEBE_TASK_DEFINITION = 'zeebe:taskDefinition';
 export const ZEEBE_TASK_HEADER_TYPE = 'zeebe:taskHeader';
 export const MESSAGE_PROPERTY_TYPE = 'bpmn:Message#property';
 export const MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE = 'bpmn:Message#zeebe:subscription#property';
+export const ZEEBE_CALLED_ELEMENT = 'zeebe:calledElement';
 
 export const EXTENSION_BINDING_TYPES = [
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
@@ -17,7 +18,8 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_PROPERTY_TYPE,
   ZEEBE_TASK_DEFINITION_TYPE_TYPE,
   ZEEBE_TASK_DEFINITION,
-  ZEEBE_TASK_HEADER_TYPE
+  ZEEBE_TASK_HEADER_TYPE,
+  ZEEBE_CALLED_ELEMENT
 ];
 
 export const TASK_DEFINITION_TYPES = [

--- a/test/spec/cloud-element-templates/CalledElementBehavior.bpmn
+++ b/test/spec/cloud-element-templates/CalledElementBehavior.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_16zi3v6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_0kgt465" isExecutable="true">
+    <bpmn:callActivity id="Templated" name="foo" zeebe:modelerTemplate="io.camunda.examples.Payment">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="one" propagateAllChildVariables="false" propagateAllParentVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="TemplatedNoProperty" name="TemplatedNoProperty" zeebe:modelerTemplate="io.camunda.examples.Payment" />
+    <bpmn:callActivity id="NonTemplated" name="NonTemplated">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:task id="Task" name="foo" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0kgt465">
+      <bpmndi:BPMNShape id="Activity_01llrle_di" bpmnElement="Templated">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CA_di" bpmnElement="TemplatedNoProperty">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_002cijc_di" bpmnElement="NonTemplated">
+        <dc:Bounds x="310" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <dc:Bounds x="310" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/CalledElementBehavior.json
+++ b/test/spec/cloud-element-templates/CalledElementBehavior.json
@@ -1,0 +1,50 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "io.camunda.examples.Payment",
+    "name": "Payment",
+    "description": "Payment process call activity",
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:CallActivity"
+    ],
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties": [
+      {
+        "id": "nameProp",
+        "label": "name",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "one",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        },
+        "condition": {
+          "equals": "foo",
+          "property": "nameProp"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "two",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        },
+        "condition": {
+          "equals": "bar",
+          "property": "nameProp"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/CalledElementBehavior.spec.js
+++ b/test/spec/cloud-element-templates/CalledElementBehavior.spec.js
@@ -1,0 +1,152 @@
+import TestContainer from 'mocha-test-container-support';
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import { BpmnPropertiesPanelModule } from 'bpmn-js-properties-panel';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import elementTemplatesModule from 'src/cloud-element-templates';
+import { findExtension } from 'src/cloud-element-templates/Helper';
+
+import diagramXML from './CalledElementBehavior.bpmn';
+import templates from './CalledElementBehavior.json';
+
+
+describe('CalledElementBehavior', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    container,
+    modules: [
+      coreModule,
+      elementTemplatesModule,
+      modelingModule,
+      BpmnPropertiesPanelModule,
+      {
+        propertiesPanel: [ 'value', { registerProvider() {} } ]
+      },
+      ZeebeBehaviorsModule
+    ],
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    },
+    elementTemplates: templates
+  }));
+
+
+  describe('variable propagation', function() {
+
+    it('should ensure no variable propagation when template is applied', inject(
+      function(elementRegistry, elementTemplates) {
+
+        // given
+        let callActivity = elementRegistry.get('Task');
+
+        // when
+        callActivity = elementTemplates.applyTemplate(callActivity, templates[0]);
+
+        // then
+        expect(getPropagation(callActivity)).to.eql({
+          propagateAllChildVariables: false,
+          propagateAllParentVariables: false
+        });
+      })
+    );
+
+
+    it('should ensure no variable propagation when property is activated via condition', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        const callActivity = elementRegistry.get('TemplatedNoProperty');
+
+        // when
+        modeling.updateProperties(callActivity, {
+          name: 'foo'
+        });
+
+        expect(getPropagation(callActivity)).to.eql({
+          propagateAllChildVariables: false,
+          propagateAllParentVariables: false
+        });
+      })
+    );
+
+
+    it('should NOT create called element if property is deactivated', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        const callActivity = elementRegistry.get('Templated');
+
+        // when
+        modeling.updateProperties(callActivity, {
+          name: 'baz'
+        });
+
+        expect(getPropagation(callActivity)).to.be.null;
+      })
+    );
+
+
+    it('should NOT affect non-templated call activities', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        const callActivity = elementRegistry.get('NonTemplated');
+        const initialPropagation = getPropagation(callActivity);
+
+        // when
+        modeling.updateProperties(callActivity, {
+          name: 'foo'
+        });
+
+        // then
+        expect(getPropagation(callActivity)).to.eql(initialPropagation);
+      })
+    );
+
+
+    it('should NOT affect non-call-activity', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        const task = elementRegistry.get('Task');
+
+        // when
+        modeling.updateProperties(task, {
+          name: 'newName'
+        });
+
+        // then
+        expect(getPropagation(task)).to.be.null;
+      })
+    );
+  });
+});
+
+
+// helpers //////////
+
+function getCalledElement(element) {
+  return findExtension(element, 'zeebe:CalledElement');
+}
+
+function getPropagation(callActivity) {
+  const calledElement = getCalledElement(callActivity);
+  return calledElement ? {
+    propagateAllChildVariables: calledElement.get('propagateAllChildVariables'),
+    propagateAllParentVariables: calledElement.get('propagateAllParentVariables')
+  } : null;
+}

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -1700,6 +1700,79 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('update zeebe:calledElement', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+      const newTemplate = require('./called-element.json');
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        task = elementRegistry.get('Task_1');
+        expectElementTemplate(task, 'calledElement');
+
+        const calledElement = findExtension(task, 'zeebe:CalledElement');
+
+        expect(calledElement).to.exist;
+        expect(calledElement).to.have.property('processId', 'paymentProcess');
+        expect(calledElement).to.have.property('propagateAllChildVariables', false);
+        expect(calledElement).to.have.property('propagateAllParentVariables', false);
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        task = elementRegistry.get('Task_1');
+        expectNoElementTemplate(task);
+
+        const calledElement = findExtension(task, 'zeebe:CalledElement');
+
+        expect(calledElement).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        task = elementRegistry.get('Task_1');
+        expectElementTemplate(task, 'calledElement');
+
+        const calledElement = findExtension(task, 'zeebe:CalledElement');
+
+        expect(calledElement).to.exist;
+        expect(calledElement).to.have.property('processId', 'paymentProcess');
+        expect(calledElement).to.have.property('propagateAllChildVariables', false);
+        expect(calledElement).to.have.property('propagateAllParentVariables', false);
+      }));
+    });
+
+
     describe('create message with zeebe:modelerTemplate', function() {
 
       beforeEach(bootstrap(require('./event.bpmn').default));

--- a/test/spec/cloud-element-templates/cmd/called-element.json
+++ b/test/spec/cloud-element-templates/cmd/called-element.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "id": "calledElement",
+  "name": "Payment",
+  "description": "Payment process call activity",
+  "appliesTo": [
+    "bpmn:Task",
+    "bpmn:CallActivity"
+  ],
+  "elementType": {
+    "value": "bpmn:CallActivity"
+  },
+  "properties":[
+    {
+      "type": "Hidden",
+      "value": "paymentProcess",
+      "binding": {
+        "type": "zeebe:calledElement",
+        "property": "processId"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -464,6 +464,28 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
         correlationKey: '=variable'
       });
     }));
+
+
+    it('should handle <zeebe:calledElement>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('calledElement');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      // then
+      const bo = getBusinessObject(element);
+      const calledElement = findExtension(bo, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.jsonEqual({
+        $type: 'zeebe:CalledElement',
+        propagateAllChildVariables: false,
+        propagateAllParentVariables: false,
+        processId: 'paymentProcess'
+      });
+    }));
   });
 
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -512,5 +512,28 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "calledElement",
+    "name": "Payment",
+    "description": "Payment process call activity",
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:CallActivity"
+    ],
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties":[
+      {
+        "type": "Hidden",
+        "value": "paymentProcess",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/fixtures/called-element.json
+++ b/test/spec/cloud-element-templates/fixtures/called-element.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "id": "io.camunda.examples.Payment",
+  "name": "Payment",
+  "description": "Payment process call activity",
+  "appliesTo": [
+    "bpmn:Task",
+    "bpmn:CallActivity"
+  ],
+  "elementType": {
+    "value": "bpmn:CallActivity"
+  },
+  "properties":[
+    {
+      "type": "Hidden",
+      "value": "paymentProcess",
+      "binding": {
+        "type": "zeebe:calledElement",
+        "property": "processId"
+      }
+    },
+    {
+      "label": "Payment ID",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "paymentID"
+      }
+    },
+    {
+      "label": "Amount",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "amount"
+      }
+    },
+    {
+      "label": "Outcome",
+      "type": "String",
+      "description": "Name of variable to store the result data in.",
+      "value": "paymentOutcome",
+      "binding": {
+        "type": "zeebe:output",
+        "source": "=outcome"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/fixtures/condition-called-element.json
+++ b/test/spec/cloud-element-templates/fixtures/condition-called-element.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "id": "io.camunda.examples.Payment",
+  "name": "Payment",
+  "description": "Payment process call activity",
+  "appliesTo": [
+    "bpmn:Task",
+    "bpmn:CallActivity"
+  ],
+  "elementType": {
+    "value": "bpmn:CallActivity"
+  },
+  "properties":[
+    {
+      "id": "nameProp",
+      "label": "name",
+      "type": "String",
+      "binding": {
+        "type": "property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "one",
+      "binding": {
+        "type": "zeebe:calledElement",
+        "property": "processId"
+      },
+      "condition": {
+        "equals": "foo",
+        "property": "nameProp"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "two",
+      "binding": {
+        "type": "zeebe:calledElement",
+        "property": "processId"
+      },
+      "condition": {
+        "equals": "bar",
+        "property": "nameProp"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="RestTask" name="REST Task" zeebe:modelerTemplate="com.example.rest">
       <bpmn:extensionElements>
@@ -63,6 +63,12 @@
         <zeebe:taskDefinition type="http" retries="5" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:callActivity id="CalledElement" name="Called Element" zeebe:modelerTemplate="calledElement">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="paymentProcess" propagateAllChildVariables="false" propagateAllParentVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CalledElement_empty" name="Called Element empty" zeebe:modelerTemplate="calledElement" />
   </bpmn:process>
   <bpmn:message id="Message" name="name">
     <bpmn:extensionElements>
@@ -130,6 +136,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0tg2czn_di" bpmnElement="TaskDefinition">
         <dc:Bounds x="620" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1nfgyhn_di" bpmnElement="CalledElement">
+        <dc:Bounds x="360" y="630" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_di" bpmnElement="CalledElement_empty">
+        <dc:Bounds x="480" y="630" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -706,5 +706,41 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "calledElement",
+    "name": "Payment",
+    "description": "Payment process call activity",
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:CallActivity"
+    ],
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties":[
+      {
+        "type": "String",
+        "value": "paymentProcess",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        },
+        "condition": {
+          "property": "name",
+          "equals": "Called Element"
+        }
+      },
+      {
+        "id": "name",
+        "type": "String",
+        "value": "Called Element",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -928,6 +928,85 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('zeebe:calledElement', function() {
+
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('CalledElement');
+
+      // then
+      const entry = findEntry('custom-entry-calledElement-0', container),
+            input = findInput('text', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('paymentProcess');
+    });
+
+
+    it('should change, setting zeebe:calledElement', async function() {
+
+      // given
+      const element = await expectSelected('CalledElement'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const entry = findEntry('custom-entry-calledElement-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'anotherProcessId');
+
+      // then
+      const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('processId', 'anotherProcessId');
+    });
+
+
+    it('should change, creating zeebe:calledElement if non-existing', async function() {
+
+      // given
+      const element = await expectSelected('CalledElement_empty'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const entry = findEntry('custom-entry-calledElement-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'Called Element');
+
+      // then
+      const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('processId', 'paymentProcess');
+    });
+
+
+    it('should NOT remove zeebe:calledElement when changed to empty value', inject(async function() {
+
+      // given
+      const event = await expectSelected('CalledElement'),
+            businessObject = getBusinessObject(event);
+
+      // when
+      const entry = findEntry('custom-entry-calledElement-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('processId', '');
+    }));
+  });
+
+
   describe('types', function() {
 
     describe('Dropdown', function() {


### PR DESCRIPTION
This PR implements `zeebe:calledElement` binding. In the implementation, the template developer is required to provide inputs and outputs explicitly as variable propagation is disabled for the templated elements.

Related to https://github.com/camunda/camunda-modeler/issues/3006
