### PR TITLE
chore(conditions): streamline data flow

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalBehavior.js
@@ -87,9 +87,12 @@ export default class ConditionalBehavior extends CommandInterceptor {
       return;
     }
 
+    // do another pass to apply further conditional bindings
+    // newTemplate will always be the original template; it is filtered
+    // at a later step (3)
     const changeContext = {
       element,
-      newTemplate: template, // newTemplate is always the original template
+      newTemplate: template,
       oldTemplate
     };
 


### PR DESCRIPTION
As the suggestions contain a small refactoring, it was hard to do this with suggestions feature in the original PR.

Notable Changes:
Add a convention that when calling `propertiesPanel.zeebe.changeTemplate`, `newTemplate` will always be the original (non-conditional) template. This ensures we only have 1 point where the template is changed, which is in `ensureConditional`. 
This adds an additional `applyConditions` to the operation, but IMO makes the code more readable

Re-ordered listeners to follow the execution path of "I changed a value, how is a condition applied"
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
