### PR TITLE
chore: remove UMD distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "umd:main": "dist/bpmn-js-element-templates.umd.js",
   "author": {
     "name": "Nico Rehwaldt",
     "url": "https://github.com/nikku"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,18 +20,6 @@ export default [
     output: [
       {
         sourcemap: true,
-        format: 'umd',
-        file: pkg['umd:main'],
-        name: 'BpmnJSElementTemplates'
-      }
-    ],
-    plugins: pgl()
-  },
-  {
-    input: 'src/index.js',
-    output: [
-      {
-        sourcemap: true,
         format: 'commonjs',
         file: pkg.main
       },

--- a/test/distro/distro.spec.js
+++ b/test/distro/distro.spec.js
@@ -11,7 +11,6 @@ const EXPORTS = [
   'bpmn-js-element-templates',
   'bpmn-js-element-templates/core',
   'bpmn-js-element-templates/dist/assets/element-templates.css',
-  'bpmn-js-element-templates/dist/bpmn-js-element-templates.umd.js',
   'bpmn-js-element-templates/package.json'
 ];
 


### PR DESCRIPTION
Closes #109

BREAKING CHANGE: UMD distribution removed; use a bundler instead

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 
Removes the UMD distribution which doesn't work due to Preact duplication.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
