### PR TITLE
test: add bindingType integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.6.0",
+        "@bpmn-io/element-templates-validator": "^2.7.0",
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "bpmnlint": "^11.4.2",
         "classnames": "^2.5.1",
@@ -491,13 +491,12 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.6.0.tgz",
-      "integrity": "sha512-Uxz996O2HO0A9rA2qyYTyqnDfB08MwpOCYZ5MuLQqmQqjzIudYRx9J+O6FsY/OLxQJgzjzdlmgzy0bFPey7C9A==",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.7.0.tgz",
+      "integrity": "sha512-udq4YGrTFo5hvteBW3Xk1lfi3Qo52Efz8mM30E1uPNXVyp/lmZlHhoKCX8CEAn179YFITZmToLKMESdcfZvO8w==",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.25.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.26.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -645,10 +644,9 @@
       }
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.25.1.tgz",
-      "integrity": "sha512-8Av7SNdcGja4LT7Gd6I8EuR/Rm6WTgmAcDFDC4rVVXNOjZJqNCveyYw4TmKd5H7s1sF2wWkZb+xYW5X8jymC9Q==",
-      "license": "MIT"
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.26.0.tgz",
+      "integrity": "sha512-dij6qz2H1t26zS10nidIWq2oqI5lljPDEw1ANNB/icfw8rzIgaSkg2KWCmeu2bKAKLcq3IGNJ/JeyuepMDH9EQ=="
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.18.4",
@@ -10351,12 +10349,12 @@
       }
     },
     "@bpmn-io/element-templates-validator": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.6.0.tgz",
