### PR TITLE
refactor: add shared update behavior for single elements with properties

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1191,7 +1191,7 @@ export default class ChangeElementTemplateHandler {
 
     oldProperties.forEach((oldProperty) => {
       const properties = {
-        [getPropertyName(oldProperty.binding)]: undefined
+        [ getPropertyName(oldProperty.binding) ]: undefined
       };
 
       commandStack.execute('element.updateModdleProperties', {

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -352,7 +352,10 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
           expect(taskDefinition.$parent).to.equal(getBusinessObject(task).get('extensionElements'));
         }));
 
+
         it('should handle `zeebe:taskDefinition:type` to `zeebe:taskDefinition` change', inject(function(elementRegistry) {
+
+          // given
           const oldTemplate = createTemplate({
             type: 'Hidden',
             value: 'task-def-without-type',
@@ -382,11 +385,12 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
           expect(taskDefinition).to.exist;
           expect(taskDefinition.get('type')).to.equal('task-def-with-type');
-
-
         }));
 
+
         it('should remove zeebe:taskDefinition:type', inject(function(elementRegistry) {
+
+          // given
           const oldTemplate = createTemplate({
             type: 'Hidden',
             value: 'task-def-with-type',
@@ -408,10 +412,12 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
           const taskDefinition = findExtension(task, 'zeebe:TaskDefinition');
 
           expect(taskDefinition).not.to.exist;
-
         }));
 
+
         it('should remove unused properties', inject(function(elementRegistry) {
+
+          // given
           const oldTemplate = createTemplate([
             {
               type: 'Hidden',
@@ -454,8 +460,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
           expect(taskDefinition.get('retries')).to.not.exist;
           expect(taskDefinition.get('taskType')).to.equal('a-new-task-type');
         }));
-
-
       });
 
 


### PR DESCRIPTION
### Proposed Changes

`calledElement` and `taskDefinition` can share their update behavior as it follows the same steps, just parameterized by the property names and the type. 

This will become very useful when implementing other elements that follow the same pattern:
e.g.: `scriptTask`, `calledDecision`, `formDefintion` etc. 

Also: this fixes a bug when switching from  `zeebe:taskDefinition` to `zeebe:taskDefinition:type`. [A regression test was added](https://github.com/bpmn-io/bpmn-js-element-templates/pull/160/commits/2c0d686d2708153d5c8ce658e77309ea153552e0).

As this left previously covered lines uncovered, [additional tests were added](https://github.com/bpmn-io/bpmn-js-element-templates/pull/160/commits/47f2852220cb53e4a038ef342bcd4cd41414932b).

related to https://github.com/camunda/web-modeler/issues/14758

To review, you can manually diff the new method against the two old implementations.
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
