### PR TITLE
Element Templates Runtime Versions support

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -9,6 +9,9 @@
   --unknown-template-background-color: var(--color-red-360-100-45);
   --unknown-template-hover-background-color: var(--color-red-360-100-40);
 
+  --incompatible-template-background-color: rgb(255, 131, 43);
+  --incompatible-template-hover-background-color: hsl(25, 100%, 50%);
+
   --select-template-information-text-color: var(--color-grey-225-10-55);
 
   --deprecated-template-hover-background-color: var(--color-grey-225-10-50);
@@ -59,7 +62,8 @@
 
 .bio-properties-panel-template-update-available:last-child,
 .bio-properties-panel-applied-template-button:last-child,
-.bio-properties-panel-template-not-found:last-child {
+.bio-properties-panel-template-not-found:last-child,
+.bio-properties-panel-template-incompatible:last-child {
   margin-right: 32px;
 }
 
@@ -77,7 +81,6 @@
   background-color: var(--deprecated-template-hover-background-color);
 }
 
-
 .bio-properties-panel-template-not-found .bio-properties-panel-group-header-button {
   background-color: var(--unknown-template-background-color);
   color: var(--select-template-label-color);
@@ -88,13 +91,25 @@
   background-color: var(--unknown-template-hover-background-color);
 }
 
+.bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button {
+  background-color: var(--incompatible-template-background-color);
+  color: var(--select-template-label-color);
+  fill: var(--select-template-fill-color);
+}
+
+.bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button:hover {
+  background-color: var(--incompatible-template-hover-background-color);
+}
+
 .bio-properties-panel-template-not-found-text,
-.bio-properties-panel-template-update-available-text {
+.bio-properties-panel-template-update-available-text,
+.bio-properties-panel-template-incompatible-text {
   color: var(--select-template-information-text-color);
 }
 
 .bio-properties-panel-template-not-found-text,
 .bio-properties-panel-template-update-available-text,
-.bio-properties-panel-deprecated-template-text {
+.bio-properties-panel-deprecated-template-text,
+.bio-properties-panel-template-incompatible-text {
   width: 216px;
 }

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,6 +1,9 @@
 /* eslint-env node */
 
 const path = require('path');
+
+const pkg = require('./package.json');
+
 const {
   DefinePlugin,
   NormalModuleReplacementPlugin
@@ -92,6 +95,9 @@ module.exports = function(karma) {
       },
       plugins: [
         new DefinePlugin({
+
+          // @nikku needs to be defined
+          'process.env.PKG_VERSION': JSON.stringify(pkg.version),
 
           // @barmac: process.env has to be defined to make @testing-library/preact work
           'process.env': {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.3",
         "preact-markup": "^2.1.1",
+        "semver": "^7.6.3",
         "semver-compare": "^1.0.0",
         "uuid": "^11.0.0"
       },
@@ -163,6 +164,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
@@ -207,6 +217,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -1190,19 +1209,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/yargs": {
@@ -2585,18 +2591,6 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4336,6 +4330,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
@@ -4442,6 +4445,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -6261,6 +6273,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -6981,6 +7002,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/media-typer": {
@@ -8843,12 +8873,14 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -10330,6 +10362,14 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
         "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -10365,6 +10405,14 @@
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-module-imports": {
@@ -11106,12 +11154,6 @@
             "strip-ansi": "^6.0.1",
             "wrap-ansi": "^7.0.0"
           }
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
         },
         "yargs": {
           "version": "17.7.2",
@@ -12114,12 +12156,6 @@
             "istanbul-lib-coverage": "^3.2.0",
             "semver": "^7.5.4"
           }
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
         }
       }
     },
@@ -13510,6 +13546,12 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         }
       }
     },
@@ -13580,6 +13622,12 @@
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         }
       }
     },
@@ -14750,6 +14798,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -15325,6 +15381,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "media-typer": {
@@ -16671,10 +16735,9 @@
       }
     },
     "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "karma-webpack": "^5.0.1",
         "mocha": "^10.8.2",
         "mocha-test-container-support": "^0.2.0",
+        "modeler-moddle": "^0.2.0",
         "npm-run-all2": "^7.0.0",
         "puppeteer": "^23.7.0",
         "raw-loader": "^4.0.2",
@@ -7379,7 +7380,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/modeler-moddle/-/modeler-moddle-0.2.0.tgz",
       "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.0",
+        "@rollup/plugin-replace": "^6.0.1",
         "@testing-library/preact": "^2.0.1",
         "@testing-library/preact-hooks": "^1.1.0",
         "assert": "^2.1.0",
@@ -1350,6 +1351,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.1.tgz",
+      "integrity": "sha512-2sPh9b73dj5IxuMmDAsQWVFT7mR+yoHweBaXG2W/R8vQ+IWZlnaI7BR7J6EguVQUp1hd8Z7XuozpDjEKQAAC2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -11232,6 +11255,16 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.1.tgz",
+      "integrity": "sha512-2sPh9b73dj5IxuMmDAsQWVFT7mR+yoHweBaXG2W/R8vQ+IWZlnaI7BR7J6EguVQUp1hd8Z7XuozpDjEKQAAC2Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
       }
     },
     "@rollup/pluginutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.1.0",
+        "@bpmn-io/element-templates-validator": "^2.2.0",
         "@bpmn-io/extract-process-variables": "^1.0.0",
         "bpmnlint": "^10.3.0",
         "classnames": "^2.3.1",