-      "integrity": "sha512-Uxz996O2HO0A9rA2qyYTyqnDfB08MwpOCYZ5MuLQqmQqjzIudYRx9J+O6FsY/OLxQJgzjzdlmgzy0bFPey7C9A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.7.0.tgz",
+      "integrity": "sha512-udq4YGrTFo5hvteBW3Xk1lfi3Qo52Efz8mM30E1uPNXVyp/lmZlHhoKCX8CEAn179YFITZmToLKMESdcfZvO8w==",
       "requires": {
         "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.25.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.26.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       }
@@ -10476,9 +10474,9 @@
       }
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.25.1.tgz",
-      "integrity": "sha512-8Av7SNdcGja4LT7Gd6I8EuR/Rm6WTgmAcDFDC4rVVXNOjZJqNCveyYw4TmKd5H7s1sF2wWkZb+xYW5X8jymC9Q=="
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.26.0.tgz",
+      "integrity": "sha512-dij6qz2H1t26zS10nidIWq2oqI5lljPDEw1ANNB/icfw8rzIgaSkg2KWCmeu2bKAKLcq3IGNJ/JeyuepMDH9EQ=="
     },
     "@codemirror/autocomplete": {
       "version": "6.18.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "bpmn-js-create-append-anything": "^1.0.0",
         "bpmn-js-properties-panel": "^5.35.0",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js-behaviors": "^1.10.0",
+        "camunda-bpmn-js-behaviors": "^1.10.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.5.0",
         "copy-webpack-plugin": "^13.0.0",
@@ -3163,11 +3163,10 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
-      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.2.tgz",
+      "integrity": "sha512-SSoLQMxQpeYxcLCjx8xfo4qOvbHHlWyL9INqE+6y5vuPIP3hQ0drquPKssczyFpJXw79k6OLDS8gi6+AoS2lrA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -12275,9 +12274,9 @@
       "dev": true
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
-      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.2.tgz",
+      "integrity": "sha512-SSoLQMxQpeYxcLCjx8xfo4qOvbHHlWyL9INqE+6y5vuPIP3hQ0drquPKssczyFpJXw79k6OLDS8gi6+AoS2lrA==",
       "dev": true,
       "requires": {
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.6.0",
+    "@bpmn-io/element-templates-validator": "^2.7.0",
     "@bpmn-io/extract-process-variables": "^1.0.1",
     "bpmnlint": "^11.4.2",
     "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "bpmn-js-create-append-anything": "^1.0.0",
     "bpmn-js-properties-panel": "^5.35.0",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js-behaviors": "^1.10.0",
+    "camunda-bpmn-js-behaviors": "^1.10.2",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.5.0",
     "copy-webpack-plugin": "^13.0.0",

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1201,6 +1201,10 @@ export default class ChangeElementTemplateHandler {
     // (1) Remove extension if no new properties
 
     if (!newProperties.length) {
+      if (!extensionElement) {
+        return;
+      }
+
       commandStack.execute('element.updateModdleProperties', {
         element,
         moddleElement: businessObject,
@@ -1639,6 +1643,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_CALLED_DECISION) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_CALLED_ELEMENT) {
     return businessObject.get(bindingProperty);
   }
 

--- a/test/spec/cloud-element-templates/fixtures/binding-type-property.json
+++ b/test/spec/cloud-element-templates/fixtures/binding-type-property.json
@@ -1,0 +1,288 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template with Binding Type",
+    "id": "io.camunda.examples.Decision.BindingType",
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:BusinessRuleTask"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "aReusableRule",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      },
+      {
+        "type": "String",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Call Activity Template with Binding Type",
+    "id": "io.camunda.examples.CallActivity.BindingType",
+    "appliesTo": [
+      "bpmn:Activity"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "aProcessId",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "deployment"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Form Definition Template with Binding Type",
+    "id": "io.camunda.examples.FormDefinition.BindingType",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "String",
+        "value": "aFormId",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "formId"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Linked resources template with Binding Type",
+    "id": "io.camunda.examples.LinkedResource.BindingType",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "camunda:RPA",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "property": "resourceType",
+          "linkName": "RPAScript"
+        },
+        "value": "RPA"
+      },
+      {
+        "type": "String",
+        "feel": "optional",
+        "label": "Script ID",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "resourceId"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_00cqa19" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CalledElement" name="Called Element">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="paymentProcess" propagateAllChildVariables="false" propagateAllParentVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:businessRuleTask id="BusinessRuleTask_called_decision" name="Business Rule Task Called Decision">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="aReusableRule" resultVariable="aResultVariableName" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:businessRuleTask id="BusinessRuleTask_empty" name="Business Rule Task empty" />
+    <bpmn:serviceTask id="Service_Task" name="Service Task for LinkedResource" />
+    <bpmn:userTask id="User_Task" name="User Task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1nfgyhn_di" bpmnElement="CalledElement">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02u8j70_di" bpmnElement="BusinessRuleTask_called_decision">
+        <dc:Bounds x="160" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03sg3f9" bpmnElement="BusinessRuleTask_empty">
+        <dc:Bounds x="280" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y0kqdp_di" bpmnElement="Service_Task">
+        <dc:Bounds x="160" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ycivhy_di" bpmnElement="User_Task">
+        <dc:Bounds x="160" y="460" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.json
@@ -1,0 +1,288 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template with Binding Type",
+    "id": "io.camunda.examples.Decision.BindingType",
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:BusinessRuleTask"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "aReusableRule",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      },
+      {
+        "type": "String",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Call Activity Template with Binding Type",
+    "id": "io.camunda.examples.CallActivity.BindingType",
+    "appliesTo": [
+      "bpmn:Activity"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties": [
+      {
+        "type": "String",
+        "value": "aProcessId",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "deployment"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Form Definition Template with Binding Type",
+    "id": "io.camunda.examples.FormDefinition.BindingType",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "String",
+        "value": "aFormId",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "formId"
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Linked resources template with Binding Type",
+    "id": "io.camunda.examples.LinkedResource.BindingType",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "category": {
+      "name": "With binding type",
+      "id": "with-binding-type"
+    },
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "camunda:RPA",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "property": "resourceType",
+          "linkName": "RPAScript"
+        },
+        "value": "RPA"
+      },
+      {
+        "type": "String",
+        "feel": "optional",
+        "label": "Script ID",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "resourceId"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "type": "Dropdown",
+        "label": "Binding",
+        "id": "bindingType",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "bindingType"
+        },
+        "choices": [
+          {
+            "name": "Latest",
+            "value": "latest"
+          },
+          {
+            "name": "Deployment",
+            "value": "deployment"
+          },
+          {
+            "name": "Version Tag",
+            "value": "versionTag"
+          }
+        ],
+        "value": "latest"
+      },
+      {
+        "type": "String",
+        "label": "Version tag",
+        "value": "v1",
+        "binding": {
+          "type": "zeebe:linkedResource",
+          "linkName": "RPAScript",
+          "property": "versionTag"
+        },
+        "condition": {
+          "property": "bindingType",
+          "equals": "versionTag"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.spec.js
@@ -1,0 +1,647 @@
+import { act } from '@testing-library/preact';
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import { BpmnPropertiesPanelModule as BpmnPropertiesPanel } from 'bpmn-js-properties-panel';
+import { query as domQuery } from 'min-dom';
+import TestContainer from 'mocha-test-container-support';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject,
+  getBpmnJS
+} from 'test/TestHelper';
+
+import elementTemplatesModule from 'src/cloud-element-templates';
+import { findExtension } from 'src/cloud-element-templates/Helper';
+
+import diagramXML from './CustomProperties.bindingType.bpmn';
+import templates from './CustomProperties.bindingType.json';
+
+
+describe('provider/cloud-element-templates - CustomProperties - binding type property', function() {
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    container,
+    debounceInput: false,
+    elementTemplates: templates,
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    },
+    modules: [
+      BpmnPropertiesPanel,
+      coreModule,
+      elementTemplatesModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('calledDecision', function() {
+
+    it('should display', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('BusinessRuleTask_empty');
+      const template = templates.find(t => t.id === 'io.camunda.examples.Decision.BindingType');
+
+      // when
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // then
+      const entry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-2', container);
+      const select = findSelect(entry);
+      const options = Array.from(select.options).map(({ selected, value }) => ({ selected, value }));
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(options).to.eql([
+        { value: 'latest', selected: true },
+        { value: 'deployment', selected: false },
+        { value: 'versionTag', selected: false }
+      ]);
+    }));
+
+
+    it('should change, setting bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('BusinessRuleTask_empty');
+      const template = templates.find(t => t.id === 'io.camunda.examples.Decision.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'deployment');
+
+      // then
+      expect(select.value).to.equal('deployment');
+
+      const calledDecision = findExtension(getBusinessObject(element), 'zeebe:CalledDecision');
+      expect(calledDecision).to.exist;
+      expect(calledDecision).to.have.property('bindingType', 'deployment');
+      expect(calledDecision).to.not.have.property('versionTag');
+    }));
+
+
+    it('should change, setting versionTag', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('BusinessRuleTask_empty');
+      const template = templates.find(t => t.id === 'io.camunda.examples.Decision.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      const versionTagEntry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      // then
+      expect(versionInput.value).to.equal('v2');
+      const calledDecision = findExtension(getBusinessObject(element), 'zeebe:CalledDecision');
+      expect(calledDecision).to.exist;
+      expect(calledDecision).to.have.property('bindingType', 'versionTag');
+      expect(calledDecision).to.have.property('versionTag', 'v2');
+    }));
+
+
+    it('should change, removing versionTag when changing bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('BusinessRuleTask_empty');
+      const template = templates.find(t => t.id === 'io.camunda.examples.Decision.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      changeInput(select, 'latest');
+
+      // then
+      versionTagEntry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-3', container);
+      expect(versionTagEntry).to.not.exist;
+
+      const calledDecision = findExtension(getBusinessObject(element), 'zeebe:CalledDecision');
+      expect(calledDecision).to.exist;
+      expect(calledDecision).to.not.have.property('bindingType', 'versionTag');
+      expect(calledDecision).to.not.have.property('versionTag');
+      expect(calledDecision).to.have.property('bindingType', 'latest');
+    }));
+
+
+    it('should remove, removing bindingType and versionTag', inject(async function(elementTemplates) {
+
+      // given
+      let element = await expectSelected('BusinessRuleTask_called_decision');
+      const template = templates.find(t => t.id === 'io.camunda.examples.Decision.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.Decision.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      await act(() => {
+        elementTemplates.removeTemplate(element);
+      });
+      element = await expectSelected('BusinessRuleTask_called_decision');
+
+      // then
+      const calledDecision = findExtension(getBusinessObject(element), 'zeebe:CalledDecision');
+      expect(calledDecision).to.not.exist;
+    }));
+
+  });
+
+
+  describe('calledElement', function() {
+
+    it('should display', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('CalledElement');
+      const template = templates.find(t => t.id === 'io.camunda.examples.CallActivity.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // then
+      const entry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-1', container);
+      const select = findSelect(entry);
+      const options = Array.from(select.options).map(({ selected, value }) => ({ selected, value }));
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(options).to.eql([
+        { value: 'latest', selected: true },
+        { value: 'deployment', selected: false },
+        { value: 'versionTag', selected: false }
+      ]);
+    }));
+
+
+    it('should change, setting bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('CalledElement');
+      const template = templates.find(t => t.id === 'io.camunda.examples.CallActivity.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-1', container);
+      const select = findSelect(entry);
+      changeInput(select, 'latest');
+
+      // then
+      expect(select.value).to.equal('latest');
+      const calledElement = findExtension(getBusinessObject(element), 'zeebe:CalledElement');
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('bindingType', 'latest');
+      expect(calledElement).to.not.have.property('versionTag');
+    }));
+
+
+    it('should change, setting versionTag', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('CalledElement');
+      const template = templates.find(t => t.id === 'io.camunda.examples.CallActivity.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-1', container);
+      const select = findSelect(entry);
+      await act(() => {
+        changeInput(select, 'versionTag');
+      });
+
+      const versionTagEntry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-2', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      // then
+      expect(versionInput.value).to.equal('v2');
+      const calledElement = findExtension(getBusinessObject(element), 'zeebe:CalledElement');
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('bindingType', 'versionTag');
+      expect(calledElement).to.have.property('versionTag', 'v2');
+    }));
+
+
+    it('should change, removing versionTag when changing bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('CalledElement');
+      const template = templates.find(t => t.id === 'io.camunda.examples.CallActivity.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-1', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-2', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      changeInput(select, 'latest');
+
+      // then
+      versionTagEntry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-2', container);
+      expect(versionTagEntry).to.not.exist;
+
+      const calledElement = findExtension(getBusinessObject(element), 'zeebe:CalledElement');
+      expect(calledElement).to.exist;
+      expect(calledElement).to.not.have.property('bindingType', 'versionTag');
+      expect(calledElement).to.not.have.property('versionTag');
+      expect(calledElement).to.have.property('bindingType', 'latest');
+    }));
+
+
+    it('should remove, removing bindingType and versionTag', inject(async function(elementTemplates) {
+
+      // given
+      let element = await expectSelected('CalledElement');
+      const template = templates.find(t => t.id === 'io.camunda.examples.CallActivity.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-1', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.CallActivity.BindingType-2', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      await act(() => {
+        elementTemplates.removeTemplate(element);
+      });
+
+      element = await expectSelected('CalledElement');
+
+      // then
+      const calledElement = findExtension(getBusinessObject(element), 'zeebe:CalledElement');
+      expect(calledElement).to.not.exist;
+    }));
+
+  });
+
+
+  describe('linkedResource', function() {
+
+    it('should display', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('Service_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.LinkedResource.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // then
+      const entry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-3', container);
+      const select = findSelect(entry);
+      const options = Array.from(select.options).map(({ selected, value }) => ({ selected, value }));
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(options).to.eql([
+        { value: 'latest', selected: true },
+        { value: 'deployment', selected: false },
+        { value: 'versionTag', selected: false }
+      ]);
+    }));
+
+
+    it('should change, setting bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('Service_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.LinkedResource.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-3', container);
+      const select = findSelect(entry);
+      changeInput(select, 'latest');
+
+      // then
+      expect(select.value).to.equal('latest');
+      const linkedResources = findExtension(getBusinessObject(element), 'zeebe:LinkedResources');
+      expect(linkedResources.values).to.have.length(1);
+      const linkedResource = linkedResources.values[0];
+      expect(linkedResource).to.have.property('bindingType', 'latest');
+      expect(linkedResource).to.not.have.property('versionTag');
+    }));
+
+
+    it('should change, setting versionTag', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('Service_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.LinkedResource.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-3', container);
+      const select = findSelect(entry);
+      await act(() => {
+        changeInput(select, 'versionTag');
+      });
+
+      const versionTagEntry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-4', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      // then
+      expect(versionInput.value).to.equal('v2');
+      const linkedResources = findExtension(getBusinessObject(element), 'zeebe:LinkedResources');
+      expect(linkedResources.values).to.have.length(1);
+      const linkedResource = linkedResources.values[0];
+      expect(linkedResource).to.have.property('bindingType', 'versionTag');
+      expect(linkedResource).to.have.property('versionTag', 'v2');
+    }));
+
+
+    it('should change, removing versionTag when changing bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('Service_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.LinkedResource.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-3', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-4', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      changeInput(select, 'latest');
+
+      // then
+      versionTagEntry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-4', container);
+      expect(versionTagEntry).to.not.exist;
+
+      const linkedResources = findExtension(getBusinessObject(element), 'zeebe:LinkedResources');
+      expect(linkedResources.values).to.have.length(1);
+      const linkedResource = linkedResources.values[0];
+      expect(linkedResource).to.not.have.property('bindingType', 'versionTag');
+      expect(linkedResource).to.not.have.property('versionTag');
+      expect(linkedResource).to.have.property('bindingType', 'latest');
+    }));
+
+
+    it('should remove, removing bindingType and versionTag', inject(async function(elementTemplates) {
+
+      // given
+      let element = await expectSelected('Service_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.LinkedResource.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-3', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.LinkedResource.BindingType-4', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      await act(() => {
+        elementTemplates.removeTemplate(element);
+      });
+
+      element = await expectSelected('Service_Task');
+
+      const linkedResources = findExtension(getBusinessObject(element), 'zeebe:LinkedResources');
+      expect(linkedResources).to.not.exist;
+    }));
+
+  });
+
+  describe('formDefinition', function() {
+
+    it('should display', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('User_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.FormDefinition.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // then
+      const entry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-2', container);
+      const select = findSelect(entry);
+      const options = Array.from(select.options).map(({ selected, value }) => ({ selected, value }));
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(options).to.eql([
+        { value: 'latest', selected: true },
+        { value: 'deployment', selected: false },
+        { value: 'versionTag', selected: false }
+      ]);
+    }));
+
+
+    it('should change, setting bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('User_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.FormDefinition.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'latest');
+
+      // then
+      expect(select.value).to.equal('latest');
+      const formDefinition = findExtension(getBusinessObject(element), 'zeebe:FormDefinition');
+      expect(formDefinition).to.exist;
+      expect(formDefinition).to.have.property('bindingType', 'latest');
+      expect(formDefinition).to.not.have.property('versionTag');
+    }));
+
+
+    it('should change, setting versionTag', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('User_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.FormDefinition.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-2', container);
+      const select = findSelect(entry);
+      await act(() => {
+        changeInput(select, 'versionTag');
+      });
+
+      const versionTagEntry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      // then
+      expect(versionInput.value).to.equal('v2');
+      const formDefinition = findExtension(getBusinessObject(element), 'zeebe:FormDefinition');
+      expect(formDefinition).to.exist;
+      expect(formDefinition).to.have.property('bindingType', 'versionTag');
+      expect(formDefinition).to.have.property('versionTag', 'v2');
+    }));
+
+
+    it('should change, removing versionTag when changing bindingType', inject(async function(elementTemplates) {
+
+      // given
+      const element = await expectSelected('User_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.FormDefinition.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      changeInput(select, 'latest');
+
+      // then
+      versionTagEntry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-3', container);
+      expect(versionTagEntry).to.not.exist;
+
+      const formDefinition = findExtension(getBusinessObject(element), 'zeebe:FormDefinition');
+      expect(formDefinition).to.exist;
+      expect(formDefinition).to.not.have.property('bindingType', 'versionTag');
+      expect(formDefinition).to.not.have.property('versionTag');
+      expect(formDefinition).to.have.property('bindingType', 'latest');
+    }));
+
+
+    it('should remove, removing bindingType and versionTag', inject(async function(elementTemplates) {
+
+      // given
+      let element = await expectSelected('User_Task');
+      const template = templates.find(t => t.id === 'io.camunda.examples.FormDefinition.BindingType');
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when
+      const entry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-2', container);
+      const select = findSelect(entry);
+      changeInput(select, 'versionTag');
+
+      let versionTagEntry = findEntry('custom-entry-io.camunda.examples.FormDefinition.BindingType-3', container);
+      const versionInput = findInput('text', versionTagEntry);
+      changeInput(versionInput, 'v2');
+
+      await act(() => {
+        elementTemplates.removeTemplate(element);
+      });
+
+      element = await expectSelected('User_Task');
+
+      // then
+      const formDefinition = findExtension(getBusinessObject(element), 'zeebe:FormDefinition');
+      expect(formDefinition).to.not.exist;
+    }));
+
+  });
+
+});
+
+// helpers //////////
+
+function findEntry(id, container) {
+  expect(container).to.not.be.null;
+
+  return domQuery(`[data-entry-id='${id}']`, container);
+}
+
+function findInput(type, container) {
+  expect(container).to.not.be.null;
+
+  return domQuery(`input[type='${type}']`, container);
+}
+
+function findSelect(container) {
+  expect(container).to.not.be.null;
+
+  return domQuery('select', container);
+}
+
+function expectSelected(id) {
+  return getBpmnJS().invoke(async function(elementRegistry, selection) {
+    const element = elementRegistry.get(id);
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    return element;
+  });
+}

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1411,6 +1411,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
   });
 
+
   describe('types', function() {
 
     describe('Dropdown', function() {


### PR DESCRIPTION
### Proposed Changes

* Adds integration tests for element templates using `zeebe:bindingType`. 
* Fixes a bug affecting such templates in combination with call activities. 
* Bumps camunda-bpmn-js-behavior

Related to https://github.com/camunda/camunda-modeler/issues/5027
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
