### PR TITLE
fix: move template group right below documentation group

### DIFF
--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -58,7 +58,7 @@ export default class ElementTemplatesPropertiesProvider {
       };
 
       // (1) Add templates group
-      addGroupsAfter(ALWAYS_DISPLAYED_GROUPS, groups, [ templatesGroup ]);
+      addGroupsAfter('documentation', groups, [ templatesGroup ]);
 
       let elementTemplate = this._elementTemplates.get(element);
 

--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -15,7 +15,7 @@ import { getPropertyValue } from '../util/propertyUtil';
 
 const LOWER_PRIORITY = 300;
 
-const ALWAYS_DISPLAYED_GROUPS = [
+const ALWAYS_VISIBLE_GROUPS = [
   'general',
   'documentation',
   'multiInstance',
@@ -75,7 +75,7 @@ export default class ElementTemplatesPropertiesProvider {
 
       // (3) apply entries visible
       if (getTemplateId(element)) {
-        groups = filterWithEntriesVisible(elementTemplate || {}, groups);
+        groups = getVisibleGroups(elementTemplate || {}, groups);
       }
 
       return groups;
@@ -145,11 +145,11 @@ function addGroupsAfter(idOrIds, groups, groupsToAdd) {
   }
 }
 
-function filterWithEntriesVisible(template, groups) {
+function getVisibleGroups(template, groups) {
   if (!template.entriesVisible) {
     return groups.filter(group => {
       return (
-        ALWAYS_DISPLAYED_GROUPS.includes(group.id) ||
+        ALWAYS_VISIBLE_GROUPS.includes(group.id) ||
         group.id.startsWith('ElementTemplates__')
       );
     });

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.entries-visible.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.entries-visible.bpmn
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_08adx7k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.29.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:task id="Task_1" zeebe:modelerTemplate="foo" />
-    <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
+    <bpmn:task id="Task_1" zeebe:modelerTemplate="foo">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:task>
     <bpmn:task id="Task_3" />
-    <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
-    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" />
+    <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -206,7 +206,7 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
     }));
 
 
-    it('should show only general, documentation, and execution listeners group, and template-related entries when entriesVisible is unset',
+    it('should show only general, documentation, template group and execution listeners group when entriesVisible is unset',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -221,14 +221,14 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         expectOnlyGroups(container, [
           'general',
           'documentation',
-          'Zeebe__ExecutionListeners',
-          'ElementTemplates__Template'
+          'ElementTemplates__Template',
+          'Zeebe__ExecutionListeners'
         ]);
       })
     );
 
 
-    it('should show only general, documentation, and execution listeners group, and template-related entries when entriesVisible=false',
+    it('should show only general, documentation, template group and execution listeners group when entriesVisible=false',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -243,14 +243,14 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         expectOnlyGroups(container, [
           'general',
           'documentation',
-          'Zeebe__ExecutionListeners',
-          'ElementTemplates__Template'
+          'ElementTemplates__Template',
+          'Zeebe__ExecutionListeners'
         ]);
       })
     );
 
 
-    it('should show only general, documentation, and execution listeners group, and template group when template is unknown',
+    it('should show only general, documentation, template group and execution listeners group when template is unknown',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -265,8 +265,8 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         expectOnlyGroups(container, [
           'general',
           'documentation',
-          'Zeebe__ExecutionListeners',
-          'ElementTemplates__Template'
+          'ElementTemplates__Template',
+          'Zeebe__ExecutionListeners'
         ]);
       })
     );

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -206,7 +206,7 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
     }));
 
 
-    it('should show only general, documentation, template group and execution listeners group when entriesVisible is unset',
+    it('should show only always-visible groups when entriesVisible is unset',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -222,13 +222,14 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
           'general',
           'documentation',
           'ElementTemplates__Template',
+          'multiInstance',
           'Zeebe__ExecutionListeners'
         ]);
       })
     );
 
 
-    it('should show only general, documentation, template group and execution listeners group when entriesVisible=false',
+    it('should show only always-visible groups when entriesVisible=false',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -244,13 +245,14 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
           'general',
           'documentation',
           'ElementTemplates__Template',
+          'multiInstance',
           'Zeebe__ExecutionListeners'
         ]);
       })
     );
 
 
-    it('should show only general, documentation, template group and execution listeners group when template is unknown',
+    it('should show only always-visible groups when template is unknown',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -266,13 +268,14 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
           'general',
           'documentation',
           'ElementTemplates__Template',
+          'multiInstance',
           'Zeebe__ExecutionListeners'
         ]);
       })
     );
 
 
-    it('should show all available groups when entriesVisible=true',
+    it('should show all groups when entriesVisible=true',
       inject(async function(elementRegistry, selection) {
 
         // given
@@ -287,10 +290,13 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         const groups = getGroupIds(container);
 
         expect(groups).to.contain('general');
-        expect(groups).to.contain('ElementTemplates__Template');
         expect(groups).to.contain('documentation');
+        expect(groups).to.contain('ElementTemplates__Template');
+        expect(groups).to.contain('Zeebe__ExecutionListeners');
+        expect(groups).to.contain('Zeebe__ExtensionProperties');
       })
     );
+
   });
 
 


### PR DESCRIPTION
closes https://github.com/camunda/camunda-modeler/issues/4617

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

These changes are moving Template group higher on the properties panel list, right below the documentation group

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
