### PR TITLE
WIP: reproduce changeTemplate.postExecute multiple fire bug

### DIFF
--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -148,6 +148,15 @@ const LogTemplateErrorsModule = {
   } ]
 };
 
+const ElementTemplateChangedModule = {
+
+  __init__: [ function(eventBus) {
+
+    eventBus.on('commandStack.propertiesPanel.zeebe.changeTemplate.postExecute', function() {
+      console.log('commandStack.propertiesPanel.zeebe.changeTemplate.postExecute handler executed');
+    });
+  } ]
+};
 
 describe('<BpmnPropertiesPanelRenderer>', function() {
 
@@ -249,7 +258,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           CreateAppendElementTemplatesModule,
           ChangeEnginesModule,
           LogTemplateErrorsModule,
-          LintingModule
+          LintingModule,
+          ElementTemplateChangedModule
         ],
         moddleExtensions: {
           zeebe: ZeebeModdle,

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -153,7 +153,7 @@ const ElementTemplateChangedModule = {
   __init__: [ function(eventBus) {
 
     eventBus.on('commandStack.propertiesPanel.zeebe.changeTemplate.postExecute', function() {
-      console.log('commandStack.propertiesPanel.zeebe.changeTemplate.postExecute handler executed');
+      console.error('commandStack.propertiesPanel.zeebe.changeTemplate.postExecute', new Error('handler executed'));
     });
   } ]
 };

--- a/test/spec/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/cloud-element-templates/fixtures/complex.json
@@ -1666,5 +1666,377 @@
         }
       }
     ]