@@ -463,12 +463,13 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.1.0.tgz",
-      "integrity": "sha512-e8oYLUaZbL1ZuJjwXFyhhStbg0YgMNosIlzhKWdY7ysPhCFVMJlJ6yNYdaxyqfpPATTKb05uXMAsIgcqTQpoLg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.2.0.tgz",
+      "integrity": "sha512-YsgvHUSSf8oGpc6C5AchQwD7wWo41vmMw3Aa9dT+myI7vgNJlo32aRfdtNkBdRCaU1OZQMIZoF0bCEasRmKgPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.18.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.20.0",
+        "@camunda/element-templates-json-schema": "^0.18.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.21.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -567,9 +568,10 @@
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.0.tgz",
-      "integrity": "sha512-k2k+1Z7UiW1TSA1oAvDQamgFZljH3hkFjU9VSpjVXnPgcjVxJMLX0mrHjLVtXhEx2tw576FzYGqlfudw6OOMKg=="
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.1.tgz",
+      "integrity": "sha512-gwQJHUYx1FrIJCgJISx2cpqTJYgnsqrJ6dpPX/R0p6ELyK6u4rHAi/m9QS1O4F6ua7dBlFFFOOtuIAbo5mAfAg==",
+      "license": "MIT"
     },
     "node_modules/@camunda/linting": {
       "version": "3.23.0",
@@ -623,9 +625,10 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.20.0.tgz",
-      "integrity": "sha512-7YRN32Nq73H8S1rCOy2/6cfx+fKiTnhveJYfP6aRaIi83ZSlhVomRJ5+pnPmlDJqdFeNcIx1qqQwVFAdgNPFhg=="
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.21.0.tgz",
+      "integrity": "sha512-etC2PXoHAQ+74xokXYczfb5HmLtisSYCeKSl1c5PCKD6nWWLpGaha86edkPvTKt6SbHCDLZ0dzWXY0iBpyWfow==",
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.17.0",
@@ -10544,12 +10547,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.1.0.tgz",
-      "integrity": "sha512-e8oYLUaZbL1ZuJjwXFyhhStbg0YgMNosIlzhKWdY7ysPhCFVMJlJ6yNYdaxyqfpPATTKb05uXMAsIgcqTQpoLg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.2.0.tgz",
+      "integrity": "sha512-YsgvHUSSf8oGpc6C5AchQwD7wWo41vmMw3Aa9dT+myI7vgNJlo32aRfdtNkBdRCaU1OZQMIZoF0bCEasRmKgPQ==",
       "requires": {
-        "@camunda/element-templates-json-schema": "^0.18.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.20.0",
+        "@camunda/element-templates-json-schema": "^0.18.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.21.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -10637,9 +10640,9 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.0.tgz",
-      "integrity": "sha512-k2k+1Z7UiW1TSA1oAvDQamgFZljH3hkFjU9VSpjVXnPgcjVxJMLX0mrHjLVtXhEx2tw576FzYGqlfudw6OOMKg=="
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.1.tgz",
+      "integrity": "sha512-gwQJHUYx1FrIJCgJISx2cpqTJYgnsqrJ6dpPX/R0p6ELyK6u4rHAi/m9QS1O4F6ua7dBlFFFOOtuIAbo5mAfAg=="
     },
     "@camunda/linting": {
       "version": "3.23.0",
@@ -10680,9 +10683,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.20.0.tgz",
-      "integrity": "sha512-7YRN32Nq73H8S1rCOy2/6cfx+fKiTnhveJYfP6aRaIi83ZSlhVomRJ5+pnPmlDJqdFeNcIx1qqQwVFAdgNPFhg=="
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.21.0.tgz",
+      "integrity": "sha512-etC2PXoHAQ+74xokXYczfb5HmLtisSYCeKSl1c5PCKD6nWWLpGaha86edkPvTKt6SbHCDLZ0dzWXY0iBpyWfow=="
     },
     "@codemirror/autocomplete": {
       "version": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-replace": "^6.0.1",
     "@testing-library/preact": "^2.0.1",
     "@testing-library/preact-hooks": "^1.1.0",
     "assert": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "karma-webpack": "^5.0.1",
     "mocha": "^10.8.2",
     "mocha-test-container-support": "^0.2.0",
+    "modeler-moddle": "^0.2.0",
     "npm-run-all2": "^7.0.0",
     "puppeteer": "^23.7.0",
     "raw-loader": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "min-dash": "^4.0.0",
     "min-dom": "^4.0.3",
     "preact-markup": "^2.1.1",
+    "semver": "^7.6.3",
     "semver-compare": "^1.0.0",
     "uuid": "^11.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.1.0",
+    "@bpmn-io/element-templates-validator": "^2.2.0",
     "@bpmn-io/extract-process-variables": "^1.0.0",
     "bpmnlint": "^10.3.0",
     "classnames": "^2.3.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,6 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import copy from 'rollup-plugin-copy';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
 
 import {
   readFileSync
@@ -81,6 +82,12 @@ function pgl(plugins = []) {
 function corePlugins(plugins = []) {
   return [
     ...plugins,
+    replace({
+      preventAssignment: true,
+      values: {
+        'process.env.PKG_VERSION': JSON.stringify(pkg.version)
+      }
+    }),
     json(),
     resolve({
       mainFields: [

--- a/src/cloud-element-templates/ElementTemplates.js
+++ b/src/cloud-element-templates/ElementTemplates.js
@@ -9,8 +9,8 @@ import { default as DefaultElementTemplates } from '../element-templates/Element
  * Registry for element templates.
  */
 export default class ElementTemplates extends DefaultElementTemplates {
-  constructor(templateElementFactory, commandStack, eventBus, modeling, injector) {
-    super(commandStack, eventBus, modeling, injector);
+  constructor(templateElementFactory, commandStack, eventBus, modeling, injector, config) {
+    super(commandStack, eventBus, modeling, injector, config);
 
     this._templateElementFactory = templateElementFactory;
   }
@@ -75,6 +75,7 @@ export default class ElementTemplates extends DefaultElementTemplates {
 
     return context.element;
   }
+
 }
 
 ElementTemplates.$inject = [
@@ -82,5 +83,6 @@ ElementTemplates.$inject = [
   'commandStack',
   'eventBus',
   'modeling',
-  'injector'
+  'injector',
+  'config.elementTemplates',
 ];

--- a/src/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/cloud-element-templates/ElementTemplatesLoader.js
@@ -2,10 +2,16 @@ import { Validator } from './Validator';
 
 import { default as TemplatesLoader } from '../element-templates/ElementTemplatesLoader';
 
+/**
+ * @param {Object|Array<TemplateDescriptor>|Function} config
+ * @param {EventBus} eventBus
+ * @param {ElementTemplates} elementTemplates
+ * @param {Moddle} moddle
+ */
 export default class ElementTemplatesLoader extends TemplatesLoader {
-  constructor(loadTemplates, eventBus, elementTemplates, moddle) {
+  constructor(config, eventBus, elementTemplates, moddle) {
 
-    super(loadTemplates, eventBus, elementTemplates, moddle);
+    super(config, eventBus, elementTemplates, moddle);
 
     this._elementTemplates = elementTemplates;
   }

--- a/src/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/cloud-element-templates/ElementTemplatesLoader.js
@@ -28,10 +28,8 @@ export default class ElementTemplatesLoader extends TemplatesLoader {
     elementTemplates.set(validTemplates);
 
     if (errors.length) {
-      this.templateErrors(errors);
+      this._templateErrors(errors);
     }
-
-    this.templatesChanged();
   }
 }
 

--- a/src/cloud-element-templates/linting/LinterPlugin.js
+++ b/src/cloud-element-templates/linting/LinterPlugin.js
@@ -10,6 +10,8 @@
 
 import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
 import ElementTemplates from '../ElementTemplates';
+import EventBus from 'diagram-js/lib/core/EventBus';
+
 import { getPropertyValue, validateProperty } from '../util/propertyUtil';
 
 import { applyConditions } from '../Condition';
@@ -30,7 +32,9 @@ export const elementTemplateLintRule = ({ templates = [] }) => {
   // We use the ElementTemplates Module without the required bpmn-js modules
   // As we only use it to facilitate template ID and version lookup,
   // access to commandstack etc. is not required
-  const elementTemplates = new ElementTemplates();
+  const eventBus = new EventBus();
+  const elementTemplates = new ElementTemplates(null, null, eventBus, null, null);
+
   elementTemplates.set(validTemplates);
 
   function check(node, reporter) {

--- a/src/cloud-element-templates/linting/index.js
+++ b/src/cloud-element-templates/linting/index.js
@@ -1,4 +1,29 @@
-export {
-  elementTemplateLintRule,
-  ElementTemplateLinterPlugin
-} from './LinterPlugin';
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
+
+import validate from './rules/element-templates-validate';
+import compatibility from './rules/element-templates-compatibility';
+
+export const ElementTemplateLinterPlugin = function(templates) {
+  return {
+    config: {
+      rules: {
+        'element-templates/validate': [ 'error', { templates } ],
+        'element-templates/compatibility': [ 'warn', { templates } ]
+      }
+    },
+    resolver: new StaticResolver({
+      'rule:bpmnlint-plugin-element-templates/validate': validate,
+      'rule:bpmnlint-plugin-element-templates/compatibility': compatibility
+    })
+  };
+};

--- a/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import ElementTemplates from '../../ElementTemplates';
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+import BpmnModdle from 'bpmn-moddle';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import { Validator } from '../../Validator';
+
+export default function({ templates = [] }) {
+  const moddle = new BpmnModdle({ zeebe: zeebeModdle });
+
+  const validator = new Validator(moddle).addAll(templates);
+  const validTemplates = validator.getValidTemplates();
+
+  // We use the ElementTemplates Module without the required bpmn-js modules
+  // As we only use it to facilitate template ID and version lookup,
+  // access to commandstack etc. is not required
+  const eventBus = new EventBus();
+  const elementTemplates = new ElementTemplates(null, null, eventBus, null, null);
+
+  elementTemplates.set(validTemplates);
+
+  function isUpdateAvailable(template) {
+
+    const latestTemplate = elementTemplates.getLatest(template.id, { deprecated: true })[0];
+
+    if (latestTemplate && latestTemplate !== template) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function check(node, reporter) {
+
+    if (is(node, 'bpmn:Definitions')) {
+      elementTemplates.setEngines(getEnginesConfig(node));
+    }
+
+    if (!is(node, 'bpmn:FlowElement')) {
+      return;
+    }
+
+    let template = elementTemplates.get(node);
+
+    if (!template) {
+      return;
+    }
+
+    // Check compatibility
+    if (template.engines) {
+      const incomp = elementTemplates.getIncompatibleEngines(template);
+      Object.keys(incomp).forEach((engine) => {
+        reporter.report(
+          node.id,
+          getIncompatibilityText(engine, incomp[engine], isUpdateAvailable(template)),
+          {
+            name: node.name
+          }
+        );
+      });
+    }
+  }
+
+  return {
+    check
+  };
+
+};
+
+// helpers //////////////////////
+
+function getEnginesConfig(definitions) {
+  const {
+    exporter,
+    exporterVersion
+  } = definitions;
+
+  const engines = {};
+
+  const executionPlatform = definitions.get('modeler:executionPlatform');
+  const executionPlatformVersion = definitions.get('modeler:executionPlatformVersion');
+
+  if (executionPlatform === 'Camunda Cloud' && executionPlatformVersion) {
+    engines.camunda = executionPlatformVersion;
+  }
+
+  if (exporter === 'Camunda Modeler' && exporterVersion) {
+    engines.camundaDesktopModeler = exporterVersion;
+  }
+
+  return engines;
+}
+
+
+function getIncompatibilityText(engine, { actual, required }, updateAvailable) {
+  const message =
+    `Element template incompatible with current <${engine}> environment. ` +
+    `Requires '${engine} ${required}'; found '${actual}'. ` +
+    `${updateAvailable ? 'Update available.' : ''}`;
+
+  return message.trim();
+}

--- a/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
@@ -83,11 +83,6 @@ export default function({ templates = [] }) {
 // helpers //////////////////////
 
 function getEnginesConfig(definitions) {
-  const {
-    exporter,
-    exporterVersion
-  } = definitions;
-
   const engines = {};
 
   const executionPlatform = definitions.get('modeler:executionPlatform');
@@ -95,10 +90,6 @@ function getEnginesConfig(definitions) {
 
   if (executionPlatform === 'Camunda Cloud' && executionPlatformVersion) {
     engines.camunda = executionPlatformVersion;
-  }
-
-  if (exporter === 'Camunda Modeler' && exporterVersion) {
-    engines.camundaDesktopModeler = exporterVersion;
   }
 
   return engines;

--- a/src/cloud-element-templates/linting/rules/element-templates-validate.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-validate.js
@@ -8,22 +8,21 @@
  * except in compliance with the MIT License.
  */
 
-import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
-import ElementTemplates from '../ElementTemplates';
+import ElementTemplates from '../../ElementTemplates';
 import EventBus from 'diagram-js/lib/core/EventBus';
 
-import { getPropertyValue, validateProperty } from '../util/propertyUtil';
+import { getPropertyValue, validateProperty } from '../../util/propertyUtil';
 
-import { applyConditions } from '../Condition';
+import { applyConditions } from '../../Condition';
 
 import BpmnModdle from 'bpmn-moddle';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
-import { Validator } from '../Validator';
+import { Validator } from '../../Validator';
 
-export const elementTemplateLintRule = ({ templates = [] }) => {
+export default function({ templates = [] }) {
   const moddle = new BpmnModdle({ zeebe: zeebeModdle });
 
   const validator = new Validator(moddle).addAll(templates);
@@ -92,21 +91,6 @@ export const elementTemplateLintRule = ({ templates = [] }) => {
   };
 
 };
-
-
-export const ElementTemplateLinterPlugin = function(templates) {
-  return {
-    config: {
-      rules: {
-        'element-templates/validate': [ 'error', { templates } ]
-      }
-    },
-    resolver: new StaticResolver({
-      'rule:bpmnlint-plugin-element-templates/validate': elementTemplateLintRule
-    })
-  };
-};
-
 
 // helpers //////////////////////
 

--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -196,24 +196,35 @@ export default class ElementTemplates {
    * @return {boolean} - true if compatible or no engine is set for elementTemplates or template.
    */
   isCompatible(template) {
+    return !Object.keys(this.getIncompatibleEngines(template)).length;
+  }
+
+  /**
+   * Get engines that are incompatible with the template.
+   *
+   * @param {any} template
+   *
+   * @return { Record<string, { required: string, found: string } } - incompatible engines along with their template and local versions
+   */
+  getIncompatibleEngines(template) {
     const localEngines = this._engines;
     const templateEngines = template.engines;
 
-    for (const engine in templateEngines) {
-
-      // we check compatibility against all locally provided
-      // engines, hence computing the overlap here.
+    return reduce(templateEngines, (result, _, engine) => {
 
       if (!has(localEngines, engine)) {
-        continue;
+        return result;
       }
 
       if (!isSemverCompatible(localEngines[engine], templateEngines[engine])) {
-        return false;
+        result[engine] = {
+          actual: localEngines[engine],
+          required: templateEngines[engine]
+        };
       }
-    }
 
-    return true;
+      return result;
+    }, {});
   }
 
   /**

--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -26,7 +26,7 @@ export default class ElementTemplates {
     this._injector = injector;
     this._modeling = modeling;
 
-    this._templates = {};
+    this._templatesById = {};
   }
 
   /**
@@ -38,7 +38,7 @@ export default class ElementTemplates {
    * @return {ElementTemplate}
    */
   get(id, version) {
-    const templates = this._templates;
+    const templates = this._templatesById;
 
     let element;
 
@@ -108,23 +108,23 @@ export default class ElementTemplates {
    * @param {Array<ElementTemplate>} templates
    */
   set(templates) {
-    this._templates = {};
+    this._templatesById = {};
 
     templates.forEach((template) => {
       const id = template.id,
             version = isUndefined(template.version) ? '_' : template.version;
 
-      if (!this._templates[ id ]) {
-        this._templates[ id ] = {
+      if (!this._templatesById[ id ]) {
+        this._templatesById[ id ] = {
           latest: template
         };
       }
 
-      this._templates[ id ][ version ] = template;
+      this._templatesById[ id ][ version ] = template;
 
-      const latestVerions = this._templates[ id ].latest.version;
+      const latestVerions = this._templatesById[ id ].latest.version;
       if (isUndefined(latestVerions) || template.version > latestVerions) {
-        this._templates[ id ].latest = template;
+        this._templatesById[ id ].latest = template;
       }
     });
   }
@@ -142,7 +142,7 @@ export default class ElementTemplates {
       deprecated: includeDeprecated
     } = options;
 
-    const templates = this._templates;
+    const templatesById = this._templatesById;
     const getVersions = (template) => {
       const { latest, ...versions } = template;
       return latestOnly ? (
@@ -151,7 +151,7 @@ export default class ElementTemplates {
     };
 
     if (isNil(id)) {
-      return flatten(values(templates).map(getVersions));
+      return flatten(values(templatesById).map(getVersions));
     }
 
     if (isObject(id)) {
@@ -163,7 +163,7 @@ export default class ElementTemplates {
     }
 
     if (isString(id)) {
-      return templates[ id ] && getVersions(templates[ id ]);
+      return templatesById[ id ] && getVersions(templatesById[ id ]);
     }
 
     throw new Error('argument must be of type {string|djs.model.Base|undefined}');

--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -24,6 +24,10 @@ import {
   coerce
 } from 'semver';
 
+// eslint-disable-next-line no-undef
+const packageVersion = process.env.PKG_VERSION;
+
+
 /**
  * Registry for element templates.
  */
@@ -155,6 +159,7 @@ export default class ElementTemplates {
   }
 
   setEngines(engines) {
+
     this._engines = this._coerceEngines(engines);
 
     this._fire('engines.changed');
@@ -168,6 +173,14 @@ export default class ElementTemplates {
    * @return { Record<string, string> } filtered, valid engines
    */
   _coerceEngines(engines) {
+
+    // we provide <elementTemplates> engine with the current
+    // package version; templates may use that engine to declare
+    // compatibility with this library
+    engines = {
+      elementTemplates: packageVersion,
+      ...engines
+    };
 
     return reduce(engines, (validEngines, version, engine) => {
 

--- a/src/element-templates/ElementTemplatesLoader.js
+++ b/src/element-templates/ElementTemplatesLoader.js
@@ -1,6 +1,7 @@
 import {
   isFunction,
-  isUndefined
+  isUndefined,
+  isArray,
 } from 'min-dash';
 
 import { Validator } from './Validator';
@@ -14,17 +15,25 @@ import { Validator } from './Validator';
  * descriptors or a node style callback to retrieve
  * the templates asynchronously.
  *
- * @param {Array<TemplateDescriptor>|Function} loadTemplates
+ * @param {Array<TemplateDescriptor>|Function} config
  * @param {EventBus} eventBus
  * @param {ElementTemplates} elementTemplates
  * @param {Moddle} moddle
  */
 export default class ElementTemplatesLoader {
-  constructor(loadTemplates, eventBus, elementTemplates, moddle) {
-    this._loadTemplates = loadTemplates;
+  constructor(config, eventBus, elementTemplates, moddle) {
+    this._loadTemplates;
     this._eventBus = eventBus;
     this._elementTemplates = elementTemplates;
     this._moddle = moddle;
+
+    if (isArray(config) || isFunction(config)) {
+      this._loadTemplates = config;
+    }
+
+    if (config && config.loadTemplates) {
+      this._loadTemplates = config.templates;
+    }
 
     eventBus.on('diagram.init', () => {
       this.reload();

--- a/src/element-templates/ElementTemplatesLoader.js
+++ b/src/element-templates/ElementTemplatesLoader.js
@@ -32,7 +32,7 @@ export default class ElementTemplatesLoader {
     }
 
     if (config && config.loadTemplates) {
-      this._loadTemplates = config.templates;
+      this._loadTemplates = config.loadTemplates;
     }
 
     eventBus.on('diagram.init', () => {
@@ -54,7 +54,7 @@ export default class ElementTemplatesLoader {
       return loadTemplates((err, templates) => {
 
         if (err) {
-          return this.templateErrors([ err ]);
+          return this._templateErrors([ err ]);
         }
 
         this.setTemplates(templates);
@@ -79,18 +79,12 @@ export default class ElementTemplatesLoader {
     elementTemplates.set(validTemplates);
 
     if (errors.length) {
-      this.templateErrors(errors);
+      this._templateErrors(errors);
     }
-
-    this.templatesChanged();
   }
 
-  templatesChanged() {
-    this._eventBus.fire('elementTemplates.changed');
-  }
-
-  templateErrors(errors) {
-    this._eventBus.fire('elementTemplates.errors', {
+  _templateErrors(errors) {
+    this._elementTemplates._fire('errors', {
       errors: errors
     });
   }

--- a/src/element-templates/Validator.js
+++ b/src/element-templates/Validator.js
@@ -1,10 +1,15 @@
 import {
   filter,
+  forEach,
   isArray,
   isString
 } from 'min-dash';
 
 import semverCompare from 'semver-compare';
+
+import {
+  validRange as isSemverRangeValid
+} from 'semver';
 
 import {
   validate as validateAgainstSchema,
@@ -13,6 +18,7 @@ import {
 
 const SUPPORTED_SCHEMA_VERSION = getTemplateSchemaVersion();
 const MORPHABLE_TYPES = [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:Gateway' ];
+
 
 /**
  * A element template validator.
@@ -79,8 +85,6 @@ export class Validator {
    * @return {Error} validation error, if any
    */
   _validateTemplate(template) {
-    let err;
-
     const id = template.id,
           version = template.version || '_',
           schemaVersion = template.$schema && getSchemaVersion(template.$schema);
@@ -110,20 +114,43 @@ export class Validator {
     }
 
     // (4) JSON schema compliance
-    const validationResult = validateAgainstSchema(template);
+    const schemaValidationResult = validateAgainstSchema(template);
 
     const {
-      errors,
+      errors: schemaErrors,
       valid
-    } = validationResult;
+    } = schemaValidationResult;
 
     if (!valid) {
-      err = new Error('invalid template');
-
-      filteredSchemaErrors(errors).forEach((error) => {
+      filteredSchemaErrors(schemaErrors).forEach((error) => {
         this._logError(error.message, template);
       });
+
+      return new Error('invalid template');
     }
+
+    // (5) engines validation
+    const enginesError = this._validateEngines(template);
+
+    if (enginesError) {
+      return enginesError;
+    }
+
+    return null;
+  }
+
+  _validateEngines(template) {
+
+    let err;
+
+    forEach(template.engines, (rangeStr, engine) => {
+
+      if (!isSemverRangeValid(rangeStr)) {
+        err = this._logError(new Error(
+          `Engine <${engine}> specifies invalid semver range <${rangeStr}>`
+        ), template);
+      }
+    });
 
     return err;
   }

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -20,9 +20,6 @@ import download from 'downloadjs';
 
 import Modeler from 'bpmn-js/lib/Modeler';
 
-import BPMNModdle from 'bpmn-moddle';
-import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
-
 let PROPERTIES_PANEL_CONTAINER;
 
 global.chai.use(function(chai, utils) {
@@ -232,55 +229,3 @@ document.addEventListener('keydown', function(event) {
     download(result.xml, 'test.bpmn', 'application/xml');
   });
 });
-
-// Moddle helpers //////////////////////
-export async function createModdle(xml) {
-  const moddle = new BPMNModdle({
-    zeebe: zeebeModdle
-  });
-
-  let root, warnings;
-
-  try {
-    ({
-      rootElement: root,
-      warnings = []
-    } = await moddle.fromXML(xml, 'bpmn:Definitions', { lax: true }));
-  } catch (err) {
-    console.log(err);
-  }
-
-  return {
-    root,
-    moddle,
-    context: {
-      warnings
-    },
-    warnings
-  };
-}
-
-export function createDefinitions(xml = '') {
-  return `
-    <bpmn:definitions
-      xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
-      xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
-      xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
-      xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
-      xmlns:modeler="http://camunda.org/schema/modeler/1.0"
-      xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
-      id="Definitions_1">
-      ${ xml }
-    </bpmn:definitions>
-  `;
-}
-
-
-export function createProcess(bpmn = '', bpmndi = '') {
-  return createDefinitions(`
-    <bpmn:process id="Process_1" isExecutable="true">
-      ${ bpmn }
-    </bpmn:process>
-    ${ bpmndi }
-  `);
-}

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -38,7 +38,7 @@ import CamundaBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-platfo
 import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud';
 
 import CamundaModdle from 'camunda-bpmn-moddle/resources/camunda';
-
+import ModelerModdle from 'modeler-moddle/resources/modeler';
 import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import CloudElementTemplatesPropertiesProviderModule from 'src/cloud-element-templates';
@@ -50,54 +50,103 @@ const singleStart = window.__env__ && window.__env__.SINGLE_START;
 
 insertCoreStyles();
 insertBpmnStyles();
-insertCSS('bottom-panel.css', `
+
+insertCSS('example.css', `
   .test-container {
     display: flex;
     flex-direction: column;
+  }
+
+  .test-container {
+    --example-properties-width: 20vw;
+    --example-bottom-height: 30vh;
+  }
+
+  .bjs-container {
+    padding-right: var(--example-properties-width);
+    padding-bottom: var(--example-bottom-height);
   }
 
   .properties-panel-container {
     position: absolute;
     top: 0;
     right: 0;
-    width: 250px;
+    width: var(--example-properties-width);
     height: 100%;
     border-left: solid 1px #ccc;
     background-color: #f7f7f8;
   }
 
-  .panel {
+  .bottom-panel {
     position: absolute;
     bottom: 0;
     left: 0;
-    width: calc(100% - 250px - 1px);
-    height: 200px;
+    width: calc(100% - var(--example-properties-width) - 1px);
+    height: var(--example-bottom-height);
     display: flex;
     flex-direction: column;
     background-color: #f7f7f8;
-    padding: 5px;
     box-sizing: border-box;
     border-top: solid 1px #ccc;
     font-family: sans-serif;
   }
 
-  .panel .errors {
+  .bottom-panel .error-container {
     resize: none;
     flex-grow: 1;
     background-color: #f7f7f8;
     border: none;
-    margin-bottom: 5px;
+    padding: 5px;
     font-family: sans-serif;
     line-height: 1.5;
     outline: none;
-    overflow-y: scroll;
+    overflow: auto;
   }
 
-  .panel button,
-  .panel input {
+  .bottom-panel .error-item {
+    cursor: pointer;
+  }
+
+  .bottom-panel .footer-container {
+    border-top: solid 1px #ccc;
+    padding: 5px;
+  }
+
+  .bottom-panel button,
+  .bottom-panel input {
     width: 200px;
   }
 `);
+
+
+const ChangeEnginesModule = {
+
+  __init__: [ function(bpmnjs, eventBus, elementTemplates) {
+
+    eventBus.on([
+      'import.done',
+      'elements.changed'
+    ], function() {
+      const executionPlatformVersion = bpmnjs.getDefinitions().get('executionPlatformVersion');
+
+      if (elementTemplates.getEngines().camunda !== executionPlatformVersion) {
+        elementTemplates.setEngines({
+          camunda: executionPlatformVersion
+        });
+      }
+    });
+  } ]
+};
+
+const LogTemplateErrorsModule = {
+
+  __init__: [ function(eventBus) {
+
+    eventBus.on('elementTemplates.errors', function({ errors }) {
+      console.error('element template parse errors', errors);
+    });
+  } ]
+};
 
 
 describe('<BpmnPropertiesPanelRenderer>', function() {
@@ -133,7 +182,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
         LintingModule
       ],
       moddleExtensions = {
-        zeebe: ZeebeModdle
+        zeebe: ZeebeModdle,
+        modeler: ModelerModdle
       },
       propertiesPanel = {},
       description = {},
@@ -197,10 +247,13 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           ElementTemplatesIconsRenderer,
           CreateAppendAnythingModule,
           CreateAppendElementTemplatesModule,
+          ChangeEnginesModule,
+          LogTemplateErrorsModule,
           LintingModule
         ],
         moddleExtensions: {
-          zeebe: ZeebeModdle
+          zeebe: ZeebeModdle,
+          modeler: ModelerModdle
         },
         propertiesPanel: {
           parent: null
@@ -212,71 +265,11 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       }
     );
 
-    const modeler = result.modeler;
-
-    const linter = new Linter({
-      plugins: [
-        ElementTemplateLinterPlugin(elementTemplates)
-      ]
-
-    });
-
-    const linting = modeler.get('linting');
-    const bpmnjs = modeler.get('bpmnjs');
-    const eventBus = modeler.get('eventBus');
-
-    const lint = () => {
-      const definitions = bpmnjs.getDefinitions();
-
-      linter.lint(definitions).then(reports => {
-        linting.setErrors(reports);
-
-        const errorContainer = panel.querySelector('.errors');
-        errorContainer.innerHTML = '';
-
-        reports.forEach((report) => {
-          let { id, message, node, data } = report;
-          node = node || (data && data.node);
-          const name = node && node.name;
-
-          const errorMessage = `${ name || id }: ${ message }`;
-          const item = domify(`<div>${escapeHtml(errorMessage)}</div>`);
-          item.addEventListener('click', () => {
-            linting.showError(report);
-          });
-
-          errorContainer.appendChild(item);
-        });
-      });
-    };
-
-    lint();
-
-    eventBus.on('elements.changed', lint);
-    linting.activate();
-
-    const propertiesPanelParent = domify('<div class="properties-panel-container"></div>');
-
-    bpmnjs._container.appendChild(propertiesPanelParent);
-
-    modeler.get('propertiesPanel').attachTo(propertiesPanelParent);
-
-    const panel = domify(`
-      <div class="panel">
-        <div class="errors"></div>
-        <div>
-          <label>Execution Platform Version</label>
-          <input type="text" />
-          <button>Deactivate Linting</button>
-        </div>
-      </div>
-    `);
-
-    bpmnjs._container.appendChild(panel);
-
-
     // then
     expect(result.error).not.to.exist;
+
+    // and
+    createTestUI(result.modeler);
   });
 
 
@@ -301,28 +294,117 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           ElementTemplatesPropertiesProviderModule
         ],
         moddleExtensions: {
-          camunda: CamundaModdle
+          camunda: CamundaModdle,
+          modeler: ModelerModdle
         },
         elementTemplates
       }
     );
 
-    const modeler = result.modeler;
-    const bpmnjs = modeler.get('bpmnjs');
-    const propertiesPanelParent = domify('<div class="properties-panel-container"></div>');
-
-    bpmnjs._container.appendChild(propertiesPanelParent);
-
-    modeler.get('propertiesPanel').attachTo(propertiesPanelParent);
-
-
     // then
     expect(result.error).not.to.exist;
+
+    // and then
+    createTestUI(result.modeler);
   });
 
 });
 
 
-const escapeHtml = (unsafe) => {
+function escapeHTML(unsafe) {
   return unsafe.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;');
-};
+}
+
+function createTestUI(modeler) {
+
+  const linting = modeler.get('linting', false);
+  const elementTemplates = modeler.get('elementTemplates', false);
+  const propertiesPanel = modeler.get('propertiesPanel', false);
+
+  const canvas = modeler.get('canvas');
+  const modeling = modeler.get('modeling');
+  const bpmnjs = modeler.get('bpmnjs');
+  const eventBus = modeler.get('eventBus');
+
+  const container = bpmnjs._container;
+
+  if (propertiesPanel) {
+
+    const propertiesPanelParent = domify('<div class="properties-panel-container"></div>');
+
+    container.appendChild(propertiesPanelParent);
+
+    propertiesPanel.attachTo(propertiesPanelParent);
+  }
+
+  if (linting && elementTemplates) {
+    const linter = new Linter({
+      plugins: [
+        ElementTemplateLinterPlugin(elementTemplates.getAll())
+      ]
+    });
+
+    const bottomPanel = domify(`
+      <div class="bottom-panel">
+        <div class="error-container"></div>
+        <div class="footer-container">
+          <label>Execution Platform Version</label>
+          <input type="text" />
+        </div>
+      </div>
+    `);
+
+    container.appendChild(bottomPanel);
+
+    bottomPanel.querySelector('input').value = bpmnjs.getDefinitions().get('executionPlatformVersion');
+
+    bottomPanel.querySelector('input').addEventListener('input', ({ target }) => {
+      modeling.updateModdleProperties(
+        canvas.getRootElement(),
+        bpmnjs.getDefinitions(),
+        { executionPlatformVersion: target.value }
+      );
+    });
+
+    const lint = () => {
+      const definitions = bpmnjs.getDefinitions();
+
+      linter.lint(definitions).then(reports => {
+        linting.setErrors(reports);
+
+        const errorContainer = bottomPanel.querySelector('.error-container');
+        errorContainer.innerHTML = '';
+
+        reports.map((report) => {
+          const { id, message, category, rule, documentation } = report;
+
+          if (category === 'rule-error') {
+            return domify(`<div class="error-item"><strong>${ category }</strong> Rule <${ escapeHTML(rule) }> errored with the following message: ${ escapeHTML(message) }</div>`);
+          }
+
+          const element = domify(`<div class="error-item"><strong>${ category }</strong> ${ id }: ${escapeHTML(message) } </div>`);
+
+          if (documentation.url) {
+            const documentationLink = domify(`<a href="${ documentation.url }" rel="noopener" target="_blank">ref</a>`);
+
+            documentationLink.addEventListener('click', e => e.stopPropagation());
+
+            element.appendChild(documentationLink);
+          }
+
+          element.addEventListener('click', () => {
+            linting.showError(report);
+          });
+
+          return element;
+        }).forEach(item => errorContainer.appendChild(item));
+      });
+    };
+
+    linting.activate();
+
+    lint();
+
+    eventBus.on('elements.changed', lint);
+  }
+}

--- a/test/spec/cloud-element-templates/ElementTemplates.engines-templates.json
+++ b/test/spec/cloud-element-templates/ElementTemplates.engines-templates.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "does not match if { desktopModeler: >=1 } is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1",
+      "desktopModeler": "^0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "matches if { camunda: ^8.6, webModeler: ^4.1 } engine is indicated, or properties are not provided",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^8.6 }, or if no <camunda> engine is provided",
+    "version": 3,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^8.5 }, or if no <camunda> engine is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.5"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "always matches",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.broken",
+    "name": "<engines> Test - broken Semver range",
+    "description": "specifies broken semver range",
+    "version": 1,
+    "engines": {
+      "camunda": "invalid-version"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -34,6 +34,9 @@ import { findExtensions, findExtension } from 'src/cloud-element-templates/Helpe
 import { getLabel } from 'bpmn-js/lib/features/label-editing/LabelUtil';
 import { findMessage } from 'src/cloud-element-templates/Helper';
 
+// eslint-disable-next-line no-undef
+const packageVersion = process.env.PKG_VERSION;
+
 
 describe('provider/cloud-element-templates - ElementTemplates', function() {
 
@@ -785,6 +788,15 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
   describe('getEngines', function() {
 
+    it('should provide default <elementTemplates> engine', inject(function(elementTemplates) {
+
+      // then
+      expect(
+        elementTemplates.getEngines()
+      ).to.have.property('elementTemplates', packageVersion);
+    }));
+
+
     it('should provide set engines', inject(function(elementTemplates) {
 
       // when
@@ -795,9 +807,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
       // then
       expect(elementTemplates.getEngines()).to.eql({
+        'elementTemplates': packageVersion,
         'camunda': '8.0.0',
         'other': '100.5.0'
       });
+
     }));
 
   });
@@ -817,6 +831,18 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
       // then
       expect(spy).to.have.been.calledOnce;
+    }));
+
+
+    it('should override <elementTemplates> engine', inject(function(elementTemplates) {
+
+      // when
+      elementTemplates.setEngines({
+        elementTemplates: '1.0.0'
+      });
+
+      // then
+      expect(elementTemplates.getEngines()).to.have.property('elementTemplates', '1.0.0');
     }));
 
   });

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -53,12 +53,13 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }
   }));
 
-  beforeEach(inject(function(elementTemplates) {
-    elementTemplates.set(templates);
-  }));
-
 
   describe('get', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
 
     it('should get template by ID', inject(function(elementTemplates) {
 
@@ -147,6 +148,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
   describe('getAll', function() {
 
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
+
     it('should get all templates', inject(function(elementTemplates) {
 
       // when
@@ -219,6 +225,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
 
   describe('getLatest', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
 
     it('should get all latest templates', inject(function(elementTemplates) {
 
@@ -345,6 +356,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
 
   describe('createElement', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
 
     it('should create element', inject(function(elementTemplates) {
 
@@ -527,6 +543,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
 
   describe('applyTemplate', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
 
     it('should set template on element', inject(function(elementRegistry, elementTemplates) {
 
@@ -807,6 +828,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
   describe('unlinkTemplate', function() {
 
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
+
     it('should unlink task template', inject(function(elementRegistry, elementTemplates) {
 
       // given
@@ -861,6 +887,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
 
   describe('removeTemplate', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(templates);
+    }));
+
 
     it('should remove task template', inject(function(elementRegistry, elementTemplates) {
 
@@ -1008,29 +1039,11 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
 
   describe('updateTemplate', function() {
 
-    let container;
-
-    beforeEach(function() {
-      container = TestContainer.get(this);
-    });
-
-    beforeEach(bootstrapModeler(diagramXML, {
-      container: container,
-      modules: [
-        coreModule,
-        elementTemplatesCoreModule,
-        modelingModule,
-        {
-          propertiesPanel: [ 'value', { registerProvider() {} } ]
-        }
-      ],
-      moddleExtensions: {
-        zeebe: zeebeModdlePackage
-      },
-      elementTemplates: [
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set([
         ...templates,
         ...messageTemplates
-      ]
+      ]);
     }));
 
 
@@ -1120,6 +1133,7 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         newTemplate
       });
     }));
+
   });
 
 });

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -1491,6 +1491,86 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
   });
 
+
+  describe('getIncompatibleEngines', function() {
+
+    it('should return incompatible engine', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        camunda: '8.5'
+      });
+
+      const template = {
+        engines: {
+          camunda: '>= 8.6'
+        }
+      };
+
+      // then
+      const result = elementTemplates.getIncompatibleEngines(template);
+
+      expect(result).to.eql({
+        camunda: {
+          actual: '8.5.0',
+          required: '>= 8.6'
+        }
+      });
+    }));
+
+
+    it('should return multiple', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        camunda: '8.5',
+        desktopModeler: '5.30'
+      });
+
+      const template = {
+        engines: {
+          camunda: '>= 8.6',
+          desktopModeler: '^4.0'
+        }
+      };
+
+      // then
+      const result = elementTemplates.getIncompatibleEngines(template);
+
+      expect(result).to.eql({
+        camunda: {
+          actual: '8.5.0',
+          required: '>= 8.6'
+        },
+        desktopModeler: {
+          actual: '5.30.0',
+          required: '^4.0'
+        }
+      });
+    }));
+
+
+    it('should return empty object if compatible', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        nonMatchingEngine: '8.5'
+      });
+
+      const template = {
+        engines: {
+          camunda: '8.5',
+        }
+      };
+
+      // then
+      const result = elementTemplates.getIncompatibleEngines(template);
+
+      expect(result).to.eql({});
+    }));
+
+  });
+
 });
 
 
@@ -1529,6 +1609,8 @@ describe('provider/cloud-element-templates - ElementTemplates - error handling o
   }));
 
 });
+
+
 
 
 describe('provider/cloud-element-templates - ElementTemplates - integration', function() {

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -24,6 +24,7 @@ describe('provider/cloud-element-templates - Validator', function() {
     moddle = new BPMNModdle();
   });
 
+
   describe('schema version', function() {
 
     it('should accept when template and library have the same version', function() {
@@ -580,6 +581,44 @@ describe('provider/cloud-element-templates - Validator', function() {
 
         expect(valid(templates)).to.be.empty;
       });
+    });
+
+  });
+
+
+  describe('engines validation', function() {
+
+    it('should accept template with valid semver range', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/engines');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should reject template with invalid semver range', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/engines-invalid');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('Engine <camunda> specifies invalid semver range <invalid-version>');
+
+      expect(valid(templates)).to.be.empty;
     });
 
   });

--- a/test/spec/cloud-element-templates/fixtures/complex.bpmn
+++ b/test/spec/cloud-element-templates/fixtures/complex.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.29.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="Process_0vvlc66" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0gw5hlt</bpmn:outgoing>
@@ -9,7 +9,7 @@
       <bpmn:incoming>Flow_0636r17</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0636r17" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
-    <bpmn:serviceTask id="ServiceTask_1" name="REST" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-s1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M16 2.5H8A5.5 5.5 0 0 0 2.5 8v8A5.5 5.5 0 0 0 8 21.5h8a5.5 5.5 0 0 0 5.5-5.5V8A5.5 5.5 0 0 0 16 2.5ZM8 1a7 7 0 0 0-7 7v8a7 7 0 0 0 7 7h8a7 7 0 0 0 7-7V8a7 7 0 0 0-7-7H8Z' fill='%23505562'/%3E%3Cpath d='M8.283 6.76v1.21c-.224 0-.416.02-.578.06a.612.612 0 0 0-.357.21c-.077.099-.106.242-.088.429l.17 1.622c.044.41-.001.742-.137.995a1.328 1.328 0 0 1-.61.584 3.306 3.306 0 0 1-.963.28c.392.059.724.154.995.286.272.132.47.323.594.572.125.25.165.583.121 1.001l-.17 1.623c-.018.183.011.326.088.429a.62.62 0 0 0 .363.209c.161.04.352.06.572.06v1.21c-.506 0-.935-.037-1.287-.11-.352-.073-.634-.19-.847-.352a1.214 1.214 0 0 1-.435-.627c-.077-.257-.097-.57-.06-.94l.165-1.573c.03-.28-.018-.497-.143-.655-.121-.158-.3-.268-.54-.33a3.102 3.102 0 0 0-.824-.099v-1.408c.308 0 .581-.031.82-.094.238-.066.42-.177.544-.335.125-.158.172-.376.143-.654L5.654 8.8c-.04-.378-.022-.697.055-.957.08-.26.225-.47.434-.627.213-.162.495-.277.847-.347a6.54 6.54 0 0 1 1.293-.11ZM9.527 16v-1.166h.77v-3.52h-.77v-1.155h2.096l.319 1.314c.209-.502.474-.876.797-1.122.326-.245.724-.368 1.194-.368a2.535 2.535 0 0 1 .962.176l-.528 1.435a2.48 2.48 0 0 0-.67-.087c-.382 0-.718.155-1.007.467-.286.312-.505.708-.655 1.188v1.672h1.155V16H9.527Zm3.955-3.399v-1.705l.258-.737h1.155l-.324 2.442h-1.09Zm2.239-5.841c.506 0 .935.037 1.287.11.352.073.633.19.842.352.212.158.36.367.44.627.08.257.1.57.06.94l-.165 1.574c-.029.278.019.496.143.654.125.158.305.27.54.335.238.063.513.094.824.094v1.408c-.308 0-.58.033-.82.099a.985.985 0 0 0-.544.33c-.124.158-.172.376-.143.655l.165 1.561c.04.378.02.697-.06.957-.077.26-.222.47-.435.628-.209.16-.491.276-.847.346a6.44 6.44 0 0 1-1.287.11v-1.21c.224 0 .415-.02.572-.06a.59.59 0 0 0 .358-.21c.08-.102.112-.245.093-.428l-.17-1.623c-.044-.414 0-.746.132-.995.136-.253.34-.446.616-.578.275-.136.598-.231.968-.286a3.52 3.52 0 0 1-1.001-.286 1.251 1.251 0 0 1-.594-.572c-.125-.253-.165-.587-.121-1.001l.17-1.622c.019-.187-.012-.33-.093-.43a.59.59 0 0 0-.358-.208 2.338 2.338 0 0 0-.572-.061V6.76Z' fill='%23505562'/%3E%3C/svg%3E">
+    <bpmn:serviceTask id="ServiceTask_1" name="REST" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-s1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width=&#39;24&#39; height=&#39;24&#39; fill=&#39;none&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M16 2.5H8A5.5 5.5 0 0 0 2.5 8v8A5.5 5.5 0 0 0 8 21.5h8a5.5 5.5 0 0 0 5.5-5.5V8A5.5 5.5 0 0 0 16 2.5ZM8 1a7 7 0 0 0-7 7v8a7 7 0 0 0 7 7h8a7 7 0 0 0 7-7V8a7 7 0 0 0-7-7H8Z&#39; fill=&#39;%23505562&#39;/%3E%3Cpath d=&#39;M8.283 6.76v1.21c-.224 0-.416.02-.578.06a.612.612 0 0 0-.357.21c-.077.099-.106.242-.088.429l.17 1.622c.044.41-.001.742-.137.995a1.328 1.328 0 0 1-.61.584 3.306 3.306 0 0 1-.963.28c.392.059.724.154.995.286.272.132.47.323.594.572.125.25.165.583.121 1.001l-.17 1.623c-.018.183.011.326.088.429a.62.62 0 0 0 .363.209c.161.04.352.06.572.06v1.21c-.506 0-.935-.037-1.287-.11-.352-.073-.634-.19-.847-.352a1.214 1.214 0 0 1-.435-.627c-.077-.257-.097-.57-.06-.94l.165-1.573c.03-.28-.018-.497-.143-.655-.121-.158-.3-.268-.54-.33a3.102 3.102 0 0 0-.824-.099v-1.408c.308 0 .581-.031.82-.094.238-.066.42-.177.544-.335.125-.158.172-.376.143-.654L5.654 8.8c-.04-.378-.022-.697.055-.957.08-.26.225-.47.434-.627.213-.162.495-.277.847-.347a6.54 6.54 0 0 1 1.293-.11ZM9.527 16v-1.166h.77v-3.52h-.77v-1.155h2.096l.319 1.314c.209-.502.474-.876.797-1.122.326-.245.724-.368 1.194-.368a2.535 2.535 0 0 1 .962.176l-.528 1.435a2.48 2.48 0 0 0-.67-.087c-.382 0-.718.155-1.007.467-.286.312-.505.708-.655 1.188v1.672h1.155V16H9.527Zm3.955-3.399v-1.705l.258-.737h1.155l-.324 2.442h-1.09Zm2.239-5.841c.506 0 .935.037 1.287.11.352.073.633.19.842.352.212.158.36.367.44.627.08.257.1.57.06.94l-.165 1.574c-.029.278.019.496.143.654.125.158.305.27.54.335.238.063.513.094.824.094v1.408c-.308 0-.58.033-.82.099a.985.985 0 0 0-.544.33c-.124.158-.172.376-.143.655l.165 1.561c.04.378.02.697-.06.957-.077.26-.222.47-.435.628-.209.16-.491.276-.847.346a6.44 6.44 0 0 1-1.287.11v-1.21c.224 0 .415-.02.572-.06a.59.59 0 0 0 .358-.21c.08-.102.112-.245.093-.428l-.17-1.623c-.044-.414 0-.746.132-.995.136-.253.34-.446.616-.578.275-.136.598-.231.968-.286a3.52 3.52 0 0 1-1.001-.286 1.251 1.251 0 0 1-.594-.572c-.125-.253-.165-.587-.121-1.001l.17-1.622c.019-.187-.012-.33-.093-.43a.59.59 0 0 0-.358-.208 2.338 2.338 0 0 0-.572-.061V6.76Z&#39; fill=&#39;%23505562&#39;/%3E%3C/svg%3E">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="http" />
         <zeebe:taskHeaders>
@@ -94,7 +94,9 @@
           <zeebe:property name="property-3-name" value="property-3-value" />
         </zeebe:properties>
       </bpmn:extensionElements>
-  </bpmn:serviceTask>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1dnqc94" name="incompatible" zeebe:modelerTemplate="example.engines.test.incompatible" />
+    <bpmn:serviceTask id="Activity_1ofw5tu" name="incompatible (update available)" zeebe:modelerTemplate="example.engines.test.basic" zeebe:modelerTemplateVersion="3" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
@@ -138,6 +140,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0xl49z8_di" bpmnElement="Activity_070m932">
         <dc:Bounds x="270" y="690" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0wdqmez" bpmnElement="Activity_1dnqc94">
+        <dc:Bounds x="650" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0xbqyuv" bpmnElement="Activity_1ofw5tu">
+        <dc:Bounds x="800" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0gw5hlt_di" bpmnElement="Flow_0gw5hlt">
         <di:waypoint x="215" y="117" />

--- a/test/spec/cloud-element-templates/fixtures/engines-invalid.json
+++ b/test/spec/cloud-element-templates/fixtures/engines-invalid.json
@@ -1,0 +1,16 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.broken",
+    "name": "<engines> Test - broken Semver range",
+    "description": "specifies broken semver range",
+    "version": 1,
+    "engines": {
+      "camunda": "invalid-version"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/cloud-element-templates/fixtures/engines.json
+++ b/test/spec/cloud-element-templates/fixtures/engines.json
@@ -1,0 +1,97 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "does not match if { desktopModeler: >=1 } is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1",
+      "desktopModeler": "^0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "matches if { camunda: ^8.6, webModeler: ^4.1 } engine is indicated, or properties are not provided",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^8.6 }, or if no <camunda> engine is provided",
+    "version": 3,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^8.5 }, or if no <camunda> engine is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.5"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "always matches",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.incompatible",
+    "name": "<engines> Test - incompatible",
+    "description": "incompatible with all camunda versions",
+    "engines": {
+      "camunda": "0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "Task Header 2",
+        "type": "String",
+        "value": "header-2-value",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "header-2-key"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/fixtures/falsy-version.json
+++ b/test/spec/cloud-element-templates/fixtures/falsy-version.json
@@ -1,0 +1,10 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "foo",
+    "name":"Foo 1",
+    "version": 0,
+    "appliesTo": [ "bpmn:Task" ],
+    "properties": []
+  }
+]

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.json
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.json
@@ -216,5 +216,55 @@
         "feel": "optional"
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "compatible",
+    "id": "compatible",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "engines": {
+      "camunda": ">1.0"
+    },
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "incompatible",
+    "id": "incompatible",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "engines": {
+      "camunda": "0"
+    },
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "incompatible-updatable",
+    "id": "incompatible-updatable",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "engines": {
+      "camunda": "0"
+    },
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "incompatible-updatable",
+    "id": "incompatible-updatable",
+    "version": 2,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "engines": {
+      "camunda": "^8.5"
+    },
+    "properties": []
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
@@ -4,6 +4,7 @@
     <bpmn:task id="Task_1" zeebe:modelerTemplate="foo" />
     <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
     <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" zeebe:modelerTemplate="engines" zeebe:modelerTemplateVersion="2" />
     <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
     <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" />
     <bpmn:serviceTask id="Deprecated" name="Deprecated" zeebe:modelerTemplate="deprecated" />
@@ -45,6 +46,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1ffxuhh_di" bpmnElement="Event_18wfkz8">
         <dc:Bounds x="302" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m5dd19_di" bpmnElement="Task_4">
+        <dc:Bounds x="500" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.json
@@ -94,5 +94,38 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "engines",
+    "name":"Engines 1",
+    "version": 1,
+    "appliesTo": [ "bpmn:Task" ],
+    "engines": {
+      "camunda": "^8.4"
+    },
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "engines",
+    "name":"Engines 2",
+    "version": 2,
+    "appliesTo": [ "bpmn:Task" ],
+    "engines": {
+      "camunda": "^8.5"
+    },
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "engines",
+    "name":"Engines 3",
+    "version": 3,
+    "appliesTo": [ "bpmn:Task" ],
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "properties": []
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -495,6 +495,75 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
     );
   });
 
+  describe('engines', function() {
+
+    it('should display update button if latest is compatible', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        const element = elementRegistry.get('Task_4');
+
+        // when
+        elementTemplates.setEngines({
+          camunda: '8.6'
+        });
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const updateAvailable = domQuery('.bio-properties-panel-template-update-available', container);
+        expect(updateAvailable).to.exist;
+      })
+    );
+
+
+    it('should NOT display update button if latest is incompatible', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        const element = elementRegistry.get('Task_4');
+
+        // when
+        elementTemplates.setEngines({
+          camunda: '8.5'
+        });
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const updateAvailable = domQuery('.bio-properties-panel-template-update-available', container);
+        expect(updateAvailable).not.to.exist;
+      })
+    );
+
+
+    it('should display incompatible button when template is incompatible', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        const element = elementRegistry.get('Task_4');
+
+        // when
+        elementTemplates.setEngines({
+          camunda: '8.0'
+        });
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const incompatible = domQuery('.bio-properties-panel-template-incompatible', container);
+        expect(incompatible).to.exist;
+      })
+    );
+
+  });
+
 
   describe('conditional entries', function() {
 

--- a/test/spec/element-templates/ElementTemplates.engines-templates.json
+++ b/test/spec/element-templates/ElementTemplates.engines-templates.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "does not match if { desktopModeler: >=1 } is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^7.14",
+      "webModeler": "^4.1",
+      "desktopModeler": "^0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "matches if { camunda: ^7.14, webModeler: ^4.1 } engine is indicated, or properties are not provided",
+    "version": 1,
+    "engines": {
+      "camunda": "^7.14",
+      "webModeler": "^4.1"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^7.14 }, or if no <camunda> engine is provided",
+    "version": 3,
+    "engines": {
+      "camunda": "^7.14"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^7.13 }, or if no <camunda> engine is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^7.13"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "always matches",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.broken",
+    "name": "<engines> Test - broken Semver range",
+    "description": "specifies broken semver range",
+    "version": 1,
+    "engines": {
+      "camunda": "invalid-version"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/element-templates/ElementTemplates.spec.js
+++ b/test/spec/element-templates/ElementTemplates.spec.js
@@ -20,6 +20,7 @@ import diagramXML from './ElementTemplates.bpmn';
 
 import templates from './fixtures/simple';
 import falsyVersionTemplate from './fixtures/falsy-version';
+import enginesTemplates from './ElementTemplates.engines-templates.json';
 
 
 describe('provider/element-templates - ElementTemplates', function() {
@@ -219,6 +220,206 @@ describe('provider/element-templates - ElementTemplates', function() {
     }));
 
 
+    describe('<engines> compatibility', function() {
+
+      beforeEach(inject(function(elementTemplates) {
+        elementTemplates.set(enginesTemplates);
+      }));
+
+
+      describe('should retrieve latest compatible', function() {
+
+        it('single template', inject(function(elementTemplates) {
+
+          // given
+          elementTemplates.setEngines({
+            camunda: '7.14.3'
+          });
+
+          // when
+          const templates = elementTemplates.getLatest('example.engines.test.basic');
+
+          // then
+          expect(templates).to.have.length(1);
+          expect(templates[0].version).to.eql(3);
+        }));
+
+
+        it('all templates', inject(function(elementTemplates) {
+
+          // given
+          elementTemplates.setEngines({
+            camunda: '7.14.3'
+          });
+
+          // when
+          const templates = elementTemplates.getLatest();
+
+          // then
+          // expect all compatible templates to be returned
+          // example.engines.test.multiple v2
+          // example.engines.test.basic v2
+          expect(templates).to.have.length(2);
+        }));
+
+      });
+
+
+      it('should retrieve older compatible', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '7.13'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.basic');
+
+        // then
+        expect(templates).to.have.length(1);
+        expect(templates[0].version).to.eql(2);
+      }));
+
+
+      it('should retrieve fallback (no <engines> meta-data)', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '4'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.basic');
+
+        // then
+        expect(templates).to.have.length(1);
+        expect(templates[0].version).to.eql(1);
+      }));
+
+
+      describe('should handle no context provided', function() {
+
+        it('single template', inject(function(elementTemplates) {
+
+          // given
+          elementTemplates.setEngines({});
+
+          // when
+          const templates = elementTemplates.getLatest('example.engines.test.basic');
+
+          // then
+          expect(templates).to.have.length(1);
+          expect(templates[0].version).to.eql(3);
+        }));
+
+
+        it('list templates', inject(function(elementTemplates) {
+
+          // given
+          elementTemplates.setEngines({});
+
+          // when
+          const templates = elementTemplates.getLatest();
+
+          // then
+          // example.engines.test.multiple v2
+          // example.engines.test.basic v3
+          // example.engines.test.broken v1
+          expect(templates).to.have.length(3);
+        }));
+
+      });
+
+
+      it('should support multiple engines', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '7.14',
+          webModeler: '4.3'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.multiple');
+
+        // then
+        expect(templates).to.have.length(1);
+        expect(templates[0].version).to.eql(2);
+      }));
+
+
+      it('should exclude engine', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '7.14',
+          webModeler: '4.3',
+          desktopModeler: '5.4'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.multiple');
+
+        // then
+        expect(templates).to.have.length(1);
+        expect(templates[0].version).to.eql(1);
+      }));
+
+
+      it('should ignore incompatible', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '7.12'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.multiple');
+
+        // then
+        expect(templates).to.be.empty;
+      }));
+
+
+      it('should handle broken <engines> provided at run-time', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: 'one-hundred'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.basic');
+
+        // then
+        // we ignore the context entry, assume it is not there
+        expect(templates).to.have.length(1);
+        expect(templates[0].version).to.eql(3);
+      }));
+
+
+      it('should handle broken <engines> provided by template', inject(function(elementTemplates) {
+
+        // given
+        elementTemplates.setEngines({
+          camunda: '7.14'
+        });
+
+        // when
+        const templates = elementTemplates.getLatest('example.engines.test.broken');
+
+        // then
+        expect(templates).to.be.empty;
+
+        // and
+        // we still regard such template as a valid template
+        const template = elementTemplates.get('example.engines.test.broken', 1);
+        expect(template).to.exist;
+      }));
+
+    });
+
+
     it('should throw for invalid argument', inject(function(elementTemplates) {
 
       // then
@@ -376,6 +577,40 @@ describe('provider/element-templates - ElementTemplates', function() {
 
       // then
       expect(elementTemplates.get(falsyVersionTemplate[0].id, 0)).to.exist;
+    }));
+
+
+    it('should emit <elementTemplates.changed> event', inject(function(elementTemplates, eventBus) {
+
+      // given
+      const spy = sinon.spy();
+
+      eventBus.on('elementTemplates.changed', spy);
+
+      // when
+      elementTemplates.set(templates);
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+    }));
+
+  });
+
+
+  describe('setEngines', function() {
+
+    it('should emit event', inject(function(elementTemplates, eventBus) {
+
+      // given
+      const spy = sinon.spy();
+
+      eventBus.on('elementTemplates.engines.changed', spy);
+
+      // when
+      elementTemplates.setEngines({});
+
+      // then
+      expect(spy).to.have.been.calledOnce;
     }));
 
   });
@@ -576,6 +811,80 @@ describe('provider/element-templates - ElementTemplates', function() {
       expect(taskBo.modelerTemplateVersion).to.eql(2);
     }));
 
+  });
+
+
+  describe('isCompatible', function() {
+
+    const compatibleTemplate = {
+      engines: {
+        camunda: '^8.5'
+      }
+    };
+
+    const incompatibleTemplate = {
+      engines: {
+        camunda: '^8.6'
+      }
+    };
+
+
+    it('should accept compatible', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        camunda: '8.5'
+      });
+
+      // then
+      expect(elementTemplates.isCompatible(compatibleTemplate)).to.be.true;
+    }));
+
+
+    it('should reject incompatible', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        camunda: '8.5'
+      });
+
+      // then
+      expect(elementTemplates.isCompatible(incompatibleTemplate)).to.be.false;
+    }));
+
+
+    it('should accept non matching engine', inject(function(elementTemplates) {
+
+      // given
+      elementTemplates.setEngines({
+        nonMatchingEngine: '8.5'
+      });
+
+      // then
+      expect(elementTemplates.isCompatible(compatibleTemplate)).to.be.true;
+      expect(elementTemplates.isCompatible(incompatibleTemplate)).to.be.true;
+    }));
+
+  });
+
+
+  describe('error handling', function() {
+
+    // given
+    const invalidEngines = {
+      camunda: '7.12',
+      invalid: 'not-a-semver'
+    };
+
+    it('should filter invalid <engines> on set', inject(function(elementTemplates) {
+
+      // when
+      elementTemplates.setEngines(invalidEngines);
+
+      // then
+      expect(elementTemplates.getEngines()).to.have.property('camunda');
+      expect(elementTemplates.getEngines()).to.not.have.property('invalid');
+    }));
   });
 
 });

--- a/test/spec/element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/element-templates/ElementTemplatesLoader.spec.js
@@ -34,6 +34,58 @@ describe('provider/element-templates - ElementTemplatesLoader', function() {
   });
 
 
+  describe('init with config={ loadTemplates } as Array<TemplateDescriptor>', function() {
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      container: container,
+      modules,
+      moddleExtensions: {
+        camunda: camundaModdlePackage
+      },
+      elementTemplates: {
+        loadTemplates: templateDescriptors
+      }
+    }));
+
+    it('should configure elementTemplates service', inject(function(elementTemplates) {
+
+      // then
+      expect(elementTemplates.getAll()).to.eql(templateDescriptors);
+    }));
+
+  });
+
+
+  describe('init with config={ loadTemplates } as function', function() {
+
+    let provider = function(done) {
+      done(null, templateDescriptors);
+    };
+
+    const templateProviderFn = function(done) {
+      provider(done);
+    };
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      container: container,
+      modules,
+      moddleExtensions: {
+        camunda: camundaModdlePackage
+      },
+      elementTemplates: {
+        loadTemplates: templateProviderFn
+      }
+    }));
+
+    it('should configure elementTemplates service', inject(function(elementTemplates) {
+
+      // then
+      expect(elementTemplates.getAll()).to.eql(templateDescriptors);
+    }));
+
+  });
+
+
   describe('init with Array<TemplateDescriptor>', function() {
 
     beforeEach(bootstrapModeler(diagramXML, {

--- a/test/spec/element-templates/Validator.spec.js
+++ b/test/spec/element-templates/Validator.spec.js
@@ -712,4 +712,42 @@ describe('provider/element-templates - Validator', function() {
 
   });
 
+
+  describe('engines validation', function() {
+
+    it('should accept template with valid semver range', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/engines');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
+    it('should reject template with invalid semver range', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/engines-invalid');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.contain('Engine <camunda> specifies invalid semver range <invalid-version>');
+
+      expect(valid(templates)).to.be.empty;
+    });
+
+  });
+
 });

--- a/test/spec/element-templates/fixtures/engines-invalid.json
+++ b/test/spec/element-templates/fixtures/engines-invalid.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "basic template with invalid engines",
+    "version": 3,
+    "engines": {
+      "camunda": "invalid-version"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/element-templates/fixtures/engines.json
+++ b/test/spec/element-templates/fixtures/engines.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "does not match if { desktopModeler: >=1 } is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^7.13",
+      "webModeler": "^4.1",
+      "desktopModeler": "^0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "matches if { camunda: ^7.13, webModeler: ^4.1 } engine is indicated, or properties are not provided",
+    "version": 1,
+    "engines": {
+      "camunda": "^7.13",
+      "webModeler": "^4.1"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: ^7.13 }, or if no <camunda> engine is provided",
+    "version": 3,
+    "engines": {
+      "camunda": "^7.13"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches if { camunda: <=7.12 }, or if no <camunda> engine is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "<=7.12"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "always matches",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "id": "example.engines.test.incompatible",
+    "name": "<engines> Test - incompatible",
+    "description": "incompatible with all camunda versions",
+    "engines": {
+      "camunda": "0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "Custom Property 2",
+        "type": "String",
+        "value": "property-2-value",
+        "binding": {
+          "type": "camunda:property",
+          "name": "property-2-key"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4530
Related to https://github.com/camunda/product-hub/issues/2368 (epic)

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 


The goal of this pull request is to ensure that served element templates are compatible (best to our knowledge) with current runtime environment. 

Modelers will be able to pass their `engines` configuration to `elementTemplates`. If templates have information about compatible engines in their schema (introduced with https://github.com/camunda/element-templates-json-schema/issues/146), compatibility will be verified and relevant templates will be provided.

If runtime environment changes dynamically, it can be adjusted with `elementTemplates#setEngines` API.

Bunch of enhancements to support element templates runtime versions:
- [x] Add `engines` configuration to ElementTemplates module.
- [x] Add API to set `engines` config.
- [x] Add API to check if template is compatible with currently set engines.
- [x] Verify compatibility when setting templates and only serve compatible templates as latest.
- [x] Introduce new "Not compatible" state in properties panel element templates group to differentiate between not found and not compatible templates.
- [x] Add linting for incompatible template.
- [x] Clean up commits
- [ ] (optional) Console warning if templates provide compatibility info, but modeler didn't provide runtime version.

### Test locally

`npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates#engines`

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
