### PR TITLE
fix: safely remove messages when changing templates

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalBehavior.js
@@ -80,6 +80,10 @@ export default class ConditionalBehavior extends CommandInterceptor {
       return;
     }
 
+    if (template.id !== oldTemplate.id) {
+      return;
+    }
+
     const newTemplateWithConditions = applyConditions(element, template);
 
     // verify that new bindings were activated

--- a/src/cloud-element-templates/behavior/ReferencedElementBehavior.js
+++ b/src/cloud-element-templates/behavior/ReferencedElementBehavior.js
@@ -1,4 +1,4 @@
-import { getBusinessObject, isAny } from 'bpmn-js/lib/util/ModelUtil';
+import { getBusinessObject, is, isAny } from 'bpmn-js/lib/util/ModelUtil';
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 import { isString } from 'min-dash';
 
@@ -144,10 +144,16 @@ ReferencedElementBehavior.$inject = [
 ];
 
 function canHaveReferencedElement(element) {
+
+  // Blank-Events can't have referenced elements
+  if (is(element, 'bpmn:Event')) {
+    const bo = getBusinessObject(element);
+    return bo.get('eventDefinitions') && bo.get('eventDefinitions')[0];
+  }
+
   return isAny(element, [
     'bpmn:ReceiveTask',
-    'bpmn:SendTask',
-    'bpmn:Event'
+    'bpmn:SendTask'
   ]);
 }
 

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -785,7 +785,14 @@ export default class ChangeElementTemplateHandler {
       return;
     }
 
-    const message = this._getOrCreateMessage(element, newTemplate);
+    let message = this._getMessage(element);
+
+    // no new properties and no message -> nothing to do
+    if (!newProperties.length && !message) {
+      return;
+    }
+
+    message = this._getOrCreateMessage(element, newTemplate);
     const messageExtensionElements = this._getOrCreateExtensionElements(element, message);
     const zeebeSubscription = this._getSubscription(element, message);
 

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1016,13 +1016,9 @@ export default class ChangeElementTemplateHandler {
       return element;
     }
 
-    // TODO(nre): handle old event definition
-    const oldType = oldTemplate && oldTemplate.elementType || {
-      value: element.type
-    };
 
     // Do not replace if the element type did not change
