### PR TITLE
feat(platform): always display multi instance configuration

### DIFF
--- a/src/element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -22,7 +22,8 @@ const LOWER_PRIORITY = 300;
 
 const ALWAYS_DISPLAYED_GROUPS = [
   'general',
-  'documentation'
+  'documentation',
+  'multiInstance'
 ];
 
 

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:task id="Task_1" camunda:modelerTemplate="foo" />
-    <bpmn:task id="Task_2" camunda:modelerTemplate="foo" camunda:modelerTemplateVersion="1" />
-    <bpmn:task id="Task_3" />
-    <bpmn:task id="UnknownTemplateTask" camunda:modelerTemplate="unknown" />
-    <bpmn:serviceTask id="ServiceTask" camunda:modelerTemplate="default" />
-    <bpmn:serviceTask id="ServiceTaskWithInputOutputError" camunda:modelerTemplate="input-output-error" camunda:modelerTemplateVersion="1" camunda:type="external" camunda:topic="topic">
+    <bpmn:task id="Task_1" name="Task_1" camunda:modelerTemplate="foo" />
+    <bpmn:task id="Task_2" name="Task_2" camunda:modelerTemplate="foo" camunda:modelerTemplateVersion="1" />
+    <bpmn:task id="Task_3" name="Task_3" />
+    <bpmn:task id="UnknownTemplateTask" name="UnknownTemplateTask" camunda:modelerTemplate="unknown" />
+    <bpmn:serviceTask id="ServiceTask" name="ServiceTask" camunda:modelerTemplate="default" />
+    <bpmn:serviceTask id="ServiceTaskWithInputOutputError" name="ServiceTaskWithInputOutputError" camunda:modelerTemplate="input-output-error" camunda:modelerTemplateVersion="1" camunda:type="external" camunda:topic="topic">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="input-1-name">input-1-value</camunda:inputParameter>
@@ -15,35 +15,52 @@
         <camunda:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_error-1" expression="error-expression" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_1" />
-    <bpmn:serviceTask id="DeprecatedTemplateTask" camunda:modelerTemplate="deprecated" />
+    <bpmn:exclusiveGateway id="Gateway_1" name="Gateway_1" />
+    <bpmn:serviceTask id="DeprecatedTemplateTask" name="DeprecatedTemplateTask" camunda:modelerTemplate="deprecated" />
+    <bpmn:serviceTask id="MultiInstanceTask" name="MultiInstanceTask" camunda:modelerTemplate="default">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmn:error id="Error_error-1" name="error-name" errorCode="error-code" camunda:errorMessage="error-message" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
         <dc:Bounds x="150" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0z29dre_di" bpmnElement="Task_2">
         <dc:Bounds x="270" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
         <dc:Bounds x="390" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
         <dc:Bounds x="390" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_di" bpmnElement="ServiceTask">
         <dc:Bounds x="150" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTaskWithInputOutputError_di" bpmnElement="ServiceTaskWithInputOutputError">
         <dc:Bounds x="150" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1l7vqgv_di" bpmnElement="Gateway_1" isMarkerVisible="true">
         <dc:Bounds x="295" y="215" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="292" y="272" width="56" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1e82w8j" bpmnElement="DeprecatedTemplateTask">
-        <dc:Bounds x="280" y="300" width="100" height="80" />
+        <dc:Bounds x="270" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03yi7kw" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="390" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -523,6 +523,29 @@ describe('provider/element-templates - ElementTemplates', function() {
 
   });
 
+
+  describe('multiInstance', function() {
+
+    it('should display multi-instance section', inject(
+      async function(elementRegistry, selection, modeling, bpmnFactory) {
+
+        // given
+        const element = elementRegistry.get('MultiInstanceTask');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-multiInstance"]', container);
+
+        expect(group).to.exist;
+      })
+    );
+
+  });
+
 });
 
 


### PR DESCRIPTION

![capture 5pIuTZ_optimized](https://github.com/bpmn-io/bpmn-js-element-templates/assets/58601/cb20d94d-0991-4819-bab1-b752bd29c49b)


Related to / ports https://github.com/bpmn-io/bpmn-js-element-templates/pull/27 to Camunda 7.