### PR TITLE
Ensure existing values are preserved

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalBehavior.js
@@ -76,7 +76,7 @@ export default class ConditionalBehavior extends CommandInterceptor {
     // new conditions might apply after the defaults are present.
     const oldTemplate = oldTemplateWithConditions || newTemplate;
 
-    if (!template || !oldTemplate || template.id !== oldTemplate.id) {
+    if (!template || !oldTemplate) {
       return;
     }
 

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -582,13 +582,13 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
       // assume
       expect(
-        task.businessObject.extensionElements.values[1].inputParameters[0].source
+        task.businessObject.extensionElements.values[0].inputParameters[0].source
       ).to.eql(
         'action1'
       );
 
       expect(
-        task.businessObject.extensionElements.values[0].type
+        task.businessObject.extensionElements.values[1].type
       ).to.eql(
         'action1-value'
       );
@@ -602,13 +602,13 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
       // assume
       expect(
-        updatedTask.businessObject.extensionElements.values[1].inputParameters[0].source
+        updatedTask.businessObject.extensionElements.values[0].inputParameters[0].source
       ).to.eql(
         'action1'
       );
 
       expect(
-        updatedTask.businessObject.extensionElements.values[0].type
+        updatedTask.businessObject.extensionElements.values[1].type
       ).to.eql(
         'action1-value-2'
       );

--- a/test/spec/cloud-element-templates/behavior/ConditionalBehavior.dependent-dropdowns.json
+++ b/test/spec/cloud-element-templates/behavior/ConditionalBehavior.dependent-dropdowns.json
@@ -6,9 +6,6 @@
   "appliesTo": [
     "bpmn:Task"
   ],
-  "elementType": {
-    "value": "bpmn:ServiceTask"
-  },
   "properties": [
     {
       "id": "root",

--- a/test/spec/cloud-element-templates/behavior/ConditionalBehavior.dependent-dropdowns.json
+++ b/test/spec/cloud-element-templates/behavior/ConditionalBehavior.dependent-dropdowns.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Dependent Dropdowns",
+  "id": "com.camunda.example.dependent.dropdowns:1",
+  "description": "Test dependent dropdowns",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "properties": [
+    {
+      "id": "root",
+      "label": "Root",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Root A",
+          "value": "Root A"
+        },
+        {
+          "name": "Root B",
+          "value": "Root B"
+        }
+      ],
+      "binding": {
+        "name": "root",
+        "type": "property"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Sub",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "/A/1",
+          "value": "/A/1"
+        },
+        {
+          "name": "/A/2",
+          "value": "/A/2"
+        }
+      ],
+      "binding": {
+        "name": "sub",
+        "type": "property"
+      },
+      "condition": {
+        "property": "root",
+        "equals": "Root A"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Sub",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "/B/1",
+          "value": "/B/1"
+        },
+        {
+          "name": "/B/2",
+          "value": "/B/2"
+        },
+        {
+          "name": "/B/3",
+          "value": "/B/3"
+        }
+      ],
+      "binding": {
+        "name": "sub",
+        "type": "property"
+      },
+      "condition": {
+        "property": "root",
+        "equals": "Root B"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
@@ -1664,7 +1664,7 @@ describe('provider/cloud-element-templates - ConditionalBehavior', function() {
         function(modeling) {
 
           // given
-          const dependentDropdownsTemplateV2 = {
+          const newTemplate = {
             ...dependentDropdownsTemplate,
             version: 2
           };
@@ -1682,7 +1682,39 @@ describe('provider/cloud-element-templates - ConditionalBehavior', function() {
           expect(businessObject.get('sub')).to.eql('/B/2');
 
           // when
-          const updatedElement = changeTemplate(element, dependentDropdownsTemplateV2, dependentDropdownsTemplate);
+          const updatedElement = changeTemplate(element, newTemplate, dependentDropdownsTemplate);
+          const updatedBusinessObject = getBusinessObject(updatedElement);
+
+          // then
+          expect(updatedBusinessObject.get('root')).to.eql('Root B');
+          expect(updatedBusinessObject.get('sub')).to.eql('/B/2');
+        }
+      ));
+
+
+      it('when changing template', inject(
+        function(modeling) {
+
+          // given
+          const newTemplate = {
+            ...dependentDropdownsTemplate,
+            id: dependentDropdownsTemplate.id + '::v2'
+          };
+
+          const element = changeTemplate('ServiceTask_1', dependentDropdownsTemplate);
+          const businessObject = getBusinessObject(element);
+
+          modeling.updateModdleProperties(element, businessObject, {
+            root: 'Root B',
+            sub: '/B/2'
+          });
+
+          // assume
+          expect(businessObject.get('root')).to.eql('Root B');
+          expect(businessObject.get('sub')).to.eql('/B/2');
+
+          // when
+          const updatedElement = changeTemplate(element, newTemplate, dependentDropdownsTemplate);
           const updatedBusinessObject = getBusinessObject(updatedElement);
 
           // then

--- a/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/ConditionalBehavior.spec.js
@@ -15,7 +15,6 @@ import { BpmnPropertiesPanelModule } from 'bpmn-js-properties-panel';
 
 import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
 
-
 import diagramXML from '../fixtures/condition.bpmn';
 import messageDiagramXML from '../fixtures/condition-message.bpmn';
 import messageCorrelationDiagramXML from '../fixtures/message-correlation-key.bpmn';
@@ -25,6 +24,7 @@ import updateTemplates from '../fixtures/condition-update.json';
 import chainedConditionsSimpleTemplate from '../fixtures/condition-chained.json';
 import chainedConditionsComplexTemplate from './ConditionalBehavior.condition-chained.json';
 import chainedConditionsSharedBindingTemplate from './ConditionalBehavior.condition-chained-shared-binding.json';
+import dependentDropdownsTemplate from './ConditionalBehavior.dependent-dropdowns.json';
 
 import messageTemplates from '../fixtures/condition-message.json';
 import messageCorrelationTemplate from '../fixtures/message-correlation-key.json';
@@ -1621,6 +1621,73 @@ describe('provider/cloud-element-templates - ConditionalBehavior', function() {
           expect(businessObject.get('prop3')).to.eql('prop3_b:foo');
 
           expect(businessObject.get('prop4')).not.to.exist;
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('user input', function() {
+
+    describe('should preserve valid <dropdown> values', function() {
+
+      it('when applying template', inject(
+        function(elementRegistry, modeling) {
+
+          // given
+          const element = elementRegistry.get('ServiceTask_1');
+          const businessObject = getBusinessObject(element);
+
+          modeling.updateModdleProperties(element, businessObject, {
+            root: 'Root B',
+            sub: '/B/2'
+          });
+
+          // assume
+          expect(businessObject.get('root')).to.eql('Root B');
+          expect(businessObject.get('sub')).to.eql('/B/2');
+
+          // when
+          const updatedElement = changeTemplate(element, dependentDropdownsTemplate);
+          const updatedBusinessObject = getBusinessObject(updatedElement);
+
+          // then
+          expect(updatedBusinessObject.get('root')).to.eql('Root B');
+          expect(updatedBusinessObject.get('sub')).to.eql('/B/2');
+        }
+      ));
+
+
+      it('when upgrading template', inject(
+        function(modeling) {
+
+          // given
+          const dependentDropdownsTemplateV2 = {
+            ...dependentDropdownsTemplate,
+            version: 2
+          };
+
+          const element = changeTemplate('ServiceTask_1', dependentDropdownsTemplate);
+          const businessObject = getBusinessObject(element);
+
+          modeling.updateModdleProperties(element, businessObject, {
+            root: 'Root B',
+            sub: '/B/2'
+          });
+
+          // assume
+          expect(businessObject.get('root')).to.eql('Root B');
+          expect(businessObject.get('sub')).to.eql('/B/2');
+
+          // when
+          const updatedElement = changeTemplate(element, dependentDropdownsTemplateV2, dependentDropdownsTemplate);
+          const updatedBusinessObject = getBusinessObject(updatedElement);
+
+          // then
+          expect(updatedBusinessObject.get('root')).to.eql('Root B');
+          expect(updatedBusinessObject.get('sub')).to.eql('/B/2');
         }
       ));
 

--- a/test/spec/cloud-element-templates/fixtures/condition.bpmn
+++ b/test/spec/cloud-element-templates/fixtures/condition.bpmn
@@ -4,6 +4,7 @@
     <bpmn:task id="Task_1" name="" zeebe:modelerTemplate="example.com.condition" />
     <bpmn:task id="Task_2" name="foo" zeebe:modelerTemplate="example.com.condition" />
     <bpmn:task id="Task_3" name="foo" customProperty="foo" customProperty2="foo" zeebe:modelerTemplate="example.com.condition-multiple"/>
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -11,12 +12,16 @@
         <dc:Bounds x="180" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0u1i5ib_di" bpmnElement="Task_2">
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="310" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0warlfb_di" bpmnElement="Task_3">
+      <bpmndi:BPMNShape id="Task_3_di" bpmnElement="Task_3">
         <dc:Bounds x="440" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="640" y="120" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>


### PR DESCRIPTION
### Context

* With https://github.com/bpmn-io/bpmn-js-element-templates/pull/82 we removed the application of filtered element templates, resolving an infinite loop. 
* We broke a core guarantee (valid values are kept) but did not notice due to missing test coverage

### This PR

* Restores the pre https://github.com/bpmn-io/bpmn-js-element-templates/pull/82 behavior and adds relevant test coverage
* It ensures that a template is always conditionally applied
* It ensures that condition is only applied once per update cycle, from the _original_ template
* This way we allow the evaluation to stabilize, and stop evaluating recursively (eventually)

---

Related to https://github.com/camunda/camunda-modeler/issues/4249