-    if (oldType && oldType.value === newType.value && oldType.eventDefinition === newType.eventDefinition) {
+    if (!shouldUpdateElementType(element, oldTemplate, newType)) {
       return element;
     }
 
@@ -1344,4 +1340,39 @@ function remove(array, item) {
 
 function hasMessageProperties(template) {
   return template.properties.some(p => MESSAGE_BINDING_TYPES.includes(p.binding.type));
+}
+
+function shouldUpdateElementType(element, oldTemplate, newType) {
+
+  // Never reuse existing eventDefinition when applying a new template
+  if (!oldTemplate && newType.eventDefinition) {
+    return true;
+  }
+
+  const oldType = oldTemplate && oldTemplate.elementType || {
+    value: element.type,
+    eventDefinition: getEventDefinitionType(element)
+  };
+
+  // Do not update if the element type did not change
+  if (oldType && oldType.value === newType.value && oldType.eventDefinition === newType.eventDefinition) {
+    return false;
+  }
+
+  return true;
+}
+
+function getEventDefinitionType(element) {
+  const businessObject = getBusinessObject(element);
+  if (!businessObject.eventDefinitions) {
+    return;
+  }
+
+  const eventDefinition = businessObject.eventDefinitions[ 0 ];
+
+  if (!eventDefinition) {
+    return;
+  }
+
+  return eventDefinition.$type;
 }

--- a/test/spec/cloud-element-templates/ElementTemplates.bpmn
+++ b/test/spec/cloud-element-templates/ElementTemplates.bpmn
@@ -35,6 +35,9 @@
       <bpmn:startEvent id="Event_0zbvlz6" />
     </bpmn:subProcess>
     <bpmn:exclusiveGateway id="Gateway_1" />
+    <bpmn:startEvent id="MessageStartEvent">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1jjph4o" messageRef="Message" />
+    </bpmn:startEvent>
     <bpmn:group id="Group_1" categoryValueRef="CategoryValue_025ggwq" />
     <bpmn:textAnnotation id="TextAnnotation_1">
       <bpmn:text>Text Annotation</bpmn:text>
@@ -53,58 +56,61 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_1srimyz_di" bpmnElement="Task_1">
-        <dc:Bounds x="150" y="160" width="100" height="80" />
+        <dc:Bounds x="160" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0z29dre_di" bpmnElement="Task_2">
-        <dc:Bounds x="270" y="160" width="100" height="80" />
+        <dc:Bounds x="280" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
-        <dc:Bounds x="390" y="160" width="100" height="80" />
+        <dc:Bounds x="400" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
-        <dc:Bounds x="390" y="260" width="100" height="80" />
+        <dc:Bounds x="400" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_di" bpmnElement="ServiceTask">
-        <dc:Bounds x="150" y="260" width="100" height="80" />
+        <dc:Bounds x="160" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1f9tp9t_di" bpmnElement="ConfiguredTask">
-        <dc:Bounds x="270" y="260" width="100" height="80" />
+        <dc:Bounds x="280" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_07znust_di" bpmnElement="IntermediateThrow">
-        <dc:Bounds x="182" y="422" width="36" height="36" />
+        <dc:Bounds x="192" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12vn43k_di" bpmnElement="IntermediateCatchMessage">
-        <dc:Bounds x="322" y="422" width="36" height="36" />
+        <dc:Bounds x="332" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1688xoq_di" bpmnElement="ConditionalEvent">
-        <dc:Bounds x="392" y="422" width="36" height="36" />
+        <dc:Bounds x="402" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="193" y="275" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0rxdmt7_di" bpmnElement="MessageEvent">
-        <dc:Bounds x="252" y="422" width="36" height="36" />
+        <dc:Bounds x="262" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_04x2ssk_di" bpmnElement="Gateway_1" isMarkerVisible="true">
-        <dc:Bounds x="175" y="70" width="50" height="50" />
+        <dc:Bounds x="185" y="70" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nu49eb_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="262" y="362" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0sitnpj_di" bpmnElement="SubProcess_1" isExpanded="false">
-        <dc:Bounds x="390" y="520" width="100" height="80" />
+        <dc:Bounds x="400" y="520" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1sxgene_di" bpmnElement="Association_1sxgene">
+        <di:waypoint x="850" y="160" />
+        <di:waypoint x="896" y="110" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
-        <dc:Bounds x="550" y="160" width="300" height="300" />
+        <dc:Bounds x="560" y="160" width="300" height="300" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="669" y="167" width="63" height="14" />
+          <dc:Bounds x="679" y="167" width="63" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
-        <dc:Bounds x="850" y="80" width="100" height="30" />
+        <dc:Bounds x="860" y="80" width="100" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1sxgene_di" bpmnElement="Association_1sxgene">
-        <di:waypoint x="840" y="160" />
-        <di:waypoint x="886" y="110" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0h3d15h">

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -699,6 +699,33 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should remove existing event definition', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const templates = require('./fixtures/start-event.json');
+      elementTemplates.set(templates);
+
+      const template = templates[0];
+      const event = elementRegistry.get('MessageStartEvent');
+      const oldMessageEventDefinition = getBusinessObject(event).get('eventDefinitions')[0];
+
+      // assume
+      expect(oldMessageEventDefinition).to.exist;
+      expect(template).to.exist;
+
+      // when
+      const updatedEvent = elementTemplates.applyTemplate(event, template);
+
+      // then
+      expect(updatedEvent).to.exist;
+      expect(elementTemplates.get(updatedEvent)).to.equal(template);
+      expect(is(updatedEvent, 'bpmn:StartEvent')).to.be.true;
+
+      const eventDefinitions = getBusinessObject(updatedEvent).get('eventDefinitions');
+      expect(eventDefinitions).to.have.length(0);
+    }));
+
+
     it('should apply message binding', inject(function(elementRegistry, elementTemplates) {
 
       // given

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -1483,6 +1483,22 @@ describe('provider/cloud-element-templates - ElementTemplates - integration', fu
       }
     ));
 
+
+    it('Github message start => Webhook blank-start', inject(
+      function(elementRegistry, elementTemplates) {
+
+        // given
+        let startEvent = elementRegistry.get('startEvent');
+        const template = elementTemplates.get('io.camunda.connectors.webhook.WebhookConnector.v1');
+
+        // when
+        const applyTemplate = () => elementTemplates.applyTemplate(startEvent, template);
+
+        // expect
+        expect(applyTemplate).not.to.throw();
+      }
+    ));
+
   });
 
 });

--- a/test/spec/cloud-element-templates/behavior/ReferencedElementBehavior.json
+++ b/test/spec/cloud-element-templates/behavior/ReferencedElementBehavior.json
@@ -29,5 +29,15 @@
         }
       }
     ]
