### PR TITLE
fix(Conditions): evaluate all chained conditions

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalBehavior.js
@@ -63,25 +63,20 @@ export default class ConditionalBehavior extends CommandInterceptor {
       return;
     }
 
-    context.oldTemplate = applyConditions(element, template);
+    context.oldTemplateWithConditions = applyConditions(element, template);
   }
 
   _applyConditions(context) {
     const {
-      element,
-      hints = {}
+      element
     } = context;
 
-
-    if (hints.skipConditionUpdate) {
-      return;
-    }
 
     const template = this._elementTemplates.get(element);
 
     // New Template is persisted before applying default values,
     // new conditions might apply after the defaults are present.
-    const oldTemplate = context.oldTemplate || context.newTemplate;
+    const oldTemplate = context.oldTemplateWithConditions || context.newTemplate;
 
     if (!template || !oldTemplate || template.id !== oldTemplate.id) {
       return;
@@ -96,8 +91,7 @@ export default class ConditionalBehavior extends CommandInterceptor {
     const changeContext = {
       element,
       newTemplate,
-      oldTemplate,
-      hints: { skipConditionUpdate: true }
+      oldTemplate
     };
 
     this._commandStack.execute('propertiesPanel.zeebe.changeTemplate', changeContext);

--- a/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
@@ -22,6 +22,7 @@ import messageCorrelationDiagramXML from '../fixtures/message-correlation-key.bp
 
 import template from '../fixtures/condition.json';
 import updateTemplates from '../fixtures/condition-update.json';
+import chainedConditions from '../fixtures/chained-conditions.json';
 
 import messageTemplates from '../fixtures/condition-message.json';
 import messageCorrelationTemplate from '../fixtures/message-correlation-key.json';
@@ -1342,6 +1343,33 @@ describe('provider/cloud-element-templates - ConditionalBehavior', function() {
     }));
 
   });
+
+
+  describe('chained conditional properties', function() {
+
+    it('should apply a chain of dependent conditional properties', inject(function(elementRegistry, modeling) {
+
+      // given
+      const element = elementRegistry.get('Task_1');
+
+      // when
+      changeTemplate(element, chainedConditions);
+
+      // then
+      const businessObject = getBusinessObject(element);
+
+      expect(businessObject.get('prop1')).to.exist;
+      expect(businessObject.get('prop1')).to.eql('foo');
+
+      expect(businessObject.get('prop2')).to.exist;
+      expect(businessObject.get('prop2')).to.eql('bar');
+
+      expect(businessObject.get('prop3')).to.exist;
+      expect(businessObject.get('prop3')).to.eql('baz');
+    }));
+
+  });
+
 });
 
 

--- a/test/spec/cloud-element-templates/behavior/UpdatePropertiesOrderBehavior.template.json
+++ b/test/spec/cloud-element-templates/behavior/UpdatePropertiesOrderBehavior.template.json
@@ -9,7 +9,7 @@
     "properties": [
       {
         "id": "name",
-        "type": "Hidden",
+        "type": "String",
         "value": "task-name",
         "binding": {
           "type": "property",
@@ -142,7 +142,7 @@
     ],
     "properties": [
       {
-        "type": "Hidden",
+        "type": "String",
         "value": "foo",
         "id": "parentProp",
         "binding": {

--- a/test/spec/cloud-element-templates/fixtures/chained-conditions.json
+++ b/test/spec/cloud-element-templates/fixtures/chained-conditions.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Condition",
+  "id": "example.com.nested.condition",
+  "description": "A conditional template.",
+  "appliesTo": ["bpmn:Task"],
+  "properties": [
+    {
+      "id": "prop1",
+      "type": "String",
+      "value": "foo",
+      "binding": {
+        "type": "property",
+        "name": "prop1"
+      }
+    },
+    {
+      "id": "prop2",
+      "type": "String",
+      "value": "bar",
+      "binding": {
+        "type": "property",
+        "name": "prop2"
+      },
+      "condition": {
+        "property": "prop1",
+        "equals": "foo"
+      }
+    },
+    {
+      "id": "prop3",
+      "type": "String",
+      "value": "baz",
+      "binding": {
+        "type": "property",
+        "name": "prop3"
+      },
+      "condition": {
+        "property": "prop2",
+        "equals": "bar"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
closes #49
also fixes https://github.com/camunda/camunda-modeler/issues/4124

Root cause here: https://github.com/camunda/camunda-modeler/issues/4124#issuecomment-1940942140

We will now re-apply conditions and the template until no further changes in conditions are present. This applies all chained conditions.

We need to rename `context.oldTemplate` to avoid naming conflicts with other behaviors that overwrite the context entry. This will cause an infinite loop, as we need the "Before state with conditions" for a proper check.



<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
