### PR TITLE
feat: Support binding type `zeebe:linkedResource`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.2.0",
+        "@bpmn-io/element-templates-validator": "^2.3.0",
         "@bpmn-io/extract-process-variables": "^1.0.0",
         "bpmnlint": "^11.0.0",
         "classnames": "^2.3.1",
@@ -75,7 +75,7 @@
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "webpack": "^5.96.1",
-        "zeebe-bpmn-moddle": "^1.4.0"
+        "zeebe-bpmn-moddle": "^1.8.0"
       },
       "engines": {
         "node": "*"
@@ -484,13 +484,13 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.2.0.tgz",
-      "integrity": "sha512-YsgvHUSSf8oGpc6C5AchQwD7wWo41vmMw3Aa9dT+myI7vgNJlo32aRfdtNkBdRCaU1OZQMIZoF0bCEasRmKgPQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.0.tgz",
+      "integrity": "sha512-zkUs0+hR5sW0oUlUtgp9G/qBOVVSm4SIC7hREcaLreS9e9hGE+FqY08L+YLXleUCDTVzgPWbb4qK/brxwemoWw==",
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.21.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.21.0.tgz",
-      "integrity": "sha512-etC2PXoHAQ+74xokXYczfb5HmLtisSYCeKSl1c5PCKD6nWWLpGaha86edkPvTKt6SbHCDLZ0dzWXY0iBpyWfow==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.0.tgz",
+      "integrity": "sha512-asl5JQHY1duxxQ4HEahB5TdP6Hn3SheXw65kGmqo9dsQo/iuZMGUv75q/HDiClz86pwdngZx+/W28YAhyxQztw==",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
@@ -10292,10 +10292,11 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
-      "dev": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.8.0.tgz",
+      "integrity": "sha512-NIImLOK3ovMikloRku6tdF2h6cGE3/CmKqCCaNPCwSV2yL0uS4KIwWyROaV14gnjYsVnrdo4idBgHExzt65jUA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.23.8",
@@ -10595,12 +10596,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.2.0.tgz",
-      "integrity": "sha512-YsgvHUSSf8oGpc6C5AchQwD7wWo41vmMw3Aa9dT+myI7vgNJlo32aRfdtNkBdRCaU1OZQMIZoF0bCEasRmKgPQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.0.tgz",
+      "integrity": "sha512-zkUs0+hR5sW0oUlUtgp9G/qBOVVSm4SIC7hREcaLreS9e9hGE+FqY08L+YLXleUCDTVzgPWbb4qK/brxwemoWw==",
       "requires": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.21.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -10751,9 +10752,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.21.0.tgz",
-      "integrity": "sha512-etC2PXoHAQ+74xokXYczfb5HmLtisSYCeKSl1c5PCKD6nWWLpGaha86edkPvTKt6SbHCDLZ0dzWXY0iBpyWfow=="
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.0.tgz",
+      "integrity": "sha512-asl5JQHY1duxxQ4HEahB5TdP6Hn3SheXw65kGmqo9dsQo/iuZMGUv75q/HDiClz86pwdngZx+/W28YAhyxQztw=="
     },
     "@codemirror/autocomplete": {
       "version": "6.17.0",
@@ -17757,9 +17758,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.7.0.tgz",
-      "integrity": "sha512-eZ6OXSt0c4n9V/oN/46gTlwDIS3GhWQLt9jbM5uS/YryB4yN8wdrrKrtw+TpyNy0SSKWXNDHyC83nCA2blPO3Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.8.0.tgz",
+      "integrity": "sha512-NIImLOK3ovMikloRku6tdF2h6cGE3/CmKqCCaNPCwSV2yL0uS4KIwWyROaV14gnjYsVnrdo4idBgHExzt65jUA==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.2.0",
+    "@bpmn-io/element-templates-validator": "^2.3.0",
     "@bpmn-io/extract-process-variables": "^1.0.0",
     "bpmnlint": "^11.0.0",
     "classnames": "^2.3.1",
@@ -126,7 +126,7 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.96.1",
-    "zeebe-bpmn-moddle": "^1.4.0"
+    "zeebe-bpmn-moddle": "^1.8.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 2.2",

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1081,7 +1081,7 @@ export default class ChangeElementTemplateHandler {
       });
     }
 