+  },
+  {
+    "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name" : "Intermediate Event",
+    "id" : "blankIntermediateEvent",
+    "appliesTo" : [ "bpmn:IntermediateCatchEvent" ],
+    "elementType" : {
+      "value" : "bpmn:IntermediateCatchEvent"
+    },
+    "properties" : [  ]
   }
 ]

--- a/test/spec/cloud-element-templates/behavior/ReferencedElementBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/ReferencedElementBehavior.spec.js
@@ -54,6 +54,24 @@ describe('provider/cloud-element-templates - ReferencedElementBehavior', functio
         expect(getMessages()).to.have.lengthOf(initialMessages.length + 1);
       })
     );
+
+
+    it('should remove message when new template has no message', inject(
+      function(elementRegistry, elementTemplates) {
+
+        // given
+        let event = elementRegistry.get('MessageEvent_2');
+        event = elementTemplates.applyTemplate(event, templates[0]);
+        const initialMessages = getMessages();
+
+        // when
+        elementTemplates.applyTemplate(event, templates[1]);
+
+        // then
+        expect(getMessages()).to.have.lengthOf(initialMessages.length - 1);
+      })
+    );
+
   });
 
 

--- a/test/spec/cloud-element-templates/fixtures/integration.bpmn
+++ b/test/spec/cloud-element-templates/fixtures/integration.bpmn
@@ -31,7 +31,12 @@
         <zeebe:taskHeaders />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:startEvent id="startEvent" zeebe:modelerTemplate="io.camunda.connectors.webhook.GithubWebhookConnectorMessageStart.v1">
+      <bpmn:extensionElements />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1fu21eo" messageRef="Message_0v0k34x" />
+    </bpmn:startEvent>
   </bpmn:process>
+  <bpmn:message id="Message_0v0k34x" name="9adab4ff-0531-4a18-aceb-55035944f461" zeebe:modelerTemplate="io.camunda.connectors.webhook.GithubWebhookConnectorMessageStart.v1" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1sefuog">
       <bpmndi:BPMNShape id="templateTask_di" bpmnElement="templateTask">
@@ -45,6 +50,9 @@
       <bpmndi:BPMNShape id="REST_TASK_di" bpmnElement="REST_TASK">
         <dc:Bounds x="160" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eswyrb_di" bpmnElement="startEvent">
