### PR TITLE
feat(platform): always display documentation section

### DIFF
--- a/src/element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -20,6 +20,11 @@ const CAMUNDA_ERROR_EVENT_DEFINITION_TYPE = 'camunda:errorEventDefinition',
 
 const LOWER_PRIORITY = 300;
 
+const ALWAYS_DISPLAYED_GROUPS = [
+  'general',
+  'documentation'
+];
+
 
 export default class ElementTemplatesPropertiesProvider {
 
@@ -50,7 +55,7 @@ export default class ElementTemplatesPropertiesProvider {
       };
 
       // (1) Add templates group
-      addGroupsAfter('documentation', groups, [ templatesGroup ]);
+      addGroupsAfter(ALWAYS_DISPLAYED_GROUPS, groups, [ templatesGroup ]);
 
       const elementTemplate = this._elementTemplates.get(element);
 
@@ -181,12 +186,20 @@ function createErrorGroup(element, elementTemplate, injector, groups) {
 
 /**
  *
- * @param {string} id
+ * @param {string|string[]} idOrIds
  * @param {Array<{ id: string }} groups
  * @param {Array<{ id: string }>} groupsToAdd
  */
-function addGroupsAfter(id, groups, groupsToAdd) {
-  const index = groups.findIndex(group => group.id === id);
+function addGroupsAfter(idOrIds, groups, groupsToAdd) {
+  let ids = idOrIds;
+  if (!Array.isArray(idOrIds)) {
+    ids = [ idOrIds ];
+  }
+
+  // find index of last group with provided id
+  const index = groups.reduce((acc, group, index) => {
+    return ids.includes(group.id) ? index : acc;
+  }, -1);
 
   if (index !== -1) {
     groups.splice(index + 1, 0, ...groupsToAdd);
@@ -201,7 +214,7 @@ function filterWithEntriesVisible(template, groups) {
   if (!template.entriesVisible) {
     return groups.filter(group => {
       return (
-        group.id === 'general' ||
+        ALWAYS_DISPLAYED_GROUPS.includes(group.id) ||
         group.id.startsWith('ElementTemplates__')
       );
     });

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -180,7 +180,7 @@ describe('provider/element-templates - ElementTemplates', function() {
     }));
 
 
-    it('should show only general group, and template-related entries when entriesVisible is unset',
+    it('should show only general and documentation group, and template-related entries when entriesVisible is unset',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -194,13 +194,14 @@ describe('provider/element-templates - ElementTemplates', function() {
         // then
         expectOnlyGroups(container, [
           'general',
+          'documentation',
           'ElementTemplates__Template'
         ]);
       })
     );
 
 
-    it('should show only general group, and template-related entries when entriesVisible=false',
+    it('should show only general and documentation group, and template-related entries when entriesVisible=false',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -214,6 +215,7 @@ describe('provider/element-templates - ElementTemplates', function() {
         // then
         expectOnlyGroups(container, [
           'general',
+          'documentation',
           'ElementTemplates__Template'
         ]);
       })
@@ -234,6 +236,7 @@ describe('provider/element-templates - ElementTemplates', function() {
         // then
         expectOnlyGroups(container, [
           'general',
+          'documentation',
           'ElementTemplates__Template',
           'ElementTemplates__Input',
           'ElementTemplates__Output',
@@ -251,6 +254,7 @@ describe('provider/element-templates - ElementTemplates', function() {
       // then
       expectOnlyGroups(container, [
         'general',
+        'documentation',
         'ElementTemplates__Template',
         'ElementTemplates__Input',
         'ElementTemplates__Output'
@@ -258,7 +262,7 @@ describe('provider/element-templates - ElementTemplates', function() {
     });
 
 
-    it('should show only general group, and template group when template is unknown',
+    it('should show only general and documentation group, and template group when template is unknown',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -272,6 +276,7 @@ describe('provider/element-templates - ElementTemplates', function() {
         // then
         expectOnlyGroups(container, [
           'general',
+          'documentation',
           'ElementTemplates__Template'
         ]);
       })
@@ -294,7 +299,7 @@ describe('provider/element-templates - ElementTemplates', function() {
 
         expect(groups).to.contain('general');
         expect(groups).to.contain('ElementTemplates__Template');
-        expect(groups).to.contain('documentation');
+        expect(groups).to.contain('CamundaPlatform__ExecutionListener');
       })
     );
   });
@@ -493,6 +498,29 @@ describe('provider/element-templates - ElementTemplates', function() {
         expect(template).to.have.property('version', 3);
       })
     );
+  });
+
+
+  describe('documentation', function() {
+
+    it('should display documentation section', inject(
+      async function(elementRegistry, selection, modeling, bpmnFactory) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-documentation"]', container);
+
+        expect(group).to.exist;
+      })
+    );
+
   });
 
 });


### PR DESCRIPTION
![capture i3Se7G_optimized](https://github.com/bpmn-io/bpmn-js-element-templates/assets/58601/21afa2b0-9428-4fcf-bf20-1f568df85f0f)

Backports https://github.com/bpmn-io/bpmn-js-element-templates/commit/80321e358c6f0fc7620770d69e390eafd7710e8c to C7.

---

Related to https://github.com/camunda/camunda-modeler/issues/4037