-    const unusedLinkedResources = linkedResources.get('values')?.slice() || [];
+    const unusedLinkedResources = linkedResources.get('values').slice();
     const unusedResourceProperties = oldTemplate?.properties.slice() || [];
 
     newLinkedResources.forEach((newLinkedResource) => {

--- a/src/cloud-element-templates/create/LinkedResourceProvider.js
+++ b/src/cloud-element-templates/create/LinkedResourceProvider.js
@@ -1,0 +1,38 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import { createElement } from '../../utils/ElementUtil';
+
+import {
+  ensureExtension
+} from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+
+export default class LinkedResourcePropertyBindingProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      binding: {
+        property: bindingProperty,
+        linkName
+      }
+    } = property;
+
+    const value = getDefaultValue(property);
+
+    const bo = getBusinessObject(element);
+    const linkedResources = ensureExtension(element, 'zeebe:LinkedResources', bpmnFactory);
+
+    let linkedResource = linkedResources.get('values').find(linkedResource => linkedResource.get('linkName') === linkName);
+
+    if (!linkedResource) {
+      linkedResource = createElement('zeebe:LinkedResource', { linkName }, bo, bpmnFactory);
+      linkedResources.get('values').push(linkedResource);
+    }
+
+    linkedResource.set(bindingProperty, value);
+  }
+}

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -13,6 +13,7 @@ import ZeebePropertiesProvider from './ZeebePropertiesProvider';
 import { MessagePropertyBindingProvider } from './MessagePropertyBindingProvider';
 import { MessageZeebeSubscriptionBindingProvider } from './MessageZeebeSubscriptionBindingProvider';
 import { CalledElementBindingProvider } from './CalledElementBindingProvider';
+import LinkedResourcePropertyBindingProvider from './LinkedResourceProvider';
 
 import {
   MESSAGE_PROPERTY_TYPE,
@@ -24,7 +25,8 @@ import {
   ZEEBE_OUTPUT_TYPE,
   ZEEBE_TASK_HEADER_TYPE,
   ZEBBE_PROPERTY_TYPE,
-  ZEEBE_CALLED_ELEMENT
+  ZEEBE_CALLED_ELEMENT,
+  ZEEBE_LINKED_RESOURCE_PROPERTY
 } from '../util/bindingTypes';
 
 import {
@@ -47,7 +49,8 @@ export default class TemplateElementFactory {
       [ZEEBE_TASK_HEADER_TYPE]: TaskHeaderBindingProvider,
       [MESSAGE_PROPERTY_TYPE]: MessagePropertyBindingProvider,
       [MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE]: MessageZeebeSubscriptionBindingProvider,
-      [ZEEBE_CALLED_ELEMENT]: CalledElementBindingProvider
+      [ZEEBE_CALLED_ELEMENT]: CalledElementBindingProvider,
+      [ZEEBE_LINKED_RESOURCE_PROPERTY]: LinkedResourcePropertyBindingProvider
     };
   }
 

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -10,6 +10,7 @@ export const ZEEBE_TASK_HEADER_TYPE = 'zeebe:taskHeader';
 export const MESSAGE_PROPERTY_TYPE = 'bpmn:Message#property';
 export const MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE = 'bpmn:Message#zeebe:subscription#property';
 export const ZEEBE_CALLED_ELEMENT = 'zeebe:calledElement';
+export const ZEEBE_LINKED_RESOURCE_PROPERTY = 'zeebe:linkedResource';
 
 export const EXTENSION_BINDING_TYPES = [
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
@@ -19,7 +20,8 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_TASK_DEFINITION_TYPE_TYPE,
   ZEEBE_TASK_DEFINITION,
   ZEEBE_TASK_HEADER_TYPE,
-  ZEEBE_CALLED_ELEMENT
+  ZEEBE_CALLED_ELEMENT,
+  ZEEBE_LINKED_RESOURCE_PROPERTY
 ];
 
 export const TASK_DEFINITION_TYPES = [

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2054,6 +2054,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
       });
 
+
       describe('zeebe:LinkedElement not specified', function() {
         const newTemplate = require('./task-template-no-properties.json');
 
@@ -2112,7 +2113,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
           expect(linkedResources).not.to.exist;
         }));
-
 
       });
 
