### PR TITLE
Handle `bpmn:Expression` type for BPMN properties.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.5.0",
+        "@bpmn-io/element-templates-validator": "^2.6.0",
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "bpmnlint": "^11.4.2",
         "classnames": "^2.5.1",
@@ -491,12 +491,13 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.5.0.tgz",
-      "integrity": "sha512-KIo9yDyyTGUDpRdLtSXbH3IPXy1b0sk/wn9IhQOg0wzFyCZOBHLlcmmQbDej6cApkfCAsITyYPf+Jw/mVYATYQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.6.0.tgz",
+      "integrity": "sha512-Uxz996O2HO0A9rA2qyYTyqnDfB08MwpOCYZ5MuLQqmQqjzIudYRx9J+O6FsY/OLxQJgzjzdlmgzy0bFPey7C9A==",
+      "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.24.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.25.1",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -644,9 +645,10 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.24.0.tgz",
-      "integrity": "sha512-TUfZ6zXtNjM/468mu6I0qOq4GSN579en2Bpncj7yv4mwwhibaJ4ieYpgw/YN/Iw9F+w5/cCPwfqtNuhPSE1SpA=="
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.25.1.tgz",
+      "integrity": "sha512-8Av7SNdcGja4LT7Gd6I8EuR/Rm6WTgmAcDFDC4rVVXNOjZJqNCveyYw4TmKd5H7s1sF2wWkZb+xYW5X8jymC9Q==",
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.18.4",
@@ -10349,12 +10351,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.5.0.tgz",
-      "integrity": "sha512-KIo9yDyyTGUDpRdLtSXbH3IPXy1b0sk/wn9IhQOg0wzFyCZOBHLlcmmQbDej6cApkfCAsITyYPf+Jw/mVYATYQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.6.0.tgz",
+      "integrity": "sha512-Uxz996O2HO0A9rA2qyYTyqnDfB08MwpOCYZ5MuLQqmQqjzIudYRx9J+O6FsY/OLxQJgzjzdlmgzy0bFPey7C9A==",
       "requires": {
         "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.24.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.25.1",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -10474,9 +10476,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.24.0.tgz",
-      "integrity": "sha512-TUfZ6zXtNjM/468mu6I0qOq4GSN579en2Bpncj7yv4mwwhibaJ4ieYpgw/YN/Iw9F+w5/cCPwfqtNuhPSE1SpA=="
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.25.1.tgz",
+      "integrity": "sha512-8Av7SNdcGja4LT7Gd6I8EuR/Rm6WTgmAcDFDC4rVVXNOjZJqNCveyYw4TmKd5H7s1sF2wWkZb+xYW5X8jymC9Q=="
     },
     "@codemirror/autocomplete": {
       "version": "6.18.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.5.0",
+    "@bpmn-io/element-templates-validator": "^2.6.0",
     "@bpmn-io/extract-process-variables": "^1.0.1",
     "bpmnlint": "^11.4.2",
     "classnames": "^2.5.1",

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -47,6 +47,7 @@ import {
   getRoot
 } from '../../utils/ElementUtil';
 import { removeMessage } from '../util/rootElementUtil';
+import { isExpression, createExpression } from '../util/bpmnExpressionUtil';
 
 /**
  * Applies an element template to an element. Sets `zeebe:modelerTemplate` and
@@ -220,7 +221,12 @@ export default class ChangeElementTemplateHandler {
         return;
       }
 
-      properties[ newBindingName ] = newPropertyValue;
+      let assignedValue = newPropertyValue;
+      if (isExpression(businessObject, newBindingName)) {
+        assignedValue = createExpression(newPropertyValue, businessObject, this._bpmnFactory);
+      }
+
+      properties[ newBindingName ] = assignedValue;
 
       commandStack.execute('element.updateModdleProperties', {
         element,

--- a/src/cloud-element-templates/create/PropertyBindingProvider.js
+++ b/src/cloud-element-templates/create/PropertyBindingProvider.js
@@ -1,10 +1,12 @@
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 import { getDefaultValue } from '../Helper';
+import { isExpression, createExpression } from '../util/bpmnExpressionUtil';
 
 
 export default class PropertyBindingProvider {
   static create(element, options) {
     const {
+      bpmnFactory,
       property
     } = options;
 
@@ -16,9 +18,15 @@ export default class PropertyBindingProvider {
       name
     } = binding;
 
-    const value = getDefaultValue(property);
+    let value = getDefaultValue(property);
 
     const businessObject = getBusinessObject(element);
+
+    if (isExpression(businessObject, name)) {
+      const expression = createExpression(value, businessObject, bpmnFactory);
+
+      value = expression;
+    }
 
     businessObject[name] = value;
   }

--- a/src/cloud-element-templates/util/bpmnExpressionUtil.js
+++ b/src/cloud-element-templates/util/bpmnExpressionUtil.js
@@ -1,0 +1,28 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import { createElement } from '../../utils/ElementUtil';
+
+const EXPRESSION_TYPES = [
+  'bpmn:Expression',
+  'bpmn:FormalExpression'
+];
+
+export function isExpression(element, propertyName) {
+  const bo = getBusinessObject(element);
+
+  const descriptor = bo.$descriptor.propertiesByName[propertyName];
+
+  return descriptor && EXPRESSION_TYPES.includes(descriptor.type);
+}
+
+export function createExpression(value, parent, bpmnFactory) {
+  const expression = createElement('bpmn:FormalExpression', { body: value }, parent, bpmnFactory);
+
+  return expression;
+}
+
+export function getExpressionValue(element, propertyName) {
+  const bo = getBusinessObject(element);
+  const expression = bo.get(propertyName);
+
+  return expression?.get('body') || undefined;
+}

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -354,7 +354,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
   if (PROPERTY_BINDING_TYPES.includes(type)) {
 
     const propertyType = businessObject.$descriptor.propertiesByName[ name ]?.type;
-    let updatedProperty = name;
+    let propertyName = name;
 
     if (!propertyType || propertyType === 'String') {
 
@@ -377,7 +377,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
 
         // re-use existing expression
         businessObject = existingExpression;
-        updatedProperty = 'body';
+        propertyName = 'body';
         propertyValue = value || '';
       } else {
         propertyValue = createExpression(value, businessObject, bpmnFactory);
@@ -394,7 +394,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
         context: {
           ...context,
           moddleElement: businessObject,
-          properties: { [ updatedProperty ]: propertyValue }
+          properties: { [ propertyName ]: propertyValue }
         }
       });
     } else {

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -371,7 +371,17 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
         propertyValue = undefined;
       }
     } else if (EXPRESSION_TYPES.includes(propertyType)) {
-      propertyValue = createExpression(value, businessObject, bpmnFactory);
+      const existingExpression = businessObject.get(name);
+
+      if (existingExpression && is(existingExpression, 'bpmn:FormalExpression')) {
+
+        // re-use existing expression
+        businessObject = existingExpression;
+        updatedProperty = 'body';
+        propertyValue = value || '';
+      } else {
+        propertyValue = createExpression(value, businessObject, bpmnFactory);
+      }
     } else {
 
       // unsupported non-primitive types cannot be set

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -25,6 +25,7 @@ import diagramXML from './ElementTemplates.bpmn';
 import integrationXML from './fixtures/integration.bpmn';
 import messageTemplates from './ElementTemplates.message-templates.json';
 import enginesTemplates from './ElementTemplates.engines-templates.json';
+import completionConditionTemplates from './fixtures/completion-condition.json';
 
 import templates from './fixtures/simple';
 import falsyVersionTemplate from './fixtures/falsy-version';
@@ -1218,6 +1219,33 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
         element: task,
         newTemplate
       });
+    }));
+
+
+    it('should apply a template with a completion condition', inject(function(elementRegistry, elementTemplates) {
+
+      // given
+      const templates = completionConditionTemplates;
+      elementTemplates.set(templates);
+
+      const template = templates[0];
+      const task = elementRegistry.get('Task_1');
+
+      // assume
+      expect(template).to.exist;
+
+      // when
+      const updatedTask = elementTemplates.applyTemplate(task, template);
+
+      // then
+      expect(updatedTask).to.exist;
+      expect(elementTemplates.get(updatedTask)).to.equal(template);
+
+      const businessObject = getBusinessObject(updatedTask);
+      const completionCondition = businessObject.get('completionCondition');
+
+      expect(completionCondition).to.exist;
+      expect(is(completionCondition, 'bpmn:Expression'), 'should be a BPMN expression').to.be.true;
     }));
   });
 

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -8,7 +8,8 @@ import {
 import { find } from 'min-dash';
 
 import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import coreModule from 'bpmn-js/lib/core';
@@ -32,6 +33,8 @@ import diagramXML from '../fixtures/simple.bpmn';
 import templates from './TemplatesElementFactory.json';
 
 import conditionTemplates from './TemplateElementFactory.conditions.json';
+
+import completionConditionTemplates from '../fixtures/completion-condition.json';
 
 
 describe('provider/cloud-element-templates - TemplateElementFactory', function() {
@@ -706,6 +709,25 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
 
       const subscription = findZeebeSubscription(message);
       expect(subscription.get('correlationKey')).to.match(uuidRegex, 'correlation key is not a uuid');
+    }));
+  });
+
+
+  describe('completion condition', function() {
+
+    it('should create element with completion condition', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = completionConditionTemplates[0];
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+      const businessObject = getBusinessObject(element);
+
+      // then
+      const completionCondition = businessObject.get('completionCondition');
+      expect(completionCondition).to.exist;
+      expect(is(completionCondition, 'bpmn:Expression'), 'should be a BPMN expression').to.be.true;
     }));
   });
 

--- a/test/spec/cloud-element-templates/fixtures/completion-condition.json
+++ b/test/spec/cloud-element-templates/fixtures/completion-condition.json
@@ -1,0 +1,27 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Completion condition template",
+    "id": "completion-condition",
+    "version": 1,
+    "description": "",
+    "appliesTo": [
+      "bpmn:Activity"
+    ],
+    "elementType": {
+      "value": "bpmn:AdHocSubProcess"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "=foo",
+        "binding": {
+          "type": "property",
+          "name": "completionCondition"
+        },
+        "feel": "required",
+        "label": "completion condition"
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
@@ -6,7 +6,7 @@
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="booleanField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="booleanField.feel.static" />
     <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="booleanField.feel.no-feel" />
-    <bpmn:adHocSubProcess id="property" name="property" cancelRemainingInstances="false" zeebe:modelerTemplate="booleanField.property" />
+    <bpmn:adHocSubProcess id="property" name="property" cancelRemainingInstances="false" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.bpmn
@@ -6,6 +6,7 @@
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="booleanField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="booleanField.feel.static" />
     <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="booleanField.feel.no-feel" />
+    <bpmn:adHocSubProcess id="property" name="property" cancelRemainingInstances="false" zeebe:modelerTemplate="booleanField.property" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
@@ -27,6 +28,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07xiq11" bpmnElement="no-feel">
         <dc:Bounds x="290" y="283" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_property" bpmnElement="property">
+        <dc:Bounds x="160" y="283" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.json
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.json
@@ -113,6 +113,7 @@
     },
     "properties": [
       {
+        "value": false,
         "type": "Boolean",
         "binding": {
           "type": "property",

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.json
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.json
@@ -99,5 +99,27 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "booleanField.property",
+    "id": "booleanField.property",
+    "description": "",
+    "appliesTo": [
+      "bpmn:Activity"
+    ],
+    "elementType": {
+      "value": "bpmn:AdHocSubProcess"
+    },
+    "properties": [
+      {
+        "type": "Boolean",
+        "binding": {
+          "type": "property",
+          "name": "cancelRemainingInstances"
+        },
+        "label": "cancel remaining instances"
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.spec.js
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.spec.js
@@ -58,6 +58,34 @@ describe('provider/cloud-element-templates - BooleanProperty', function() {
   }));
 
 
+  describe('property', function() {
+
+    let entry, input;
+
+    beforeEach(async function() {
+      await expectSelected('property');
+      entry = findEntry('custom-entry-booleanField.property-0', container);
+      input = findInput('checkbox', entry);
+    });
+
+    it('should render boolean field', async function() {
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should be editable', async function() {
+
+      // when
+      await input.click();
+
+      // then
+      expectProperty('property', 'cancelRemainingInstances', true);
+    });
+  });
+
+
   describe('feel disabled', function() {
 
     let entry, input;
@@ -277,6 +305,17 @@ describe('provider/cloud-element-templates - BooleanProperty', function() {
 
 // helpers //////////
 
+function expectProperty(id, name, value) {
+  return getBpmnJS().invoke(function(elementRegistry) {
+    const element = elementRegistry.get(id);
+
+    const bo = getBusinessObject(element);
+
+    const property = bo.get(name);
+
+    expect(property).to.eql(value);
+  });
+}
 
 function expectZeebeProperty(id, name, value) {
   return getBpmnJS().invoke(function(elementRegistry) {

--- a/test/spec/cloud-element-templates/properties/BooleanProperty.spec.js
+++ b/test/spec/cloud-element-templates/properties/BooleanProperty.spec.js
@@ -2,7 +2,8 @@ import TestContainer from 'mocha-test-container-support';
 
 import {
   bootstrapPropertiesPanel,
-  getBpmnJS
+  getBpmnJS,
+  inject
 } from 'test/TestHelper';
 
 import {
@@ -62,11 +63,17 @@ describe('provider/cloud-element-templates - BooleanProperty', function() {
 
     let entry, input;
 
-    beforeEach(async function() {
-      await expectSelected('property');
+    beforeEach(inject(async function(elementTemplates) {
+      const element = await expectSelected('property');
+      const template = templates.find(t => t.id === 'booleanField.property');
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
       entry = findEntry('custom-entry-booleanField.property-0', container);
       input = findInput('checkbox', entry);
-    });
+    }));
 
     it('should render boolean field', async function() {
 
@@ -78,7 +85,7 @@ describe('provider/cloud-element-templates - BooleanProperty', function() {
     it('should be editable', async function() {
 
       // when
-      await input.click();
+      await act(() => input.click());
 
       // then
       expectProperty('property', 'cancelRemainingInstances', true);

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -96,6 +96,7 @@
         <zeebe:taskDefinition type="aType" retries="1" />
       </bpmn:extensionElements>
     </bpmn:scriptTask>
+    <bpmn:task id="nonexisting" name="non-existing propert" zeebe:modelerTemplate="my.example.non-existing-property" test="value" />
   </bpmn:process>
   <bpmn:message id="Message" name="name">
     <bpmn:extensionElements>
@@ -196,6 +197,9 @@
       <bpmndi:BPMNShape id="BPMNShape_02sbchp" bpmnElement="ScriptTask_taskDefinition">
         <dc:Bounds x="480" y="1020" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="nonexisting_di" bpmnElement="nonexisting">
+        <dc:Bounds x="30" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
@@ -4,11 +4,15 @@
     <bpmn:adHocSubProcess id="AdHocSubProcess" name="completion-condition" zeebe:modelerTemplate="completion-condition" zeebe:modelerTemplateVersion="1">
       <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=foo</bpmn:completionCondition>
     </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="AdHocSubProcess_empty" name="no-expression" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_1d5ac68_di" bpmnElement="AdHocSubProcess">
         <dc:Bounds x="160" y="80" width="400" height="400" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_di" bpmnElement="AdHocSubProcess_empty">
+        <dc:Bounds x="160" y="580" width="400" height="400" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:adHocSubProcess id="AdHocSubProcess" name="completion-condition" zeebe:modelerTemplate="completion-condition" zeebe:modelerTemplateVersion="1">
-      <bpmn:completionCondition>=foo</bpmn:completionCondition>
+      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=foo</bpmn:completionCondition>
     </bpmn:adHocSubProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn-expression.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="completion-condition" zeebe:modelerTemplate="completion-condition" zeebe:modelerTemplateVersion="1">
+      <bpmn:completionCondition>=foo</bpmn:completionCondition>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1d5ac68_di" bpmnElement="AdHocSubProcess">
+        <dc:Bounds x="160" y="80" width="400" height="400" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.complex-property.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.complex-property.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Complex property",
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "my.custom.ComplexProperty",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "Complex type",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "extensionElements"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -862,5 +862,23 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Non-existing property",
+    "id": "my.example.non-existing-property",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "type": "String",
+        "value": "my Task",
+        "binding": {
+          "type": "property",
+          "name": "test"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -78,6 +78,8 @@ import placeholderElementTemplates from './CustomProperties.placeholder.json';
 import bpmnExpressionXML from './CustomProperties.bpmn-expression.bpmn';
 import bpmnExpressionTemplates from '../fixtures/completion-condition.json';
 
+import complexPropertyTemplates from './CustomProperties.complex-property.json';
+
 
 describe('provider/cloud-element-templates - CustomProperties', function() {
 
@@ -234,6 +236,44 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(expression === initialExpression, 'should reuse expression').to.be.true;
     });
+  });
+
+
+  describe('property (complex)', function() {
+
+    let errorHandler;
+
+    beforeEach(function() {
+      errorHandler = window.onerror;
+    });
+
+    afterEach(function() {
+      window.onerror = errorHandler;
+    });
+
+    it('should fail to change', inject(async function(elementTemplates) {
+
+      // given
+      const task = await expectSelected('Task_1');
+      elementTemplates.set(complexPropertyTemplates);
+      await act(() => {
+        elementTemplates.applyTemplate(task, complexPropertyTemplates[0]);
+      });
+      const initialValue = task.businessObject.get('extensionElements');
+      const entry = findEntry('custom-entry-my.custom.ComplexProperty-0', container),
+            input = findInput('text', entry);
+
+      // input event causes an uncaught error which cannot be caught in try/catch
+      const spy = sinon.spy();
+      window.onerror = spy;
+
+      // when
+      changeInput(input, 'foo');
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+      expect(task.businessObject.get('extensionElements')).to.equal(initialValue);
+    }));
   });
 
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -236,6 +236,33 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(expression === initialExpression, 'should reuse expression').to.be.true;
     });
+
+
+    it('should create bpmn:FormalExpression if non-existing', inject(async function(elementTemplates) {
+
+      // given
+      const task = await expectSelected('AdHocSubProcess_empty'),
+            businessObject = getBusinessObject(task);
+
+      await act(() => {
+        elementTemplates.applyTemplate(task, bpmnExpressionTemplates[0]);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-completion-condition-0', container),
+            editor = findEditor(entry);
+
+      await act(() => {
+        editor.textContent = 'bar';
+      });
+
+      // then
+      const expression = businessObject.get('completionCondition');
+
+      expect(expression).to.exist;
+      expect(is(expression, 'bpmn:FormalExpression')).to.be.true;
+      expect(expression.get('body')).to.equal('=bar');
+    }));
   });
 
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -212,6 +212,28 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(is(expression, 'bpmn:FormalExpression')).to.be.true;
       expect(expression.get('body')).to.equal('=bar');
     });
+
+
+    it('should re-use existing bpmn:FormalExpression', async function() {
+
+      // given
+      const task = await expectSelected('AdHocSubProcess'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const initialExpression = businessObject.get('completionCondition');
+      const entry = findEntry('custom-entry-completion-condition-0', container),
+            editor = findEditor(entry);
+
+      await act(() => {
+        editor.textContent = 'bar';
+      });
+
+      // then
+      const expression = businessObject.get('completionCondition');
+
+      expect(expression === initialExpression, 'should reuse expression').to.be.true;
+    });
   });
 
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -277,6 +277,62 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('property (non-existing)', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('nonexisting');
+
+      // then
+      const entry = findEntry('custom-entry-my.example.non-existing-property-0', container);
+
+      expect(entry).to.exist;
+
+      const input = findInput('text', entry);
+
+      expect(input).to.exist;
+      expect(input.value).to.equal('value');
+    });
+
+
+    it('should change', async function() {
+
+      // given
+      const task = await expectSelected('nonexisting'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-my.example.non-existing-property-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, 'foo');
+
+      // then
+      expect(input.value).to.equal('foo');
+      expect(businessObject.get('test')).to.equal('foo');
+    });
+
+
+    it('should change String property to empty string when erased', async function() {
+
+      // given
+      const task = await expectSelected('nonexisting'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-my.example.non-existing-property-0', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      expect(input.value).to.eql('');
+      expect(businessObject.get('test')).to.be.eql('');
+    });
+  });
+
+
   describe('zeebe:taskDefinition:type', function() {
 
     it('should display', async function() {

--- a/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
@@ -6,7 +6,7 @@
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="numberField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="numberField.feel.static" />
     <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="numberField.feel.no-feel" />
-    <bpmn:serviceTask id="property" name="property" zeebe:modelerTemplate="numberField.property" />
+    <bpmn:serviceTask id="property" name="property" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">

--- a/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.bpmn
@@ -6,6 +6,7 @@
     <bpmn:serviceTask id="optional" name="feel optional" zeebe:modelerTemplate="numberField.feel.optional" />
     <bpmn:serviceTask id="static" name="feel static" zeebe:modelerTemplate="numberField.feel.static" />
     <bpmn:serviceTask id="no-feel" name="no feel" zeebe:modelerTemplate="numberField.feel.no-feel" />
+    <bpmn:serviceTask id="property" name="property" zeebe:modelerTemplate="numberField.property" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1gpk8uz">
@@ -27,6 +28,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07xiq11" bpmnElement="no-feel">
         <dc:Bounds x="290" y="283" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_property" bpmnElement="property">
+        <dc:Bounds x="160" y="283" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/properties/NumberProperty.json
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.json
@@ -100,5 +100,23 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "property",
+    "id": "numberField.property",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "NumberProperty",
+        "type": "Number",
+        "binding": {
+          "type": "property",
+          "name": "completionQuantity"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
@@ -3,7 +3,8 @@ import TestContainer from 'mocha-test-container-support';
 import {
   bootstrapPropertiesPanel,
   changeInput,
-  getBpmnJS
+  getBpmnJS,
+  inject
 } from 'test/TestHelper';
 
 import {
@@ -64,11 +65,17 @@ describe('provider/cloud-element-templates - NumberProperty', function() {
   describe('property', function() {
     let entry, input;
 
-    beforeEach(async function() {
-      await expectSelected('property');
+    beforeEach(inject(async function(elementTemplates) {
+      const element = await expectSelected('property');
+      const template = templates.find(t => t.id === 'numberField.property');
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
       entry = findEntry('custom-entry-numberField.property-0', container);
       input = findInput('number', entry);
-    });
+    }));
 
     it('should render number field', async function() {
 

--- a/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
@@ -103,6 +103,18 @@ describe('provider/cloud-element-templates - NumberProperty', function() {
       const errorMessage = domQuery('.bio-properties-panel-error', entry);
       expect(errorMessage).not.to.exist;
     });
+
+
+    it('should NOT accept NaN', async function() {
+
+      const initialValue = 1;
+
+      // when
+      await changeInput(input, 'NaN');
+
+      // then
+      expectProperty('property', 'completionQuantity', initialValue);
+    });
   });
 
 

--- a/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
+++ b/test/spec/cloud-element-templates/properties/NumberProperty.spec.js
@@ -61,6 +61,44 @@ describe('provider/cloud-element-templates - NumberProperty', function() {
   }));
 
 
+  describe('property', function() {
+    let entry, input;
+
+    beforeEach(async function() {
+      await expectSelected('property');
+      entry = findEntry('custom-entry-numberField.property-0', container);
+      input = findInput('number', entry);
+    });
+
+    it('should render number field', async function() {
+
+      // then
+      expect(input).to.exist;
+    });
+
+
+    it('should be editable', async function() {
+
+      // when
+      await changeInput(input, '123');
+
+      // then
+      expectProperty('property', 'completionQuantity', 123);
+    });
+
+
+    it('should accept scientific notation', async function() {
+
+      // when
+      await changeInput(input, '1.23e100');
+
+      // then
+      const errorMessage = domQuery('.bio-properties-panel-error', entry);
+      expect(errorMessage).not.to.exist;
+    });
+  });
+
+
   describe('feel disabled', function() {
 
     let entry, input;
@@ -332,6 +370,17 @@ describe('provider/cloud-element-templates - NumberProperty', function() {
 
 // helpers //////////
 
+function expectProperty(id, name, value) {
+  return getBpmnJS().invoke(function(elementRegistry) {
+    const element = elementRegistry.get(id);
+
+    const bo = getBusinessObject(element);
+
+    const property = bo.get(name);
+
+    expect(property).to.eql(value);
+  });
+}
 
 function expectZeebeProperty(id, name, value) {
   return getBpmnJS().invoke(function(elementRegistry) {


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

When a template defines `completionCondition`, it should be created and updated as a `bpmn:Expression` type. We will use a specialization `bpmn:FormalExpression` as this is the approach taken in https://github.com/bpmn-io/bpmn-js-properties-panel, and also supports automation while the base type can be in natural language.

Related to https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/2

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
