### PR TITLE
chore: change incompatible button text color to more accessible

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -11,6 +11,8 @@
 
   --incompatible-template-background-color: rgb(255, 131, 43);
   --incompatible-template-hover-background-color: hsl(25, 100%, 50%);
+  --incompatible-template-fill-color: var(--color-grey-225-10-15);
+  --incompatible-template-label-color: var(--color-grey-225-10-15);
 
   --select-template-information-text-color: var(--color-grey-225-10-55);
 
@@ -93,8 +95,8 @@
 
 .bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button {
   background-color: var(--incompatible-template-background-color);
-  color: var(--select-template-label-color);
-  fill: var(--select-template-fill-color);
+  color: var(--incompatible-template-label-color);
+  fill: var(--incompatible-template-fill-color);
 }
 
 .bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button:hover {


### PR DESCRIPTION
Change text color on incompatible templates button.

`npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates#incompatible-color`

Related to https://github.com/camunda/camunda-modeler/issues/4766

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