+  },
+  {
+    "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name" : "AWS S3 Outbound Connector",
+    "id" : "io.camunda.connectors.aws.s3.v1",
+    "description" : "Execute S3 requests",
+    "metadata" : {
+      "keywords" : [ ]
+    },
+    "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
+    "version" : 1,
+    "category" : {
+      "id" : "connectors",
+      "name" : "Connectors"
+    },
+    "appliesTo" : [ "bpmn:Task" ],
+    "elementType" : {
+      "value" : "bpmn:ServiceTask"
+    },
+    "groups" : [ {
+      "id" : "authentication",
+      "label" : "Authentication"
+    }, {
+      "id" : "configuration",
+      "label" : "Configuration"
+    }, {
+      "id" : "action",
+      "label" : "Action"
+    }, {
+      "id" : "deleteObject",
+      "label" : "Delete an object"
+    }, {
+      "id" : "uploadObject",
+      "label" : "Upload an object"
+    }, {
+      "id" : "downloadObject",
+      "label" : "Download an object"
+    }, {
+      "id" : "output",
+      "label" : "Output mapping"
+    }, {
+      "id" : "error",
+      "label" : "Error handling"
+    }, {
+      "id" : "retries",
+      "label" : "Retries"
+    } ],
+    "properties" : [ {
+      "value" : "io.camunda:aws-s3:1",
+      "binding" : {
+        "property" : "type",
+        "type" : "zeebe:taskDefinition"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "authentication.type",
+      "label" : "Authentication",
+      "description" : "Specify AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-lambda/#aws-authentication-types\" target=\"_blank\">documentation page</a>",
+      "value" : "credentials",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "authentication.type",
+        "type" : "zeebe:input"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+        "value" : "defaultCredentialsChain"
+      }, {
+        "name" : "Credentials",
+        "value" : "credentials"
+      } ]
+    }, {
+      "id" : "authentication.accessKey",
+      "label" : "Access key",
+      "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "authentication.accessKey",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "authentication.secretKey",
+      "label" : "Secret key",
+      "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "authentication",
+      "binding" : {
+        "name" : "authentication.secretKey",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      },
+      "type" : "String"
+    }, {
+      "id" : "configuration.region",
+      "label" : "Region",
+      "description" : "Specify the AWS region",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "configuration",
+      "binding" : {
+        "name" : "configuration.region",
+        "type" : "zeebe:input"
+      },
+      "type" : "String"
+    }, {
+      "id" : "configuration.endpoint",
+      "label" : "Endpoint",
+      "description" : "Specify endpoint if need to use custom endpoint",
+      "optional" : true,
+      "group" : "configuration",
+      "binding" : {
+        "name" : "configuration.endpoint",
+        "type" : "zeebe:input"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "actionDiscriminator",
+      "label" : "Action",
+      "value" : "uploadObject",
+      "group" : "action",
+      "binding" : {
+        "name" : "actionDiscriminator",
+        "type" : "zeebe:input"
+      },
+      "type" : "Dropdown",
+      "choices" : [ {
+        "name" : "Delete object",
+        "value" : "deleteObject"
+      }, {
+        "name" : "Download object",
+        "value" : "downloadObject"
+      }, {
+        "name" : "Upload object",
+        "value" : "uploadObject"
+      } ]
+    }, {
+      "id" : "deleteActionBucket",
+      "label" : "AWS bucket",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "deleteObject",
+      "binding" : {
+        "name" : "action.bucket",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "deleteObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Bucket from where an object should be deleted",
+      "type" : "String"
+    }, {
+      "id" : "deleteActionKey",
+      "label" : "AWS key",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "deleteObject",
+      "binding" : {
+        "name" : "action.key",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "deleteObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Key of the object which should be deleted",
+      "type" : "String"
+    }, {
+      "id" : "uploadActionBucket",
+      "label" : "AWS bucket",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "uploadObject",
+      "binding" : {
+        "name" : "action.bucket",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "uploadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Bucket from where an object should be uploaded",
+      "type" : "String"
+    }, {
+      "id" : "uploadActionKey",
+      "label" : "AWS key",
+      "optional" : true,
+      "feel" : "optional",
+      "group" : "uploadObject",
+      "binding" : {
+        "name" : "action.key",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "uploadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Key of the uploaded object, if not given. The file name from the document metadata will be used",
+      "type" : "String"
+    }, {
+      "id" : "uploadActionDocument",
+      "label" : "Document",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "required",
+      "group" : "uploadObject",
+      "binding" : {
+        "name" : "action.document",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "uploadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Document to be uploaded on AWS S3",
+      "type" : "String"
+    }, {
+      "id" : "downloadActionBucket",
+      "label" : "AWS bucket",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "downloadObject",
+      "binding" : {
+        "name" : "action.bucket",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "downloadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Bucket from where an object should be downloaded",
+      "type" : "String"
+    }, {
+      "id" : "downloadActionKey",
+      "label" : "AWS key",
+      "optional" : false,
+      "constraints" : {
+        "notEmpty" : true
+      },
+      "feel" : "optional",
+      "group" : "downloadObject",
+      "binding" : {
+        "name" : "action.key",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "downloadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "Key of the object which should be download",
+      "type" : "String"
+    }, {
+      "id" : "downloadActionAsFile",
+      "label" : "Create document",
+      "optional" : false,
+      "value" : true,
+      "feel" : "static",
+      "group" : "downloadObject",
+      "binding" : {
+        "name" : "action.asFile",
+        "type" : "zeebe:input"
+      },
+      "condition" : {
+        "property" : "actionDiscriminator",
+        "equals" : "downloadObject",
+        "type" : "simple"
+      },
+      "tooltip" : "If set to true, a document reference will be created. If set to false, the content will be extracted and provided inside the response.",
+      "type" : "Boolean"
+    }, {
+      "id" : "resultVariable",
+      "label" : "Result variable",
+      "description" : "Name of variable to store the response in",
+      "group" : "output",
+      "binding" : {
+        "key" : "resultVariable",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "String"
+    }, {
+      "id" : "resultExpression",
+      "label" : "Result expression",
+      "description" : "Expression to map the response into process variables",
+      "feel" : "required",
+      "group" : "output",
+      "binding" : {
+        "key" : "resultExpression",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Text"
+    }, {
+      "id" : "errorExpression",
+      "label" : "Error expression",
+      "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+      "feel" : "required",
+      "group" : "error",
+      "binding" : {
+        "key" : "errorExpression",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Text"
+    }, {
+      "id" : "retryCount",
+      "label" : "Retries",
+      "description" : "Number of retries",
+      "value" : "3",
+      "feel" : "optional",
+      "group" : "retries",
+      "binding" : {
+        "property" : "retries",
+        "type" : "zeebe:taskDefinition"
+      },
+      "type" : "String"
+    }, {
+      "id" : "retryBackoff",
+      "label" : "Retry backoff",
+      "description" : "ISO-8601 duration to wait between retries",
+      "value" : "PT0S",
+      "group" : "retries",
+      "binding" : {
+        "key" : "retryBackoff",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "String"
+    } ],
+    "icon" : {
+      "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4xMjUgMy4wOTM4MUwxMC41MzEyIDguMDMxMzFMMTMuMTI1IDEyLjk2ODhMMTQuMTg3NSAxMi4zNzUxVjMuNjg3NTZMMTMuMTI1IDMuMDkzODFaIiBmaWxsPSIjRTI1NDQ0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTMuMTI1IDMuMDkzODFMNy45Mzc1IDMuNjg3NTZMNS4yOTY4OCA4LjAzMTMxTDcuOTM3NSAxMi4zNzUxTDEzLjEyNSAxMi45Njg4VjMuMDkzODFaIiBmaWxsPSIjN0IxRDEzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMi42NTYyNSAzLjA5MzgxTDEuODEyNSAzLjQ2ODgxVjEyLjU5MzhMMi42NTYyNSAxMi45Njg4TDcuOTM3NSA4LjAzMTMxTDIuNjU2MjUgMy4wOTM4MVoiIGZpbGw9IiM1ODE1MEQiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yLjY0NDUzIDMuMDgzMzFMNy45NDQxMyA0LjU1NTUzVjExLjYzODhMMi42NDQ1MyAxMi45NzIyVjMuMDgzMzFaIiBmaWxsPSIjRTI1NDQ0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNy45NDc1MiA1LjMzMzVMNS42OTcyNyA0Ljk3MjM3TDcuOTQ3NTIgMi40MTY4MUwxMC4xOTIyIDQuOTcyMzdMNy45NDc1MiA1LjMzMzVaIiBmaWxsPSIjNTgxNTBEIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTAuMTkyMiA0Ljk3MjM3TDcuOTQ0NzMgNS4zMzkwM0w1LjY5NzI3IDQuOTcyMzdWMi40MTY4MSIgZmlsbD0iIzU4MTUwRCIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTcuOTQ3NTIgMTAuNjk0NEw1LjY5NzI3IDExLjExMTFMNy45NDc1MiAxMy4zMDU1TDEwLjE5MjIgMTEuMTExMUw3Ljk0NzUyIDEwLjY5NDRaIiBmaWxsPSIjNTgxNTBEIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNy45Mzc1IDAuNTAwMDYxTDUuNjg3NSAxLjY4NzU2VjQuOTY4ODFMNy45NDQ1IDQuMzMzNDFMNy45Mzc1IDAuNTAwMDYxWiIgZmlsbD0iIzdCMUQxMyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTcuOTQ0NzMgNi4xMzg5OEw1LjY5NzI3IDYuMzgzNDVWOS42NTk2M0w3Ljk0NDczIDkuOTE2NzZWNi4xMzg5OFoiIGZpbGw9IiM3QjFEMTMiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03Ljk0NDczIDExLjY2NjZMNS42OTcyNyAxMS4xMDMxVjE0LjMyMzhMNy45NDQ3MyAxNS41VjExLjY2NjZaIiBmaWxsPSIjN0IxRDEzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTAuMTkxOCAxMS4xMDMxTDcuOTQ0MzQgMTEuNjY2OFYxNS41TDEwLjE5MTggMTQuMzIzOFYxMS4xMDMxWiIgZmlsbD0iI0UyNTQ0NCIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTcuOTQ0MzQgNi4xMzg5OEwxMC4xOTE4IDYuMzgzNDVWOS42NTk2M0w3Ljk0NDM0IDkuOTE2NzZWNi4xMzg5OFoiIGZpbGw9IiNFMjU0NDQiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03LjkzNzUgMC41MDAwNjFMMTAuMTg3NSAxLjY4NzU2VjQuOTY4ODFMNy45Mzc1IDQuMzQzODFWMC41MDAwNjFaIiBmaWxsPSIjRTI1NDQ0Ii8+Cjwvc3ZnPgo="
+    }
   }
 ]


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

⚠️ DO NOT MERGE ⚠️ 

This PR is a work in progress and is not ready to be merged.
So far, it is used to reproduce a bug that affects the `changeTemplate.postExecute` event handler.

When certain element templates are applied to an element, the `commandStack.propertiesPanel.zeebe.changeTemplate.postExecute` event is fired multiple times.

To reproduce it, change one element to an `AWS S3` connector.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