+        <dc:Bounds x="322" y="222" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/fixtures/integration.json
+++ b/test/spec/cloud-element-templates/fixtures/integration.json
@@ -375,5 +375,618 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "GitHub Webhook Message Start Event Connector",
+    "id": "io.camunda.connectors.webhook.GithubWebhookConnectorMessageStart.v1",
+    "description": "Receive events from GitHub",
+    "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github/?github=inbound",
+    "category": {
+      "id": "connectors",
+      "name": "Connectors"
+    },
+    "appliesTo": [
+      "bpmn:StartEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:StartEvent",
+      "eventDefinition": "bpmn:MessageEventDefinition"
+    },
+    "groups": [
+      {
+        "id": "endpoint",
+        "label": "Webhook configuration"
+      },
+      {
+        "id": "activation",
+        "label": "Activation"
+      },
+      {
+        "id": "correlation",
+        "label": "Subprocess correlation"
+      },
+      {
+        "id": "variable-mapping",
+        "label": "Variable mapping"
+      }
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "io.camunda:webhook:1",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.type"
+        }
+      },
+      {
+        "type": "Hidden",
+        "generatedValue": {
+          "type": "uuid"
+        },
+        "binding": {
+          "type": "bpmn:Message#property",
+          "name": "name"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "GitHubWebhook",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.subtype"
+        }
+      },
+      {
+        "label": "Webhook ID",
+        "type": "String",
+        "group": "endpoint",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.context"
+        },
+        "description": "The webhook ID is a part of the URL",
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "enabled",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.shouldValidateHmac"
+        }
+      },
+      {
+        "label": "GitHub secret",
+        "description": "Shared secret key. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github/?github=inbound' target='_blank'>See documentation</a> regarding GitHub secret",
+        "type": "String",
+        "group": "endpoint",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.hmacSecret"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "X-Hub-Signature-256",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.hmacHeader"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "sha_256",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.hmacAlgorithm"
+        }
+      },
+      {
+        "label": "Message ID expression",
+        "feel": "required",
+        "type": "String",
+        "optional": true,
+        "group": "activation",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "messageIdExpression"
+        },
+        "description": "Expression to extract unique identifier of a message"
+      },
+      {
+        "label": "Condition",
+        "type": "String",
+        "group": "activation",
+        "feel": "required",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "inbound.activationCondition"
+        },
+        "description": "Condition under which the connector triggers. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github/?github=inbound' target='_blank'>See documentation</a>"
+      },
+      {
+        "label": "Correlation required",
+        "description": "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
+        "id": "correlationRequired",
+        "group": "correlation",
+        "type": "Dropdown",
+        "value": "notRequired",
+        "choices": [
+          {
+            "name": "Correlation not required",
+            "value": "notRequired"
+          },
+          {
+            "name": "Correlation required",
+            "value": "required"
+          }
+        ],
+        "binding": {
+          "type": "zeebe:property",
+          "name": "correlationRequired"
+        }
+      },
+      {
+        "label": "Correlation key (process)",
+        "type": "String",
+        "group": "correlation",
+        "feel": "required",
+        "description": "Sets up the correlation key from process variables",
+        "binding": {
+          "type": "bpmn:Message#zeebe:subscription#property",
+          "name": "correlationKey"
+        },
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "correlationRequired",
+          "equals": "required"
+        }
+      },
+      {
+        "label": "Correlation key (payload)",
+        "type": "String",
+        "group": "correlation",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "correlationKeyExpression"
+        },
+        "description": "Extracts the correlation key from the incoming message payload",
+        "constraints": {
+          "notEmpty": true
+        },
+        "condition": {
+          "property": "correlationRequired",
+          "equals": "required"
+        }
+      },
+      {
+        "label": "Result variable",
+        "type": "String",
+        "group": "variable-mapping",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "resultVariable"
+        },
+        "description": "Name of variable to store the result of the connector in"
+      },
+      {
+        "label": "Result expression",
+        "type": "String",
+        "group": "variable-mapping",
+        "feel": "required",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "resultExpression"
+        },
+        "description": "Expression to map the inbound payload to process variables"
+      }
+    ],
+    "icon": {
+      "contents": "data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 1024 1024' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z' transform='scale(64)' fill='%231B1F23'/%3E%3C/svg%3E"
+    }
+  },
+  {
+    "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name" : "Webhook Start Event Connector",
+    "id" : "io.camunda.connectors.webhook.WebhookConnector.v1",
+    "description" : "Configure webhook to receive callbacks",
+    "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
+    "category" : {
+      "id" : "connectors",
+      "name" : "Connectors"
+    },
+    "appliesTo" : [ "bpmn:StartEvent" ],
+    "elementType" : {
+      "value" : "bpmn:StartEvent"
+    },
+    "groups" : [ {
+      "id" : "endpoint",
+      "label" : "Webhook configuration"
+    }, {
+      "id" : "authentication",
+      "label" : "Authentication"
+    }, {
+      "id" : "authorization",
+      "label" : "Authorization"
+    }, {
+      "id" : "webhookResponse",
+      "label" : "Webhook response"
+    }, {
+      "id" : "activation",
+      "label" : "Activation"
+    }, {
+      "id" : "output",
+      "label" : "Output mapping"
+    } ],
+    "properties" : [ {
+      "value" : "io.camunda:webhook:1",
+      "binding" : {
+        "name" : "inbound.type",
+        "type" : "zeebe:property"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "inbound.webhookMethod",
+      "label" : "Webhook method",
+      "description" : "Select HTTP method",
+      "optional" : false,
+      "value" : "any",
+      "group" : "endpoint",
+      "binding" : {
+        "name" : "inbound.method",
+        "type" : "zeebe:property"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "Any",
+        "value" : "any"
+      }, {
+        "name" : "GET",
+        "value" : "get"
+      }, {
+        "name" : "POST",
+        "value" : "post"
+      }, {
+        "name" : "PUT",
+        "value" : "put"
+      }, {
+        "name" : "DELETE",
+        "value" : "delete"
+      } ]
+    }, {
+      "id" : "inbound.webhookId",
+      "label" : "Webhook ID",
+      "description" : "The webhook ID is a part of the URL",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true,
+        "pattern" : {
+          "value" : "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",
+          "message" : "can only contain letters, numbers, or single underscores/hyphens and cannot begin or end with an underscore/hyphen"
+        }
+      },
+      "feel" : "optional",
+      "group" : "endpoint",
+      "binding" : {
+        "name" : "inbound.context",
+        "type" : "zeebe:property"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.shouldValidateHmac",
+      "label" : "HMAC authentication",
+      "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "optional" : false,
+      "value" : "disabled",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "inbound.shouldValidateHmac",
+        "type" : "zeebe:property"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "Enabled",
+        "value" : "enabled"
+      }, {
+        "name" : "Disabled",
+        "value" : "disabled"
+      } ]
+    }, {
+      "id" : "inbound.hmacSecret",
+      "label" : "HMAC secret key",
+      "description" : "Shared secret key",
+      "optional" : true,
+      "feel" : "optional",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "inbound.hmacSecret",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.shouldValidateHmac",
+        "equals" : "enabled",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.hmacHeader",
+      "label" : "HMAC header",
+      "description" : "Name of header attribute that will contain the HMAC value",
+      "optional" : true,
+      "feel" : "optional",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "inbound.hmacHeader",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.shouldValidateHmac",
+        "equals" : "enabled",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.hmacAlgorithm",
+      "label" : "HMAC algorithm",
+      "description" : "Choose HMAC algorithm",
+      "optional" : false,
+      "value" : "sha_256",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "inbound.hmacAlgorithm",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.shouldValidateHmac",
+        "equals" : "enabled",
+        "type" : "simple"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "SHA-1",
+        "value" : "sha_1"
+      }, {
+        "name" : "SHA-256",
+        "value" : "sha_256"
+      }, {
+        "name" : "SHA-512",
+        "value" : "sha_512"
+      } ]
+    }, {
+      "id" : "inbound.hmacScopes",
+      "label" : "HMAC scopes",
+      "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+      "optional" : true,
+      "feel" : "required",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "inbound.hmacScopes",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.shouldValidateHmac",
+        "equals" : "enabled",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.type",
+      "label" : "Authorization type",
+      "description" : "Choose the authorization type",
+      "value" : "NONE",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.type",
+        "type" : "zeebe:property"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "None",
+        "value" : "NONE"
+      }, {
+        "name" : "Basic",
+        "value" : "BASIC"
+      }, {
+        "name" : "API key",
+        "value" : "APIKEY"
+      }, {
+        "name" : "JWT",
+        "value" : "JWT"
+      } ]
+    }, {
+      "id" : "inbound.auth.username",
+      "label" : "Username",
+      "description" : "Username for basic authentication",
+      "optional" : false,
+      "feel" : "optional",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.username",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "BASIC",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.password",
+      "label" : "Password",
+      "description" : "Password for basic authentication",
+      "optional" : false,
+      "feel" : "optional",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.password",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "BASIC",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.apiKey",
+      "label" : "API key",
+      "description" : "Expected API key",
+      "optional" : false,
+      "feel" : "optional",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.apiKey",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "APIKEY",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.apiKeyLocator",
+      "label" : "API key locator",
+      "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+      "optional" : false,
+      "value" : "=split(request.headers.authorization, \" \")[2]",
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "required",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.apiKeyLocator",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "APIKEY",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.jwt.jwkUrl",
+      "label" : "JWK URL",
+      "description" : "Well-known URL of JWKs",
+      "optional" : false,
+      "feel" : "optional",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.jwt.jwkUrl",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "JWT",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.jwt.permissionsExpression",
+      "label" : "JWT role property expression",
+      "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+      "optional" : false,
+      "feel" : "required",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.jwt.permissionsExpression",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "JWT",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.auth.jwt.requiredPermissions",
+      "label" : "Required roles",
+      "description" : "List of roles to test JWT roles against",
+      "optional" : false,
+      "feel" : "required",
+      "group" : "authorization",
+      "binding" : {
+        "name" : "inbound.auth.jwt.requiredPermissions",
+        "type" : "zeebe:property"
+      },
+      "condition" : {
+        "property" : "inbound.auth.type",
+        "equals" : "JWT",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "inbound.responseBodyExpression",
+      "label" : "Response body expression",
+      "description" : "Specify condition and response",
+      "optional" : true,
+      "feel" : "required",
+      "group" : "webhookResponse",
+      "binding" : {
+        "name" : "inbound.responseBodyExpression",
+        "type" : "zeebe:property"
+      },
+      "type" : "Text"
+    }, {
+      "id" : "inbound.verificationExpression",
+      "label" : "One time verification response expression",
+      "description" : "Specify condition and response. Learn more in the <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#verification-expression' target='_blank'>documentation</a>",
+      "optional" : true,
+      "feel" : "required",
+      "group" : "webhookResponse",
+      "binding" : {
+        "name" : "inbound.verificationExpression",
+        "type" : "zeebe:property"
+      },
+      "type" : "Text"
+    }, {
+      "id" : "activationCondition",
+      "label" : "Activation condition",
+      "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+      "optional" : true,
+      "feel" : "required",
+      "group" : "activation",
+      "binding" : {
+        "name" : "activationCondition",
+        "type" : "zeebe:property"
+      },
+      "type" : "String"
+    }, {
+      "id" : "resultVariable",
+      "label" : "Result variable",
+      "description" : "Name of variable to store the response in",
+      "group" : "output",
+      "binding" : {
+        "name" : "resultVariable",
+        "type" : "zeebe:property"
+      },
+      "type" : "String"
+    }, {
+      "id" : "resultExpression",
+      "label" : "Result expression",
+      "description" : "Expression to map the response into process variables",
+      "feel" : "required",
+      "group" : "output",
+      "binding" : {
+        "name" : "resultExpression",
+        "type" : "zeebe:property"
+      },
+      "type" : "Text"
+    } ],
+    "icon" : {
+      "contents" : "data:image/svg+xml;base64,PHN2ZyBpZD0naWNvbicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB3aWR0aD0nMTgnIGhlaWdodD0nMTgnIHZpZXdCb3g9JzAgMCAzMiAzMic+CiAgPGRlZnM+CiAgICA8c3R5bGU+LmNscy0xIHsgZmlsbDogbm9uZTsgfTwvc3R5bGU+CiAgPC9kZWZzPgogIDxwYXRoCiAgICBkPSdNMjQsMjZhMywzLDAsMSwwLTIuODE2NC00SDEzdjFhNSw1LDAsMSwxLTUtNVYxNmE3LDcsMCwxLDAsNi45Mjg3LDhoNi4yNTQ5QTIuOTkxNCwyLjk5MTQsMCwwLDAsMjQsMjZaJy8+CiAgPHBhdGgKICAgIGQ9J00yNCwxNmE3LjAyNCw3LjAyNCwwLDAsMC0yLjU3LjQ4NzNsLTMuMTY1Ni01LjUzOTVhMy4wNDY5LDMuMDQ2OSwwLDEsMC0xLjczMjYuOTk4NWw0LjExODksNy4yMDg1Ljg2ODYtLjQ5NzZhNS4wMDA2LDUuMDAwNiwwLDEsMS0xLjg1MSw2Ljg0MThMMTcuOTM3LDI2LjUwMUE3LjAwMDUsNy4wMDA1LDAsMSwwLDI0LDE2WicvPgogIDxwYXRoCiAgICBkPSdNOC41MzIsMjAuMDUzN2EzLjAzLDMuMDMsMCwxLDAsMS43MzI2Ljk5ODVDMTEuNzQsMTguNDcsMTMuODYsMTQuNzYwNywxMy44OSwxNC43MDhsLjQ5NzYtLjg2ODItLjg2NzctLjQ5N2E1LDUsMCwxLDEsNi44MTItMS44NDM4bDEuNzMxNSwxLjAwMmE3LjAwMDgsNy4wMDA4LDAsMSwwLTEwLjM0NjIsMi4wMzU2Yy0uNDU3Ljc0MjctMS4xMDIxLDEuODcxNi0yLjA3MzcsMy41NzI4WicvPgogIDxyZWN0IGlkPSdfVHJhbnNwYXJlbnRfUmVjdGFuZ2xlXycgZGF0YS1uYW1lPScmbHQ7VHJhbnNwYXJlbnQgUmVjdGFuZ2xlJmd0OycgY2xhc3M9J2Nscy0xJwogICAgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJy8+Cjwvc3ZnPg=="
+    }
   }
 ]


### PR DESCRIPTION
### Proposed Changes
This PR fixes the following flows:

- Apply a non-message template to a message element. Currently, this would keep the event definition reference in the element.
- Applying a non-message template to a templated message element. Currently, this would result in an error thrown. Root cause can be found here: https://github.com/camunda/camunda-modeler/issues/4357#issuecomment-2205682401

related to https://github.com/camunda/camunda-modeler/issues/4357

![Recording 2024-07-04 at 12 05 09](https://github.com/bpmn-io/bpmn-js-element-templates/assets/21984219/3547b25c-4db1-4567-8d92-7adbbcbaed5c)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
