### PR TITLE
fix: correctly export core

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js"
+    },
+    "./core": {
+      "import": "./dist/core.esm.js",
+      "require": "./dist/core.js"
+    }
+  },
   "scripts": {
     "all": "run-s lint test distro",
     "distro": "run-s build test:build",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -49,6 +49,23 @@ export default [
         ]
       })
     ])
+  },
+  {
+    input: 'src/core.js',
+    output: [
+      {
+        sourcemap: true,
+        format: 'commonjs',
+        file: 'dist/core.js'
+      },
+      {
+        sourcemap: true,
+        format: 'esm',
+        file: 'dist/core.esm.js'
+      }
+    ],
+    external: externalDependencies(),
+    plugins: pgl()
   }
 ];
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,12 +65,12 @@ export default [
       }
     ],
     external: externalDependencies(),
-    plugins: pgl()
+    plugins: corePlugins()
   }
 ];
 
 function pgl(plugins = []) {
-  return [
+  return corePlugins([
     ...plugins,
     alias({
       entries: [
@@ -86,7 +86,13 @@ function pgl(plugins = []) {
           'runtime': 'automatic'
         } ]
       ]
-    }),
+    })
+  ]);
+}
+
+function corePlugins(plugins = []) {
+  return [
+    ...plugins,
     json(),
     resolve({
       mainFields: [

--- a/src/cloud-element-templates/linting/index.js
+++ b/src/cloud-element-templates/linting/index.js
@@ -1,1 +1,4 @@
-export * from './LinterPlugin';
+export {
+  elementTemplateLintRule,
+  ElementTemplateLinterPlugin
+} from './LinterPlugin';

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -853,6 +853,7 @@ export function unsetProperty(commandStack, element, property) {
   }
 }
 
+// TODO(@barmac): fix translate usage
 export function validateProperty(value, property, translate = defaultTranslate) {
   const {
     constraints = {},

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -3,8 +3,6 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import defaultTranslate from 'diagram-js/lib/i18n/translate/translate';
-
 import {
   isString,
   isUndefined, without
@@ -929,5 +927,14 @@ function isOnlyProperty(moddleElement, propertyName) {
 
   return descriptor.properties.every(({ name }) => {
     return propertyName === name || moddleElement.get(name) === undefined;
+  });
+}
+
+function defaultTranslate(template, replacements) {
+
+  replacements = replacements || {};
+
+  return template.replace(/{([^}]+)}/g, function(_, key) {
+    return replacements[key] || '{' + key + '}';
   });
 }

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -3,9 +3,7 @@ import {
   is
 } from 'bpmn-js/lib/util/ModelUtil';
 
-import {
-  default as defaultTranslate
-} from 'diagram-js/lib/i18n/translate/translate';
+import defaultTranslate from 'diagram-js/lib/i18n/translate/translate';
 
 import {
   isString,

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -853,7 +853,7 @@ export function unsetProperty(commandStack, element, property) {
   }
 }
 
-// TODO(@barmac): fix translate usage
+// TODO(@barmac): fix translate usage (https://github.com/bpmn-io/bpmn-js-element-templates/pull/53#issuecomment-1906203270)
 export function validateProperty(value, property, translate = defaultTranslate) {
   const {
     constraints = {},

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,3 @@
+// core
+export { default as CloudElementTemplatesCoreModule } from './cloud-element-templates/core';
+export { default as ElementTemplatesCoreModule } from './element-templates/core';


### PR DESCRIPTION
This exports `core` without calling browser APIs.