### PR TITLE
fix: make `feel` default to `static` for inputs and outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.5.2
+
+* `FIX`: make `feel` default value `static` for inputs and outputs ([#142](https://github.com/bpmn-io/bpmn-js-element-templates/pull/142))
+* `DEPS`: update to `@bpmn-io/element-templates-validator@2.3.3`
+
+### Note
+
+This release reverts the breaking changes introduced via [camunda/element-templates-json-schema#156](https://github.com/camunda/element-templates-json-schema/pull/156). Any `feel` value out of the supported enum is allowed, but `static` is used if the property is missing.
+
 ## 2.5.1
 
 * `FIX`: require `feel` to be `optional` or `static` for `Boolean` and `Number` inputs and outputs ([camunda/element-templates-json-schema#156](https://github.com/camunda/element-templates-json-schema/pull/156))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.3.2",
+        "@bpmn-io/element-templates-validator": "^2.3.3",
         "@bpmn-io/extract-process-variables": "^1.0.0",
         "bpmnlint": "^11.0.0",
         "classnames": "^2.3.1",
@@ -484,13 +484,13 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.2.tgz",
-      "integrity": "sha512-Gr6pNSoFif2Sgd01+NdPVVLGrz4R/AICHbK29zBcF849RDH+iLq7qAUhbT8MwwUKOs9WHztXoDTEiKbF85lx5g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.3.tgz",
+      "integrity": "sha512-Q39lxuUA1T7pCkKiy40EAncr7MLVITq/P1MRDPHpFUz2S1Yvt5aZ4IdyKBpATlffcF5s6UfnRY7bq8qE+e2byw==",
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.22.2",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.3",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.2.tgz",
-      "integrity": "sha512-qKUa64twO5Ewh6rN+z0n1cdTweuKYuwPCZH6VL7knsdfSYe4PBLnx8FwTXS6Hc5LZCP60rp+XXgQ5puQZfqlNQ==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.3.tgz",
+      "integrity": "sha512-22D9ZAkBounIpQ0DKQ5lmkGGE7LZM7WCwLBez8AT0hGTHVve5egUCrh3f7QIm5DkdIHxyWdibD0zRIWUhDBrYg==",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
@@ -10596,12 +10596,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.2.tgz",
-      "integrity": "sha512-Gr6pNSoFif2Sgd01+NdPVVLGrz4R/AICHbK29zBcF849RDH+iLq7qAUhbT8MwwUKOs9WHztXoDTEiKbF85lx5g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.3.3.tgz",
+      "integrity": "sha512-Q39lxuUA1T7pCkKiy40EAncr7MLVITq/P1MRDPHpFUz2S1Yvt5aZ4IdyKBpATlffcF5s6UfnRY7bq8qE+e2byw==",
       "requires": {
         "@camunda/element-templates-json-schema": "^0.18.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.22.2",
+        "@camunda/zeebe-element-templates-json-schema": "^0.22.3",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -10752,9 +10752,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.2.tgz",
-      "integrity": "sha512-qKUa64twO5Ewh6rN+z0n1cdTweuKYuwPCZH6VL7knsdfSYe4PBLnx8FwTXS6Hc5LZCP60rp+XXgQ5puQZfqlNQ=="
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.22.3.tgz",
+      "integrity": "sha512-22D9ZAkBounIpQ0DKQ5lmkGGE7LZM7WCwLBez8AT0hGTHVve5egUCrh3f7QIm5DkdIHxyWdibD0zRIWUhDBrYg=="
     },
     "@codemirror/autocomplete": {
       "version": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.3.2",
+    "@bpmn-io/element-templates-validator": "^2.3.3",
     "@bpmn-io/extract-process-variables": "^1.0.0",
     "bpmnlint": "^11.0.0",
     "classnames": "^2.3.1",

--- a/src/cloud-element-templates/Helper.js
+++ b/src/cloud-element-templates/Helper.js
@@ -3,7 +3,7 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 import { is, isAny } from 'bpmn-js/lib/util/ModelUtil';
 
 import { v4 as uuid } from 'uuid';
-import { isSpecialFeelProperty, toFeelExpression } from './util/FeelUtil';
+import { shouldCastToFeel, toFeelExpression } from './util/FeelUtil';
 
 /**
  * The BPMN 2.0 extension attribute name under
@@ -179,7 +179,7 @@ export function findZeebeSubscription(message) {
 export function getDefaultValue(property) {
 
   if (
-    isSpecialFeelProperty(property)
+    shouldCastToFeel(property)
   ) {
     return toFeelExpression(property.value, property.type);
   }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/NumberProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/NumberProperty.js
@@ -1,7 +1,7 @@
 import { FeelNumberEntry, NumberFieldEntry } from '@bpmn-io/properties-panel';
 import { useService } from 'bpmn-js-properties-panel';
 import { propertyValidator, usePropertyAccessors } from './util';
-import { isSpecialFeelProperty } from '../../../util/FeelUtil';
+import { shouldCastToFeel } from '../../../util/FeelUtil';
 import { PropertyDescription } from '../../../../components/PropertyDescription';
 import { PropertyTooltip } from '../../components/PropertyTooltip';
 import { useCallback } from '@bpmn-io/properties-panel/preact/hooks';
@@ -32,7 +32,7 @@ export function NumberProperty(props) {
   const [ getValue, setValue ] = usePropertyAccessors(bpmnFactory, commandStack, element, property);
 
   const validate = useCallback((value) => {
-    if (isSpecialFeelProperty(property) && isNumber(value) && value.toString().includes('e')) {
+    if (shouldCastToFeel(property) && isNumber(value) && value.toString().includes('e')) {
       return translate('Scientific notation is disallowed in FEEL.');
     }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
@@ -1,6 +1,6 @@
 import { find, groupBy } from 'min-dash';
 import { getPropertyValue, setPropertyValue, validateProperty } from '../../../util/propertyUtil';
-import { isSpecialFeelProperty, toFeelExpression } from '../../../util/FeelUtil';
+import { shouldCastToFeel, toFeelExpression } from '../../../util/FeelUtil';
 
 import { useCallback, useState } from '@bpmn-io/properties-panel/preact/hooks';
 
@@ -33,7 +33,7 @@ export function usePropertyAccessors(bpmnFactory, commandStack, element, propert
     return fromFeelExpression(directGet(), property.type);
   }, [ directGet, property, isFeelEnabled ]);
 
-  if (!isSpecialFeelProperty(property)) {
+  if (!shouldCastToFeel(property)) {
     return [ directGet, directSet ];
   }
 
@@ -62,7 +62,7 @@ const fromFeelExpression = (value, type) => {
 };
 
 const feelEnabled = (property, value) => {
-  if (!isSpecialFeelProperty(property)) {
+  if (!shouldCastToFeel(property)) {
     return true;
   }
 

--- a/src/cloud-element-templates/util/FeelUtil.js
+++ b/src/cloud-element-templates/util/FeelUtil.js
@@ -1,6 +1,28 @@
-export const isSpecialFeelProperty = (property) => {
-  return [ 'optional', 'static' ].includes(property.feel) && [ 'Boolean', 'Number' ].includes(property.type);
+/**
+ * Check if the property is cast to FEEL expression:
+ * - Boolean and Number properties with feel set to 'optional' or 'static'
+ * - Boolean and Number input/output parameters have default feel=static
+ *
+ * @returns {boolean}
+ */
+export const shouldCastToFeel = (property) => {
+  const feel = getFeelValue(property);
+
+  return [ 'optional', 'static' ].includes(feel) && [ 'Boolean', 'Number' ].includes(property.type);
 };
+
+const ALWAYS_CAST_TO_FEEL = [
+  'zeebe:input',
+  'zeebe:output'
+];
+
+function getFeelValue(property) {
+  if (ALWAYS_CAST_TO_FEEL.includes(property.binding.type)) {
+    return property.feel || 'static';
+  }
+
+  return property.feel;
+}
 
 export const toFeelExpression = (value, type) => {
   if (typeof value === 'string' && value.startsWith('=')) {

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
@@ -5,6 +5,7 @@
     <bpmn:serviceTask id="required" name="feel required" zeebe:modelerTemplate="booleanField.feel.required" />
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="booleanField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="booleanField.feel.static" />
+    <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="booleanField.feel.no-feel" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
@@ -22,6 +23,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07xiqk8" bpmnElement="static">
         <dc:Bounds x="290" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_07xiq11" bpmnElement="no-feel">
+        <dc:Bounds x="290" y="283" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.json
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.json
@@ -73,5 +73,31 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "FEEL missing - input output",
+    "id": "booleanField.feel.no-feel",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "BooleanProperty",
+        "type": "Boolean",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "BooleanProperty"
+        }
+      },
+      {
+        "label": "BooleanProperty",
+        "type": "Boolean",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "BooleanProperty"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
@@ -5,6 +5,7 @@
     <bpmn:serviceTask id="required" name="feel required" zeebe:modelerTemplate="numberField.feel.required" />
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="numberField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="numberField.feel.static" />
+    <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="numberField.feel.no-feel" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
@@ -22,6 +23,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07xiqk8" bpmnElement="static">
         <dc:Bounds x="290" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_07xiq11" bpmnElement="no-feel">
+        <dc:Bounds x="290" y="283" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/properties/NumberProperty.json
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.json
@@ -73,5 +73,31 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "FEEL missing - input output",
+    "id": "numberField.feel.no-feel",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "NumberProperty",
+        "type": "Number",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "NumberProperty"
+        }
+      },
+      {
+        "label": "NumberProperty",
+        "type": "Number",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "NumberProperty"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
deps: update to `@bpmn-io/element-templates-validator@2.3.3`

### Proposed Changes

This PR reverts the breaking changes introduced via [camunda/element-templates-json-schema#156](https://github.com/camunda/element-templates-json-schema/pull/156). Any `feel` value out of the supported enum is allowed, but `static` is used if the property is missing.

Related to https://github.com/camunda/camunda-modeler/issues/4593

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
