### PR TITLE
fix(cloud-element-templates): only change type when actually necessary

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1009,7 +1009,10 @@ export default class ChangeElementTemplateHandler {
       return element;
     }
 
-    const oldType = oldTemplate && oldTemplate.elementType;
+    // TODO(nre): handle old event definition
+    const oldType = oldTemplate && oldTemplate.elementType || {
+      value: element.type
+    };
 
     // Do not replace if the element type did not change
     if (oldType && oldType.value === newType.value && oldType.eventDefinition === newType.eventDefinition) {

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -1133,6 +1133,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
       beforeEach(bootstrap(require('./task.bpmn').default));
 
+
       it('execute', inject(function(elementRegistry) {
 
         // given
@@ -1186,6 +1187,23 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         expect(currentTask).to.equal(task);
         expectElementTemplate(currentTask, 'element-type-template', 1);
         expect(is(currentTask, 'bpmn:UserTask')).to.be.true;
+      }));
+
+
+      it('preserve (no-op)', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('UserTask_1');
+
+        // assume
+        expect(is(task, 'bpmn:UserTask')).to.be.true;
+
+        // when
+        const updatedTask = changeTemplate(task, newTemplate);
+
+        // then
+        // expect identity to be kept (no replace)
+        expect(updatedTask).to.equal(task);
       }));
 
     });

--- a/test/spec/cloud-element-templates/cmd/task.bpmn
+++ b/test/spec/cloud-element-templates/cmd/task.bpmn
@@ -2,13 +2,14 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_039bbyr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="Task_1" />
+    <bpmn:userTask id="UserTask_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="0" y="0" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
         <dc:Bounds x="0" y="120" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>


### PR DESCRIPTION
This ensures we don't unnecessarily perform change operations on the diagram. There is more in our code-based and I'd like to discuss if we do this unnecessary work as an oversight or safety feature.

If this is an oversight, then let's only execute what is necessary.