### PR TITLE
fix: do not remove documentation and execution listeners when template is removed

### DIFF
--- a/src/cloud-element-templates/cmd/ElementTemplateCommands.js
+++ b/src/cloud-element-templates/cmd/ElementTemplateCommands.js
@@ -1,5 +1,5 @@
 import ChangeElementTemplateHandler from './ChangeElementTemplateHandler';
-import RemoveElementTemplateHandler from '../../element-templates/cmd/RemoveElementTemplateHandler';
+import RemoveElementTemplateHandler from './RemoveElementTemplateHandler';
 import MultiCommandHandler from '../../element-templates/cmd/MultiCommandHandler';
 
 export default class ElementTemplatesCommands {

--- a/src/cloud-element-templates/cmd/RemoveElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/RemoveElementTemplateHandler.js
@@ -1,0 +1,147 @@
+import { getLabel, setLabel } from 'bpmn-js/lib/features/label-editing/LabelUtil';
+import { getShapeIdFromPlane, isPlane } from 'bpmn-js/lib/util/DrilldownUtil';
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+
+export default class RemoveElementTemplateHandler {
+  constructor(
+      modeling,
+      elementFactory,
+      elementRegistry,
+      canvas,
+      bpmnFactory,
+      replace,
+      commandStack
+  ) {
+    this._modeling = modeling;
+    this._elementFactory = elementFactory;
+    this._elementRegistry = elementRegistry;
+    this._canvas = canvas;
+    this._bpmnFactory = bpmnFactory;
+    this._replace = replace;
+    this._commandStack = commandStack;
+  }
+
+  preExecute(context) {
+    const {
+      element
+    } = context;
+
+    if (element.parent) {
+      context.newElement = this._removeTemplate(element);
+    } else {
+      context.newElement = this._removeRootTemplate(element);
+    }
+  }
+
+  _removeTemplate(element) {
+    const replace = this._replace;
+
+    const businessObject = getBusinessObject(element);
+
+    const type = businessObject.$type,
+          eventDefinitionType = this._getEventDefinitionType(businessObject);
+
+    const newBusinessObject = this._createBlankBusinessObject(element);
+
+    return replace.replaceElement(element,
+      {
+        type: type,
+        businessObject: newBusinessObject,
+        eventDefinitionType: eventDefinitionType,
+      },
+      {
+        createElementsBehavior: false
+      }
+    );
+  }
+
+  /**
+   * Remove template from a given element.
+   *
+   * @param {djs.model.Base} element
+   *
+   * @return {djs.model.Base} the updated element
+   */
+  _removeRootTemplate(element) {
+    var modeling = this._modeling,
+        elementFactory = this._elementFactory,
+        elementRegistry = this._elementRegistry,
+        canvas = this._canvas;
+
+    // We are inside a collapsed subprocess, move up to the parent before replacing the collapsed object
+    if (isPlane(element)) {
+      const shapeId = getShapeIdFromPlane(element);
+      const shape = elementRegistry.get(shapeId);
+
+      if (shape && shape !== element) {
+        canvas.setRootElement(canvas.findRoot(shape));
+        return this._removeTemplate(shape);
+      }
+    }
+
+    const businessObject = getBusinessObject(element);
+
+    const type = businessObject.$type;
+
+    const newBusinessObject = this._createBlankBusinessObject(element);
+
+    const newRoot = elementFactory.create('root', {
+      type: type,
+      businessObject: newBusinessObject
+    });
+
+    this._commandStack.execute('canvas.updateRoot', {
+      newRoot: newRoot,
+      oldRoot: element
+    });
+
+    modeling.moveElements(element.children, { x: 0, y: 0 }, newRoot);
+
+    return newRoot;
+  }
+
+  _getEventDefinitionType(businessObject) {
+    if (!businessObject.eventDefinitions) {
+      return null;
+    }
+
+    const eventDefinition = businessObject.eventDefinitions[ 0 ];
+
+    if (!eventDefinition) {
+      return null;
+    }
+
+    return eventDefinition.$type;
+  }
+
+  _createBlankBusinessObject(element) {
+    const bpmnFactory = this._bpmnFactory;
+
+    const bo = getBusinessObject(element),
+          newBo = bpmnFactory.create(bo.$type),
+          label = getLabel(element);
+
+    if (!label) {
+      return newBo;
+    }
+
+    if (is(element, 'bpmn:Group')) {
+      newBo.categoryValueRef = bpmnFactory.create('bpmn:CategoryValue');
+    }
+
+    setLabel({ businessObject: newBo }, label);
+
+    return newBo;
+  }
+}
+
+
+RemoveElementTemplateHandler.$inject = [
+  'modeling',
+  'elementFactory',
+  'elementRegistry',
+  'canvas',
+  'bpmnFactory',
+  'replace',
+  'commandStack'
+];

--- a/test/spec/cloud-element-templates/ElementTemplates.bpmn
+++ b/test/spec/cloud-element-templates/ElementTemplates.bpmn
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
   <bpmn:process id="Process_1" isExecutable="true" zeebe:modelerTemplate="process-template" zeebe:modelerTemplateVersion="1">
-    <bpmn:task id="Task_1" name="foo" zeebe:modelerTemplate="foo" />
+    <bpmn:task id="Task_1" name="foo" zeebe:modelerTemplate="foo">
+      <bpmn:documentation>bar</bpmn:documentation>
+    </bpmn:task>
     <bpmn:task id="Task_2" name="icon" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg xmlns=&#39;http://www.w3.org/2000/svg&#39; height=&#39;100&#39; width=&#39;100&#39;%3E%3Ccircle cx=&#39;50&#39; cy=&#39;50&#39; r=&#39;40&#39; stroke=&#39;black&#39; stroke-width=&#39;3&#39; fill=&#39;red&#39; /%3E%3C/svg%3E" />
     <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_5" zeebe:modelerTemplate="default" zeebe:modelerTemplateVersion="1">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="bar" type="foo" />
+          <zeebe:executionListener eventType="end" retries="foo" type="bar" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:task>
     <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
     <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" zeebe:modelerTemplateVersion="1" />
     <bpmn:serviceTask id="ConfiguredTask">
@@ -87,6 +97,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0rxdmt7_di" bpmnElement="MessageEvent">
         <dc:Bounds x="262" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_05tjg7w" bpmnElement="Task_5">
+        <dc:Bounds x="160" y="520" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_04x2ssk_di" bpmnElement="Gateway_1" isMarkerVisible="true">
         <dc:Bounds x="185" y="70" width="50" height="50" />

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -1341,6 +1341,38 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
       });
     }));
 
+
+    it('should keep documentation', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let task = elementRegistry.get('Task_1');
+
+      // assume
+      const bo = getBusinessObject(task);
+      expect(bo.documentation[0].text).to.exist;
+
+      // when
+      task = elementTemplates.removeTemplate(task);
+
+      // then
+      const newBo = getBusinessObject(task);
+      expect(newBo.documentation[0].text).to.exist;
+    }));
+
+
+    it('should keep execution listeners', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      let task = elementRegistry.get('Task_5');
+
+      // when
+      task = elementTemplates.removeTemplate(task);
+
+      // then
+      const bo = getBusinessObject(task);
+      expect(bo.extensionElements.values[0].$type).to.equal('zeebe:ExecutionListeners');
+    }));
+
   });
 
 


### PR DESCRIPTION
Closes #114

### Proposed Changes

When removing template from element, documentation and execution listeners (and potentially more non-template properties in the future) are kept.

https://github.com/user-attachments/assets/187c7e81-aac5-4c81-b9c1-6a20e605f512

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
