### PR TITLE
fix: disable default Camunda user task implementation in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.5.4
+
+* `FIX`: disable default Camunda user task implementation in templates ([#159](https://github.com/bpmn-io/bpmn-js-element-templates/pull/159))
+
 ## 2.5.3
 
 * `FIX`: keep documentation and execution listeners when template is removed ([#120](https://github.com/bpmn-io/bpmn-js-element-templates/pull/120))

--- a/src/cloud-element-templates/behavior/UserTaskBehavior.js
+++ b/src/cloud-element-templates/behavior/UserTaskBehavior.js
@@ -1,0 +1,35 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import { assign } from 'min-dash';
+
+/**
+ * Disable the default Camunda behavior for a newly created element
+ * if it is a templated `<bpmn:UserTask>`.
+ */
+export default class UserTaskBehavior extends CommandInterceptor {
+  constructor(eventBus, elementTemplates) {
+    super(eventBus);
+
+    this.preExecute('shape.create', function(event) {
+      const {
+        context: {
+          shape,
+          hints = {},
+        }
+      } = event;
+
+      if (is(shape, 'bpmn:UserTask') && elementTemplates.get(shape)) {
+        assign(hints, {
+          createElementsBehavior: false
+        });
+      }
+    });
+  }
+}
+
+UserTaskBehavior.$inject = [
+  'eventBus',
+  'elementTemplates'
+];

--- a/src/cloud-element-templates/behavior/index.js
+++ b/src/cloud-element-templates/behavior/index.js
@@ -4,6 +4,7 @@ import UpdatePropertiesOrderBehavior from './UpdatePropertiesOrderBehavior';
 import { ReferencedElementBehavior } from './ReferencedElementBehavior';
 import { GeneratedValueBehavior } from './GeneratedValueBehavior';
 import { CalledElementBehavior } from './CalledElementBehavior';
+import UserTaskBehavior from './UserTaskBehavior';
 
 export default {
   __init__: [
@@ -12,12 +13,14 @@ export default {
     'elementTemplatesGeneratedValueBehavior',
     'elementTemplatesReferencedElementBehavior',
     'elementTemplatesUpdatePropertiesOrderBehavior',
-    'elementTemplatesCalledElementBehavior'
+    'elementTemplatesCalledElementBehavior',
+    'elementTemplatesUserTaskBehavior'
   ],
   elementTemplatesReplaceBehavior: [ 'type', ReplaceBehavior ],
   elementTemplatesConditionalBehavior: [ 'type', ConditionalBehavior ],
   elementTemplatesGeneratedValueBehavior: [ 'type', GeneratedValueBehavior ],
   elementTemplatesReferencedElementBehavior: [ 'type', ReferencedElementBehavior ],
   elementTemplatesUpdatePropertiesOrderBehavior: [ 'type', UpdatePropertiesOrderBehavior ],
-  elementTemplatesCalledElementBehavior: [ 'type', CalledElementBehavior ]
+  elementTemplatesCalledElementBehavior: [ 'type', CalledElementBehavior ],
+  elementTemplatesUserTaskBehavior: [ 'type', UserTaskBehavior ]
 };

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -109,6 +109,8 @@ export default class ChangeElementTemplateHandler {
       this._updateCalledElement(element, oldTemplate, newTemplate);
 
       this._updateLinkedResources(element, oldTemplate, newTemplate);
+
+      this._updateZeebeUserTask(element, newTemplate);
     }
   }
 
@@ -1166,6 +1168,28 @@ export default class ChangeElementTemplateHandler {
       });
     });
   }
+
+  _updateZeebeUserTask = function(element, newTemplate) {
+
+    const commandStack = this._commandStack;
+
+    // check if element has zeebe:UserTask extension element
+    const extensionElements = getBusinessObject(element).get('extensionElements');
+    const userTaskExtension = findExtension(element, 'zeebe:UserTask');
+
+    // remove zeebe:UserTask (not supported in v2.5.x)
+    if (userTaskExtension) {
+      commandStack.execute('element.updateModdleProperties', {
+        element,
+        moddleElement: extensionElements,
+        properties: {
+          values: without(extensionElements.get('values'), userTaskExtension)
+        }
+      });
+
+      return;
+    }
+  };
 
 }
 

