### PR TITLE
fix(css): make selectors more specific

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -28,35 +28,35 @@
   position: initial;
 }
 
-.bio-properties-panel-templates-group .bio-properties-panel-group-header-button:not(.bio-properties-panel-arrow) {
+.bio-properties-panel-templates-group .bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button:not(.bio-properties-panel-arrow) {
   padding-right: 6px;
   padding-left: 9px;
   border-radius: 11px;
 }
 
-.bio-properties-panel-applied-template-button .bio-properties-panel-group-header-button,
-.bio-properties-panel-template-update-available .bio-properties-panel-group-header-button,
-.bio-properties-panel-group-header-button.bio-properties-panel-select-template-button {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-applied-template-button .bio-properties-panel-group-header-button,
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-update-available .bio-properties-panel-group-header-button,
+.bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button.bio-properties-panel-select-template-button {
   background-color: var(--select-template-background-color);
   color: var(--select-template-label-color);
   fill: var(--select-template-fill-color);
 }
 
-.bio-properties-panel-applied-template-button .bio-properties-panel-group-header-button:hover,
-.bio-properties-panel-template-update-available .bio-properties-panel-group-header-button:hover,
-.bio-properties-panel-group-header-button.bio-properties-panel-select-template-button:hover {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-applied-template-button .bio-properties-panel-group-header-button:hover,
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-update-available .bio-properties-panel-group-header-button:hover,
+.bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button.bio-properties-panel-select-template-button:hover {
   background-color: var(--select-template-hover-background-color);
 }
 
-.bio-properties-panel-templates-group .bio-properties-panel-group-header-button * {
+.bio-properties-panel-templates-group .bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button * {
   color: inherit;
 }
 
-.bio-properties-panel-templates-group .bio-properties-panel-group-header-button * + * {
+.bio-properties-panel-templates-group .bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button * + * {
   margin-left: 2px;
 }
 
-.bio-properties-panel-group-header-button.bio-properties-panel-select-template-button:last-child {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-group-header-button.bio-properties-panel-select-template-button:last-child {
   padding-right: 9px;
   padding-left: 6px;
   margin-right: 22px;
@@ -73,33 +73,33 @@
   color: var(--text-error-color);
 }
 
-.bio-properties-panel-deprecated-template-button .bio-properties-panel-group-header-button {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-deprecated-template-button .bio-properties-panel-group-header-button {
   background-color: var(--deprecated-template-background-color);
   color: var(--select-template-label-color);
   fill: var(--select-template-fill-color);
 }
 
-.bio-properties-panel-deprecated-template-button:hover .bio-properties-panel-group-header-button:hover {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-deprecated-template-button:hover .bio-properties-panel-group-header-button:hover {
   background-color: var(--deprecated-template-hover-background-color);
 }
 
-.bio-properties-panel-template-not-found .bio-properties-panel-group-header-button {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-not-found .bio-properties-panel-group-header-button {
   background-color: var(--unknown-template-background-color);
   color: var(--select-template-label-color);
   fill: var(--select-template-fill-color);
 }
 
-.bio-properties-panel-template-not-found .bio-properties-panel-group-header-button:hover {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-not-found .bio-properties-panel-group-header-button:hover {
   background-color: var(--unknown-template-hover-background-color);
 }
 
-.bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button {
   background-color: var(--incompatible-template-background-color);
   color: var(--incompatible-template-label-color);
   fill: var(--incompatible-template-fill-color);
 }
 
-.bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button:hover {
+.bio-properties-panel-group-header-buttons .bio-properties-panel-template-incompatible .bio-properties-panel-group-header-button:hover {
   background-color: var(--incompatible-template-hover-background-color);
 }
 


### PR DESCRIPTION
### Proposed Changes

CSS selector specificity should always work regarless of what stylesheet is loaded first. You can test this by switching the order of stylesheets in the helper:

<img width="660" height="219" alt="image" src="https://github.com/user-attachments/assets/06371e96-8eee-4527-b637-be3b1e825752" />

Related to https://github.com/camunda/camunda-modeler/issues/5059

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
