### PR TITLE
fix(cloud): do not remove unrelated properties on linkedResource update

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1082,7 +1082,8 @@ export default class ChangeElementTemplateHandler {
     }
 
     const unusedLinkedResources = linkedResources.get('values').slice();
-    const unusedResourceProperties = oldTemplate?.properties.slice() || [];
+    const unusedResourceProperties = (oldTemplate?.properties.slice() || [])
+      .filter((property) => property.binding.type === ZEEBE_LINKED_RESOURCE_PROPERTY);
 
     newLinkedResources.forEach((newLinkedResource) => {
       const oldProperty = findOldProperty(oldTemplate, newLinkedResource),

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -4320,6 +4320,13 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const oldTemplate = createTemplate([
           {
+            value: 'unrelated',
+            binding: {
+              type: 'zeebe:taskDefinition',
+              property: 'type'
+            }
+          },
+          {
             value: 'old-value',
             binding: {
               type: 'zeebe:linkedResource',
@@ -4346,6 +4353,13 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         ]);
 
         const newTemplate = createTemplate([
+          {
+            value: 'unrelated',
+            binding: {
+              type: 'zeebe:taskDefinition',
+              property: 'type'
+            }
+          },
           {
             value: 'new-value',
             binding: {
@@ -4377,6 +4391,12 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
             resourceId: 'new-value',
           }
         );
+
+        // does not update unrelated properties
+        const taskDefinition = findExtension(serviceTask, 'zeebe:TaskDefinition');
+
+        expect(taskDefinition).to.exist;
+        expect(taskDefinition.get('type')).to.eql('unrelated');
       }));
 
     });


### PR DESCRIPTION
### Proposed Changes
This PR ensures that unrelated properties are not removed when a linked resource gets updated.

### Steps to reproduce

Add the following Template to your modeler:

<details>
<pre>
{
  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
  "name": "Broken Task defintion type",
  "id": "323540f6-0c23-4f2asd7-b9a1-f821ed92585e",
  "appliesTo": [
    "bpmn:Task"
  ],
  "elementType": {
    "value": "bpmn:ServiceTask"
  },
  "properties": [
    {
      "type": "String",
      "binding": {
        "type": "zeebe:taskDefinition",
        "property": "type"
      },
      "value": "I should never disappear"
    },
    {
      "type": "Dropdown",
      "label": "Binding",
      "id": "bindingType",
      "binding": {
        "type": "zeebe:input",
        "name": "something"
      },
      "choices": [
        {
          "name": "Latest",
          "value": "latest"
        },
        {
          "name": "Deployment",
          "value": "deployment"
        },
        {
          "name": "Version Tag",
          "value": "versionTag"
        }
      ],
      "value": "latest"
    },
    {
      "type": "String",
      "label": "Version tag",
      "binding": {
        "type": "zeebe:linkedResource",
        "linkName": "RPAScript",
        "property": "versionTag"
      },
      "condition": {
        "property": "bindingType",
        "equals": "versionTag"
      }
    }
  ]
}
</pre>
</details>

- Change `Binding` to `versionTag`. 
- The `zeebe:taskDefinition` is gone

[screencap-2025-02-06-15-59-16.webm](https://github.com/user-attachments/assets/a547c1f7-b07e-44dd-b789-18598619787d)



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