--- a/test/spec/cloud-element-templates/ElementTemplates.bpmn
+++ b/test/spec/cloud-element-templates/ElementTemplates.bpmn
@@ -48,6 +48,11 @@
     <bpmn:startEvent id="MessageStartEvent">
       <bpmn:messageEventDefinition id="MessageEventDefinition_1jjph4o" messageRef="Message" />
     </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
     <bpmn:group id="Group_1" categoryValueRef="CategoryValue_025ggwq" />
     <bpmn:textAnnotation id="TextAnnotation_1">
       <bpmn:text>Text Annotation</bpmn:text>
@@ -74,6 +79,9 @@
       <bpmndi:BPMNShape id="Activity_1m5rz19_di" bpmnElement="Task_3">
         <dc:Bounds x="400" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_05tjg7w" bpmnElement="Task_5">
+        <dc:Bounds x="160" y="520" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UnknownTemplateTask_di" bpmnElement="UnknownTemplateTask">
         <dc:Bounds x="400" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -98,8 +106,11 @@
       <bpmndi:BPMNShape id="Event_0rxdmt7_di" bpmnElement="MessageEvent">
         <dc:Bounds x="262" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_05tjg7w" bpmnElement="Task_5">
-        <dc:Bounds x="160" y="520" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1iahht4_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="160" y="620" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sitnpj_di" bpmnElement="SubProcess_1" isExpanded="false">
+        <dc:Bounds x="400" y="520" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_04x2ssk_di" bpmnElement="Gateway_1" isMarkerVisible="true">
         <dc:Bounds x="185" y="70" width="50" height="50" />
@@ -107,13 +118,6 @@
       <bpmndi:BPMNShape id="Event_0nu49eb_di" bpmnElement="MessageStartEvent">
         <dc:Bounds x="262" y="362" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0sitnpj_di" bpmnElement="SubProcess_1" isExpanded="false">
-        <dc:Bounds x="400" y="520" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1sxgene_di" bpmnElement="Association_1sxgene">
-        <di:waypoint x="850" y="160" />
-        <di:waypoint x="896" y="110" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
         <dc:Bounds x="560" y="160" width="300" height="300" />
         <bpmndi:BPMNLabel>
@@ -124,6 +128,10 @@
         <dc:Bounds x="860" y="80" width="100" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1sxgene_di" bpmnElement="Association_1sxgene">
+        <di:waypoint x="850" y="160" />
+        <di:waypoint x="896" y="110" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0h3d15h">

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -1110,6 +1110,38 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
     }));
 
 
+    it('should not create <zeebe:UserTask> for a templated element', inject(function(elementTemplates) {
+
+      // given
+      const template = require('./fixtures/user-task-no-binding.json');
+
+      // when
+      const task = elementTemplates.createElement(template);
+
+      // then
+      const updatedUserTask = findExtension(task, 'zeebe:UserTask');
+      expect(updatedUserTask).to.not.exist;
+    }));
+
+
+    it('should remove <zeebe:UserTask> when template is applied', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const templates = [
+        require('./fixtures/user-task-no-binding.json')
+      ];
+      elementTemplates.set(templates);
+      const task = elementRegistry.get('UserTask_1');
+
+      // when
+      const updatedTask = elementTemplates.applyTemplate(task, templates[0]);
+
+      // then
+      const updatedUserTask = findExtension(updatedTask, 'zeebe:UserTask');
+      expect(updatedUserTask).to.not.exist;
+    }));
+
+
     it('should fire elementTemplates.apply event', inject(function(elementRegistry, elementTemplates, eventBus) {
 
       // given

--- a/test/spec/cloud-element-templates/fixtures/user-task-no-binding.json
+++ b/test/spec/cloud-element-templates/fixtures/user-task-no-binding.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Zeebe User Task (no binding)",
+  "id": "cloud.element.templates.no.zeebe.user.task",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:UserTask"
+  },
+  "properties": []
+}


### PR DESCRIPTION
### Proposed Changes

This commit partially applies logic from d240af62f12b6767268501f608c5ac1783c0e33d in order to maintain pre-8.7 job worker implementation in the templates.

Related to https://jira.camunda.com/browse/SUPPORT-27874

https://github.com/user-attachments/assets/b2830931-54dd-44ea-baf9-280120940aa0

https://github.com/user-attachments/assets/dd7613db-e2c1-453a-acff-36f2b5bf6658

Once merged, I will release it as v2.5.4. There is no need to port it to `main`, and the fix is intended to be applied to WM 8.7

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
