### PR TITLE
test: verify engines in example test bed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "karma-webpack": "^5.0.1",
         "mocha": "^10.8.2",
         "mocha-test-container-support": "^0.2.0",
+        "modeler-moddle": "^0.2.0",
         "npm-run-all2": "^7.0.0",
         "puppeteer": "^23.7.0",
         "raw-loader": "^4.0.2",
@@ -7376,7 +7377,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/modeler-moddle/-/modeler-moddle-0.2.0.tgz",
       "integrity": "sha512-l8OUpvX94m3spe+RBwWFQ0bGvPBZ3FBCiSY3yNtDk52j0YRj+cnVOxTMQvVM+i6k1T326IfqYM3F9HJfPZtXRw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "karma-webpack": "^5.0.1",
     "mocha": "^10.8.2",
     "mocha-test-container-support": "^0.2.0",
+    "modeler-moddle": "^0.2.0",
     "npm-run-all2": "^7.0.0",
     "puppeteer": "^23.7.0",
     "raw-loader": "^4.0.2",

--- a/test/spec/cloud-element-templates/fixtures/engines.json
+++ b/test/spec/cloud-element-templates/fixtures/engines.json
@@ -1,0 +1,88 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "does not match <desktopModeler>, if explicit <desktopModeler>=1> is provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1",
+      "desktopModeler": "^0"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.multiple",
+    "name": "<engines> Test - Multiple",
+    "description": "matches when compatible <camunda> and/or <webModeler> run-time is indicated, or properties are not provided",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6",
+      "webModeler": "^4.1"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches when compatible <camunda> run-time is indicated, or property is not provided",
+    "version": 3,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "matches when compatible <camunda> run-time is indicated, or property is not provided",
+    "version": 2,
+    "engines": {
+      "camunda": "^8.5"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.basic",
+    "name": "<engines> Test - Basic",
+    "description": "always matches",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "example.engines.test.broken",
+    "name": "<engines> Test - broken Semver range",
+    "description": "specifies broken semver range",
+    "version": 1,
+    "engines": {
+      "camunda": "-foobar"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  }
+]


### PR DESCRIPTION
### Proposed Changes

This shows the integration of engines / compatible templates in an E2E setup:

![capture YbnWaP_optimized](https://github.com/user-attachments/assets/56c632d1-f951-471e-a4ac-18ad619b97f2)

Example works off [these templates](https://github.com/bpmn-io/bpmn-js-element-templates/compare/engines...example-test-bed?expand=1#diff-085b49be6e7d3757d8808464a6c0a126559f06ae64aa3ec5946cf9160e808a23).

Related to #132 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