@@ -4178,6 +4178,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
 
     describe('update zeebe:LinkedResource', function() {
+
       beforeEach(bootstrap(require('./linked-resource.bpmn').default));
 
       it('property changed', inject(function(elementRegistry) {

--- a/test/spec/cloud-element-templates/cmd/linked-resource.bpmn
+++ b/test/spec/cloud-element-templates/cmd/linked-resource.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.29.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_0vvlc66" isExecutable="true">
+    <bpmn:serviceTask id="withResources">
+      <bpmn:extensionElements>
+        <zeebe:linkedResources>
+          <zeebe:linkedResource linkName="persistedLink" resourceType="originalType" resourceId="originalResource" bindingType="originalBinding" />
+          <zeebe:linkedResource linkName="toBeRemoved" resourceId="adsf" />
+        </zeebe:linkedResources>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="noResources">
+      <bpmn:extensionElements />
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
+      <bpmndi:BPMNShape id="Activity_0vyioq6_di" bpmnElement="withResources">
+        <dc:Bounds x="200" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wr3cux_di" bpmnElement="noResources">
+        <dc:Bounds x="200" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/cmd/linked-resource.json
+++ b/test/spec/cloud-element-templates/cmd/linked-resource.json
@@ -1,0 +1,85 @@
+[ 
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "linkedResource",
+    "id": "linkedResource",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "RPA",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "persistedLink",
+          "property": "resourceType"
+        }
+      },
+      {
+        "type": "String",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "persistedLink",
+          "property": "resourceId"
+        }
+      },
+      {
+        "type": "String",
+        "value": "latest",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "persistedLink",
+          "property": "bindingType"
+        }
+      },
+      {
+        "type": "String",
+        "value": "RPA",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "removedLink",
+          "property": "resourceType"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "linkedResource v2",
+    "id": "linkedResource",
+    "version": 2,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "RPA",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "persistedLink",
+          "property": "resourceType"
+        }
+      },
+      {
+        "type": "String",
+        "feel": "optional",
+        "value": "changed",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "persistedLink",
+          "property": "resourceId"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -486,6 +486,34 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
         processId: 'paymentProcess'
       });
     }));
+
+
+    it('should handle <zeebe:linkedElement>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('linkedResource');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      const linkedResources = findExtension(element, 'zeebe:LinkedResources');
+      const resources = linkedResources.get('values');
+
+      // then
+      expect(resources).to.exist;
+      expect(resources).to.jsonEqual([
+        {
+          $type: 'zeebe:LinkedResource',
+          linkName: 'Link1',
+          resourceType: 'foo'
+        },
+        {
+          $type: 'zeebe:LinkedResource',
+          linkName: 'Link2',
+          resourceId: 'bar'
+        },
+      ]);
+    }));
   });
 
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -535,5 +535,36 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "linkedResource",
+    "id": "linkedResource",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "foo",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "Link1",
+          "property": "resourceType"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "bar",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "Link2",
+          "property": "resourceId"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/fixtures/linked-resource.json
+++ b/test/spec/cloud-element-templates/fixtures/linked-resource.json
@@ -1,0 +1,72 @@
+[ 
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "linkedResource",
+    "id": "linkedResource",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "RPA",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "entryPoint",
+          "property": "resourceType"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "camunda:RPA",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Script ID",
+        "type": "String",
+        "feel": "optional",
+        "constraints": {
+          "notEmpty": true
+        },
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "entryPoint",
+          "property": "resourceId"
+        }
+      },
+      {
+        "label": "Binding",
+        "id": "binding",
+        "type": "Dropdown",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "entryPoint",
+          "property": "bindingType"
+        },
+        "choices": [
+          { "name": "latest", "value": "latest" },
+          { "name": "deployment", "value": "deployment" },
+          { "name": "version tag", "value": "versionTag" }
+        ]
+      },
+      {
+        "label": "Version Tag",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "entryPoint",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "binding",
+          "equals": "versionTag"
+        }
+      }
+    ] 
+  }
+]


### PR DESCRIPTION
### Proposed Changes

This PR adds the ability to template `zeebe:LinkedResource` elements. You can try it out with `npm run start`.

[screencap-2025-01-17-12-02-38.webm](https://github.com/user-attachments/assets/7e48c7de-621a-435c-9454-a2e432bd7448)

closes https://github.com/bpmn-io/bpmn-js-element-templates/issues/137

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
