### PR TITLE
Keep groups closed when template is first applied

### DIFF
--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
@@ -93,7 +93,7 @@ function addCustomGroup(groups, props) {
     element,
     id,
     label,
-    openByDefault = true,
+    openByDefault = false,
     properties,
     templateId,
     tooltip

--- a/src/element-templates/properties-panel/properties/CustomProperties.js
+++ b/src/element-templates/properties-panel/properties/CustomProperties.js
@@ -160,7 +160,7 @@ function addCustomGroup(groups, props) {
     label,
     component: Group,
     entries: [],
-    shouldOpen: true
+    shouldOpen: false
   };
 
   properties.forEach((property, index) => {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1988,7 +1988,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
-    it('should open custom groups by default', async function() {
+    it('should not open custom groups by default', async function() {
 
       // given
       await expectSelected('ServiceTask_groupsCollapsed');
@@ -1997,8 +1997,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       var customGroups = [
         [ getGroupById('ElementTemplates__CustomProperties-collapsed', container), false ],
         [ getGroupById('ElementTemplates__CustomProperties-open', container), true ],
-        [ getGroupById('ElementTemplates__CustomProperties-unspecified', container), true ],
-        [ getGroupById('ElementTemplates__CustomProperties', container), true ]
+        [ getGroupById('ElementTemplates__CustomProperties-unspecified', container), false ],
+        [ getGroupById('ElementTemplates__CustomProperties', container), false ]
       ];
 
       // then
@@ -2057,19 +2057,19 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
-    it('should open default group', async function() {
+    it('should not open default group', async function() {
 
       // given
       await expectSelected('ServiceTask_noGroups');
 
       // when
-      var tempalteGroup = getGroupById('ElementTemplates__Template', container);
+      var templateGroup = getGroupById('ElementTemplates__Template', container);
       var customPropertiesGroup = getGroupById('ElementTemplates__CustomProperties', container);
 
 
       // then
-      expectGroupOpen(tempalteGroup, false);
-      expectGroupOpen(customPropertiesGroup, true);
+      expectGroupOpen(templateGroup, false);
+      expectGroupOpen(customPropertiesGroup, false);
     });
 
 

--- a/test/spec/element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/element-templates/properties/CustomProperties.spec.js
@@ -1777,7 +1777,7 @@ describe('provider/element-templates - CustomProperties', function() {
     });
 
 
-    it('should open defined groups', async function() {
+    it('should not open defined groups', async function() {
 
       // given
       await expectSelected('ServiceTask_1');
@@ -1792,7 +1792,7 @@ describe('provider/element-templates - CustomProperties', function() {
 
       // then
       customGroups.forEach(function(group) {
-        expectGroupOpen(group, true);
+        expectGroupOpen(group, false);
       });
 
     });
@@ -1846,19 +1846,19 @@ describe('provider/element-templates - CustomProperties', function() {
     });
 
 
-    it('should open default group', async function() {
+    it('should not open default group', async function() {
 
       // given
       await expectSelected('ServiceTask_noGroups');
 
       // when
-      var tempalteGroup = getGroupById('ElementTemplates__Template', container);
+      var templateGroup = getGroupById('ElementTemplates__Template', container);
       var customPropertiesGroup = getGroupById('ElementTemplates__CustomProperties', container);
 
 
       // then
-      expectGroupOpen(tempalteGroup, false);
-      expectGroupOpen(customPropertiesGroup, true);
+      expectGroupOpen(templateGroup, false);
+      expectGroupOpen(customPropertiesGroup, false);
     });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5039

### Proposed Changes

Change the default for groups to be collapsed by default, can be overwritten by `openByDefault: true` for zeebe element templates (cf. https://github.com/camunda/element-templates-json-schema/pull/177)

<img width="353" alt="image" src="https://github.com/user-attachments/assets/384d8087-a786-4378-aeb9-6b2d6fba47fc" />

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
