### PR TITLE
feat: support `zeebe:taskSchedule`

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -38,7 +38,8 @@ import {
   ZEEBE_FORM_DEFINITION,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
-  ZEEBE_AD_HOC
+  ZEEBE_AD_HOC,
+  ZEEBE_TASK_SCHEDULE
 } from '../util/bindingTypes';
 
 import {
@@ -130,6 +131,8 @@ export default class ChangeElementTemplateHandler {
       this._updateZeebePriorityDefinition(element, oldTemplate, newTemplate);
 
       this._updateAdHoc(element, oldTemplate, newTemplate);
+
+      this._updateZeebeTaskSchedule(element, oldTemplate, newTemplate);
     }
   }
 
@@ -966,6 +969,20 @@ export default class ChangeElementTemplateHandler {
     );
   }
 
+
+  _updateZeebeTaskSchedule(element, oldTemplate, newTemplate) {
+    this._updateSingleExtensionElement(
+      element,
+      oldTemplate,
+      newTemplate,
+      {
+        bindingTypes: [ ZEEBE_TASK_SCHEDULE ],
+        extensionType: 'zeebe:TaskSchedule',
+        getPropertyName: (binding) => binding.property
+      }
+    );
+  }
+
   /**
    * Replaces the element with the specified elementType.
    * Takes into account the eventDefinition for events.
@@ -1624,6 +1641,19 @@ export function findOldProperty(oldTemplate, newProperty) {
       return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
     });
   }
+
+  if (newBindingType === ZEEBE_TASK_SCHEDULE) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_TASK_SCHEDULE) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
 }
 
 /**
@@ -1754,6 +1784,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_AD_HOC) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_TASK_SCHEDULE) {
     return businessObject.get(bindingProperty);
   }
 }

--- a/src/cloud-element-templates/create/TaskScheduleBindingProvider.js
+++ b/src/cloud-element-templates/create/TaskScheduleBindingProvider.js
@@ -1,0 +1,28 @@
+import {
+  ensureExtension,
+} from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+
+export default class TaskScheduleBindingProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      binding
+    } = property;
+
+    const {
+      property: propertyName
+    } = binding;
+
+    const value = getDefaultValue(property);
+
+    const taskSchedule = ensureExtension(element, 'zeebe:TaskSchedule', bpmnFactory);
+
+    taskSchedule.set(propertyName, value);
+  }
+}

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -21,6 +21,7 @@ import ZeebeFormDefinitionBindingProvider from './FormDefinitionBindingProvider'
 import ZeebeAssignmentDefinitionBindingProvider from './AssignmentDefinitionBindingProvider';
 import ZeebePriorityDefinitionBindingProvider from './PriorityDefinitionBindingProvider';
 import AdHocBindingProvider from './AdHocBindingProvider';
+import TaskScheduleBindingProvider from './TaskScheduleBindingProvider';
 
 import {
   MESSAGE_PROPERTY_TYPE,
@@ -40,7 +41,8 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
-  ZEEBE_AD_HOC
+  ZEEBE_AD_HOC,
+  ZEEBE_TASK_SCHEDULE
 } from '../util/bindingTypes';
 
 import {
@@ -71,7 +73,8 @@ export default class TemplateElementFactory {
       [ZEEBE_SCRIPT_TASK]: ScriptTaskBindingProvider,
       [ZEEBE_ASSIGNMENT_DEFINITION]: ZeebeAssignmentDefinitionBindingProvider,
       [ZEEBE_PRIORITY_DEFINITION]: ZeebePriorityDefinitionBindingProvider,
-      [ZEEBE_AD_HOC]: AdHocBindingProvider
+      [ZEEBE_AD_HOC]: AdHocBindingProvider,
+      [ZEEBE_TASK_SCHEDULE]: TaskScheduleBindingProvider
     };
   }
 

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -18,6 +18,7 @@ export const ZEEBE_SCRIPT_TASK = 'zeebe:script';
 export const ZEEBE_ASSIGNMENT_DEFINITION = 'zeebe:assignmentDefinition';
 export const ZEEBE_PRIORITY_DEFINITION = 'zeebe:priorityDefinition';
 export const ZEEBE_AD_HOC = 'zeebe:adHoc';
+export const ZEEBE_TASK_SCHEDULE = 'zeebe:taskSchedule';
 
 export const EXTENSION_BINDING_TYPES = [
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
@@ -34,7 +35,8 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
-  ZEEBE_AD_HOC
+  ZEEBE_AD_HOC,
+  ZEEBE_TASK_SCHEDULE
 ];
 
 export const TASK_DEFINITION_TYPES = [

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -30,7 +30,8 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
-  ZEEBE_AD_HOC
+  ZEEBE_AD_HOC,
+  ZEEBE_TASK_SCHEDULE
 } from './bindingTypes';
 
 import {
@@ -265,6 +266,12 @@ function getRawPropertyValue(element, property) {
     const assignmentDefinition = findExtension(businessObject, 'zeebe:AssignmentDefinition');
 
     return assignmentDefinition ? assignmentDefinition.get(bindingProperty) : defaultValue;
+  }
+
+  if (type === ZEEBE_TASK_SCHEDULE) {
+    const taskSchedule = findExtension(businessObject, 'zeebe:TaskSchedule');
+
+    return taskSchedule ? taskSchedule.get(bindingProperty) : defaultValue;
   }
 
   if (type === ZEEBE_PRIORITY_DEFINITION) {
@@ -828,6 +835,38 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
           ...context,
           moddleElement: extensionElements,
           properties: { values: [ ...extensionElements.get('values'), assignmentDefinition ] }
+        }
+      });
+    }
+  }
+
+  // zeebe:taskSchedule
+  if (type === ZEEBE_TASK_SCHEDULE) {
+    let taskSchedule = findExtension(element, 'zeebe:TaskSchedule');
+    const propertyName = binding.property;
+
+    const properties = {
+      [ propertyName ]: value || ''
+    };
+
+    if (taskSchedule) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          properties,
+          moddleElement: taskSchedule
+        }
+      });
+    } else {
+      taskSchedule = createElement('zeebe:TaskSchedule', properties, extensionElements, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: extensionElements,
+          properties: { values: [ ...extensionElements.get('values'), taskSchedule ] }
         }
       });
     }

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -42,7 +42,6 @@ import {
   isString,
   isUndefined
 } from 'min-dash';
-import newTemplate from './priority-definition.json';
 
 const modules = [
   CoreModule,
@@ -2387,6 +2386,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
     });
 
+
     describe('update zeebe:calledDecision', function() {
 
       beforeEach(bootstrap(require('./business-rule-tasks.bpmn').default));
@@ -2751,267 +2751,316 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
     });
 
-  });
 
-  describe('zeebe:assignmentDefinition', function() {
-    beforeEach(bootstrap(require('./assignment-definition.bpmn').default));
+    describe('zeebe:assignmentDefinition', function() {
 
-    const newTemplate = require('./assignment-definition.json');
+      beforeEach(bootstrap(require('./assignment-definition.bpmn').default));
 
-    it('should execute', inject(function(elementRegistry) {
+      const newTemplate = require('./assignment-definition.json');
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('should execute', inject(function(elementRegistry) {
 
-      // when
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // then
-      expectElementTemplate(task, 'com.camunda.example.AssignmentDefinition');
+        // when
+        changeTemplate(task, newTemplate);
 
-      const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+        // then
+        expectElementTemplate(task, 'com.camunda.example.AssignmentDefinition');
 
-      expect(assignmentDefinition).to.exist;
-      expect(assignmentDefinition).to.have.property('assignee', 'anAssignee');
-    }));
+        const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
 
+        expect(assignmentDefinition).to.exist;
+        expect(assignmentDefinition).to.have.property('assignee', 'anAssignee');
+      }));
 
-    it('undo', inject(function(commandStack, elementRegistry) {
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('undo', inject(function(commandStack, elementRegistry) {
 
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // when
-      commandStack.undo();
+        changeTemplate(task, newTemplate);
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectNoElementTemplate(task);
+        // when
+        commandStack.undo();
 
-      const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectNoElementTemplate(task);
 
-      expect(assignmentDefinition).not.to.exist;
+        const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
 
-    }));
+        expect(assignmentDefinition).not.to.exist;
 
+      }));
 
-    it('redo', inject(function(commandStack, elementRegistry) {
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('redo', inject(function(commandStack, elementRegistry) {
 
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // when
-      commandStack.undo();
-      commandStack.redo();
+        changeTemplate(task, newTemplate);
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectElementTemplate(task, 'com.camunda.example.AssignmentDefinition');
+        // when
+        commandStack.undo();
+        commandStack.redo();
 
-      const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectElementTemplate(task, 'com.camunda.example.AssignmentDefinition');
 
-      expect(assignmentDefinition).to.exist;
-      expect(assignmentDefinition).to.have.property('assignee', 'anAssignee');
-    }));
+        const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
 
+        expect(assignmentDefinition).to.exist;
+        expect(assignmentDefinition).to.have.property('assignee', 'anAssignee');
+      }));
 
-    it('should not override existing', inject(function(elementRegistry) {
 
-      // given
-      const task = elementRegistry.get('UserTask_assignmentDefinition');
+      it('should not override existing', inject(function(elementRegistry) {
 
-      // when
-      changeTemplate(task, newTemplate);
+        // given
+        const task = elementRegistry.get('UserTask_assignmentDefinition');
 
-      // then
-      const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+        // when
+        changeTemplate(task, newTemplate);
 
-      expect(assignmentDefinition).to.exist;
+        // then
+        const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
 
-      // Should keep the old values, not override with newTemplate's values
-      expect(assignmentDefinition).to.have.property('assignee', 'aCustomAssignee');
-      expect(assignmentDefinition).to.have.property('candidateGroups', 'aCandidateGroup, anotherCandidateGroup');
+        expect(assignmentDefinition).to.exist;
 
-    }));
+        // Should keep the old values, not override with newTemplate's values
+        expect(assignmentDefinition).to.have.property('assignee', 'aCustomAssignee');
+        expect(assignmentDefinition).to.have.property('candidateGroups', 'aCandidateGroup, anotherCandidateGroup');
 
-  });
+      }));
 
+    });
 
-  describe('zeebe:priorityDefinition', function() {
 
-    beforeEach(bootstrap(require('./priority-definition.bpmn').default));
+    describe('zeebe:priorityDefinition', function() {
 
-    const newTemplate = require('./priority-definition.json');
+      beforeEach(bootstrap(require('./priority-definition.bpmn').default));
 
-    it('should execute', inject(function(elementRegistry) {
+      const newTemplate = require('./priority-definition.json');
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('should execute', inject(function(elementRegistry) {
 
-      // when
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // then
-      expectElementTemplate(task, 'com.camunda.example.PriorityDefinition');
+        // when
+        changeTemplate(task, newTemplate);
 
-      const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+        // then
+        expectElementTemplate(task, 'com.camunda.example.PriorityDefinition');
 
-      expect(priorityDefinition).to.exist;
-      expect(priorityDefinition).to.have.property('priority', 10);
-    }));
+        const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
 
+        expect(priorityDefinition).to.exist;
+        expect(priorityDefinition).to.have.property('priority', 10);
+      }));
 
-    it('undo', inject(function(commandStack, elementRegistry) {
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('undo', inject(function(commandStack, elementRegistry) {
 
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // when
-      commandStack.undo();
+        changeTemplate(task, newTemplate);
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectNoElementTemplate(task);
+        // when
+        commandStack.undo();
 
-      const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectNoElementTemplate(task);
 
-      expect(priorityDefinition).not.to.exist;
+        const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
 
-    }));
+        expect(priorityDefinition).not.to.exist;
 
+      }));
 
-    it('redo', inject(function(commandStack, elementRegistry) {
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      it('redo', inject(function(commandStack, elementRegistry) {
 
-      changeTemplate(task, newTemplate);
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // when
-      commandStack.undo();
-      commandStack.redo();
+        changeTemplate(task, newTemplate);
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectElementTemplate(task, 'com.camunda.example.PriorityDefinition');
+        // when
+        commandStack.undo();
+        commandStack.redo();
 
-      const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectElementTemplate(task, 'com.camunda.example.PriorityDefinition');
 
-      expect(priorityDefinition).to.exist;
-      expect(priorityDefinition).to.have.property('priority', 10);
-    }));
+        const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
 
+        expect(priorityDefinition).to.exist;
+        expect(priorityDefinition).to.have.property('priority', 10);
+      }));
 
-    it('should not override existing', inject(function(elementRegistry) {
 
-      // given
-      const task = elementRegistry.get('UserTask_priorityDefinition');
+      it('should not override existing', inject(function(elementRegistry) {
 
-      // when
-      changeTemplate(task, newTemplate);
+        // given
+        const task = elementRegistry.get('UserTask_priorityDefinition');
 
-      // then
-      const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+        // when
+        changeTemplate(task, newTemplate);
 
-      expect(priorityDefinition).to.exist;
+        // then
+        const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
 
-      // Should keep the old values, not override with newTemplate's values
-      expect(priorityDefinition).to.have.property('priority', '5');
+        expect(priorityDefinition).to.exist;
 
-    }));
-  });
+        // Should keep the old values, not override with newTemplate's values
+        expect(priorityDefinition).to.have.property('priority', '5');
 
+      }));
+    });
 
-  describe('zeebe:taskSchedule', function() {
-    beforeEach(bootstrap(require('./task-schedule.bpmn').default));
 
-    const newTemplate = require('./task-schedule.json');
+    describe('zeebe:taskSchedule', function() {
 
-    it('should execute', inject(function(elementRegistry) {
+      beforeEach(bootstrap(require('./task-schedule.bpmn').default));
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
+      const newTemplate = require('./task-schedule.json');
 
-      // when
-      changeTemplate(task, newTemplate);
+      it('should execute', inject(function(elementRegistry) {
 
-      // then
-      expectElementTemplate(task, 'com.camunda.example.TaskSchedule');
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+        // when
+        changeTemplate(task, newTemplate);
 
-      expect(taskSchedule).to.exist;
-      expect(taskSchedule).to.have.property('dueDate', '2023-02-01T12:00:00Z');
-      expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
-    }));
+        // then
+        expectElementTemplate(task, 'com.camunda.example.TaskSchedule');
 
+        const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
 
-    it('undo', inject(function(commandStack, elementRegistry) {
+        expect(taskSchedule).to.exist;
+        expect(taskSchedule).to.have.property('dueDate', '2023-02-01T12:00:00Z');
+        expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
+      }));
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
 
-      changeTemplate(task, newTemplate);
+      it('undo', inject(function(commandStack, elementRegistry) {
 
-      // when
-      commandStack.undo();
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectNoElementTemplate(task);
+        changeTemplate(task, newTemplate);
 
-      const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+        // when
+        commandStack.undo();
 
-      expect(taskSchedule).not.to.exist;
-    }));
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectNoElementTemplate(task);
 
+        const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
 
-    it('redo', inject(function(commandStack, elementRegistry) {
+        expect(taskSchedule).not.to.exist;
+      }));
 
-      // given
-      let task = elementRegistry.get('UserTask_1');
 
-      changeTemplate(task, newTemplate);
+      it('redo', inject(function(commandStack, elementRegistry) {
 
-      // when
-      commandStack.undo();
-      commandStack.redo();
+        // given
+        let task = elementRegistry.get('UserTask_1');
 
-      // then
-      task = elementRegistry.get('UserTask_1');
-      expectElementTemplate(task, 'com.camunda.example.TaskSchedule');
+        changeTemplate(task, newTemplate);
 
-      const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+        // when
+        commandStack.undo();
+        commandStack.redo();
 
-      expect(taskSchedule).to.exist;
-      expect(taskSchedule).to.have.property('dueDate', '2023-02-01T12:00:00Z');
-      expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
-    }));
+        // then
+        task = elementRegistry.get('UserTask_1');
+        expectElementTemplate(task, 'com.camunda.example.TaskSchedule');
 
+        const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
 
-    it('should not override existing', inject(function(elementRegistry) {
+        expect(taskSchedule).to.exist;
+        expect(taskSchedule).to.have.property('dueDate', '2023-02-01T12:00:00Z');
+        expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
+      }));
 
-      // given
-      const task = elementRegistry.get('UserTask_taskSchedule');
 
-      // when
-      changeTemplate(task, newTemplate);
+      it('should not override existing', inject(function(elementRegistry) {
 
-      // then
-      const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+        // given
+        const task = elementRegistry.get('UserTask_taskSchedule');
 
-      expect(taskSchedule).to.exist;
+        // when
+        changeTemplate(task, newTemplate);
 
-      // Should keep the old values, not override with newTemplate's values
-      expect(taskSchedule).to.have.property('dueDate', '2033-02-01T12:00:00Z');
-      expect(taskSchedule).to.have.property('followUpDate', '2033-02-05T12:00:00Z');
-    }));
+        // then
+        const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+
+        expect(taskSchedule).to.exist;
+
+        // Should keep the old values, not override with newTemplate's values
+        expect(taskSchedule).to.have.property('dueDate', '2033-02-01T12:00:00Z');
+        expect(taskSchedule).to.have.property('followUpDate', '2033-02-05T12:00:00Z');
+      }));
+
+    });
+
+
+    describe('FEEL Boolean and Numbers', function() {
+
+      beforeEach(bootstrap(require('./casted-values.bpmn').default));
+
+      describe('Boolean', function() {
+
+        const template = require('./casted-values.json')[0];
+
+        it('should apply generated value (uuid)', inject(function(elementRegistry) {
+
+          // given
+          let task = elementRegistry.get('Task_1');
+
+          // when
+          task = changeTemplate(task, template);
+
+          // then
+          expect(getZeebeProperty(task, 'StaticBooleanProperty').value).to.eql('=true');
+          expect(getZeebeProperty(task, 'OptionalBooleanProperty').value).to.eql('=true');
+        }));
+
+      });
+
+      describe('Number', function() {
+
+        const template = require('./casted-values.json')[1];
+
+        it('should apply generated value (uuid)', inject(function(elementRegistry) {
+
+          // given
+          let task = elementRegistry.get('Task_1');
+
+          // when
+          task = changeTemplate(task, template);
+
+          // then
+          expect(getZeebeProperty(task, 'StaticNumberProperty').value).to.eql('=123');
+          expect(getZeebeProperty(task, 'OptionalNumberProperty').value).to.eql('=123');
+        }));
+
+      });
+
+    });
+
   });
 
 
@@ -5797,6 +5846,306 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
       }));
     });
 
+
+    describe('update zeebe:AssignmentDefinition', function() {
+
+      beforeEach(bootstrap(require('./assignment-definition.bpmn').default));
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given a user applies a template and updates a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'anAssignee-old',
+            binding: {
+              type: 'zeebe:assignmentDefinition',
+              property: 'assignee'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'anAssignee-new',
+            binding: {
+              type: 'zeebe:assignmentDefinition',
+              property: 'assignee'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+        let assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+
+        updateBusinessObject('UserTask_1', assignmentDefinition, {
+          assignee: 'anAssignee-changed'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+
+        expect(assignmentDefinition).to.exist;
+        expect(assignmentDefinition.get('assignee')).to.equal('anAssignee-changed');
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given a user applies a template and does not update a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'anAssignee-old',
+            binding: {
+              type: 'zeebe:assignmentDefinition',
+              property: 'assignee'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'anAssignee-new',
+            binding: {
+              type: 'zeebe:assignmentDefinition',
+              property: 'assignee'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const assignmentDefinition = findExtension(task, 'zeebe:AssignmentDefinition');
+
+        expect(assignmentDefinition).to.exist;
+        expect(assignmentDefinition.get('assignee')).to.equal('anAssignee-new');
+      }));
+    });
+
+
+    describe('update zeebe:PriorityDefinition', function() {
+
+      beforeEach(bootstrap(require('./priority-definition.bpmn').default));
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given a user applies a template and updates a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 5,
+            binding: {
+              type: 'zeebe:priorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 10,
+            binding: {
+              type: 'zeebe:priorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+        let priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+
+        updateBusinessObject('UserTask_1', priorityDefinition, {
+          priority: 7
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+
+        expect(priorityDefinition).to.exist;
+        expect(priorityDefinition.get('priority')).to.equal(7);
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given a user applies a template and does not update a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 5,
+            binding: {
+              type: 'zeebe:priorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 10,
+            binding: {
+              type: 'zeebe:priorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const priorityDefinition = findExtension(task, 'zeebe:PriorityDefinition');
+
+        expect(priorityDefinition).to.exist;
+        expect(priorityDefinition.get('priority')).to.equal(10);
+      }));
+    });
+
+
+    describe('update zeebe:TaskSchedule', function() {
+
+      beforeEach(bootstrap(require('./task-schedule.bpmn').default));
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given a user applies a template and updates a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: '2023-02-01T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'dueDate'
+            }
+          },
+          {
+            value: '2023-02-05T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'followUpDate'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: '3023-03-01T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'dueDate'
+            }
+          },
+          {
+            value: '3023-03-05T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'followUpDate'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+        let taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+
+        updateBusinessObject('UserTask_1', taskSchedule, {
+          dueDate: '4023-02-15T12:00:00Z'
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+
+        expect(taskSchedule).to.exist;
+        expect(taskSchedule.get('dueDate')).to.equal('4023-02-15T12:00:00Z');
+        expect(taskSchedule.get('followUpDate')).to.equal('3023-03-05T12:00:00Z');
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given a user applies a template and does not update a property
+        let task = elementRegistry.get('UserTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: '2023-02-01T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'dueDate'
+            }
+          },
+          {
+            value: '2023-02-05T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'followUpDate'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: '3023-03-01T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'dueDate'
+            }
+          },
+          {
+            value: '3023-03-05T12:00:00Z',
+            binding: {
+              type: 'zeebe:taskSchedule',
+              property: 'followUpDate'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('UserTask_1');
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const taskSchedule = findExtension(task, 'zeebe:TaskSchedule');
+
+        expect(taskSchedule).to.exist;
+        expect(taskSchedule.get('dueDate')).to.equal('3023-03-01T12:00:00Z');
+        expect(taskSchedule.get('followUpDate')).to.equal('3023-03-05T12:00:00Z');
+      }));
+    });
+
   });
 
 
@@ -6027,50 +6376,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
   });
 
-
-  describe('FEEL Boolean and Numbers', function() {
-
-    beforeEach(bootstrap(require('./casted-values.bpmn').default));
-
-    describe('Boolean', function() {
-
-      const template = require('./casted-values.json')[0];
-
-      it('should apply generated value (uuid)', inject(function(elementRegistry) {
-
-        // given
-        let task = elementRegistry.get('Task_1');
-
-        // when
-        task = changeTemplate(task, template);
-
-        // then
-        expect(getZeebeProperty(task, 'StaticBooleanProperty').value).to.eql('=true');
-        expect(getZeebeProperty(task, 'OptionalBooleanProperty').value).to.eql('=true');
-      }));
-
-    });
-
-    describe('Number', function() {
-
-      const template = require('./casted-values.json')[1];
-
-      it('should apply generated value (uuid)', inject(function(elementRegistry) {
-
-        // given
-        let task = elementRegistry.get('Task_1');
-
-        // when
-        task = changeTemplate(task, template);
-
-        // then
-        expect(getZeebeProperty(task, 'StaticNumberProperty').value).to.eql('=123');
-        expect(getZeebeProperty(task, 'OptionalNumberProperty').value).to.eql('=123');
-      }));
-
-    });
-
-  });
 
 });
 

--- a/test/spec/cloud-element-templates/cmd/task-schedule.bpmn
+++ b/test/spec/cloud-element-templates/cmd/task-schedule.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1dvk1qu" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0">
+  <bpmn:process id="Process_10shw5p" isExecutable="true">
+    <bpmn:userTask id="UserTask_1" name="Task without schedule">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="test" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:userTask id="UserTask_taskSchedule" name="Task with schedule" zeebe:modelerTemplate="com.camunda.example.TaskSchedule">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="test" />
+        <zeebe:taskSchedule dueDate="2033-02-01T12:00:00Z" followUpDate="2033-02-05T12:00:00Z" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_10shw5p">
+      <bpmndi:BPMNShape id="Activity_1phbbua_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cwyzhq_di" bpmnElement="UserTask_taskSchedule">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/test/spec/cloud-element-templates/cmd/task-schedule.json
+++ b/test/spec/cloud-element-templates/cmd/task-schedule.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "TaskSchedule",
+  "id": "com.camunda.example.TaskSchedule",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "label": "Due Date",
+      "description": "The due date for the task",
+      "type": "String",
+      "value": "2023-02-01T12:00:00Z",
+      "binding": {
+        "type": "zeebe:taskSchedule",
+        "property": "dueDate"
+      }
+    },
+    {
+      "label": "Follow-up Date",
+      "description": "The follow-up date for the task",
+      "type": "String",
+      "value": "2023-02-05T12:00:00Z",
+      "binding": {
+        "type": "zeebe:taskSchedule",
+        "property": "followUpDate"
+      }
+    }
+  ]
+}
+

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -653,6 +653,27 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
       expect(adHoc.get('outputElement')).to.equal('={ id: toolCall._meta.id }');
     }));
 
+
+    it('should handle <zeebe:taskSchedule>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('com.camunda.example.TaskSchedule');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      // then
+      const bo = getBusinessObject(element);
+      const taskSchedule = findExtension(bo, 'zeebe:TaskSchedule');
+
+      expect(taskSchedule).to.exist;
+      expect(taskSchedule).to.jsonEqual({
+        $type: 'zeebe:TaskSchedule',
+        dueDate: '2023-02-01T12:00:00Z',
+        followUpDate: '2023-02-05T12:00:00Z'
+      });
+    }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -786,5 +786,41 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "TaskSchedule",
+    "id": "com.camunda.example.TaskSchedule",
+    "appliesTo": [
+      "bpmn:UserTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "label": "Due Date",
+        "description": "The due date for the task",
+        "type": "String",
+        "value": "2023-02-01T12:00:00Z",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "dueDate"
+        }
+      },
+      {
+        "label": "Follow-up Date",
+        "description": "The follow-up date for the task",
+        "type": "String",
+        "value": "2023-02-05T12:00:00Z",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "followUpDate"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/fixtures/task-schedule.json
+++ b/test/spec/cloud-element-templates/fixtures/task-schedule.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "TaskSchedule",
+  "id": "com.camunda.example.TaskSchedule",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+    "elementType": {
+        "value": "bpmn:UserTask"
+    },
+  "properties": [
+    {
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:userTask"
+      }
+    },
+    {
+      "label": "Due Date",
+      "description": "The due date for the task",
+      "type": "String",
+      "value": "2023-02-01T12:00:00Z",
+      "binding": {
+        "type": "zeebe:taskSchedule",
+        "property": "dueDate"
+      }
+    },
+    {
+      "label": "Follow-up Date",
+      "description": "The follow-up date for the task",
+      "type": "String",
+      "value": "2023-02-05T12:00:00Z",
+      "binding": {
+        "type": "zeebe:taskSchedule",
+        "property": "followUpDate"
+      }
+    }
+  ]
+}
+

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -117,6 +117,12 @@
       </bpmn:extensionElements>
     </bpmn:adHocSubProcess>
     <bpmn:adHocSubProcess id="AdHocSubProcess_empty" name="AdHocSubProcess" />
+    <bpmn:userTask id="UserTask_schedule" name="schedule" zeebe:modelerTemplate="com.camunda.example.TaskSchedule">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:taskSchedule dueDate="=someDate" followUpDate="2023-02-05T12:00:00Z" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmn:message id="Message" name="name">
     <bpmn:extensionElements>
@@ -235,6 +241,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1q9rek1_di" bpmnElement="AdHocSubProcess_empty">
         <dc:Bounds x="415" y="1490" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13u3ox2_di" bpmnElement="UserTask_schedule">
+        <dc:Bounds x="290" y="1130" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -989,6 +989,44 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Custom Properties",
+    "id": "com.camunda.example.TaskSchedule",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "String",
+        "feel": "required",
+        "value": "=someDate",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "dueDate"
+        }
+      },
+      {
+        "label": "Follow-up Date",
+        "description": "The follow-up date for the task",
+        "type": "String",
+        "value": "2023-02-05T12:00:00Z",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "followUpDate"
+        }
+      }
+    ]
   }
 
 ]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1673,6 +1673,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
   });
 
+
   describe('zeebe:taskSchedule', function() {
 
     it('should display', async function() {
@@ -1751,6 +1752,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(taskSchedule).to.have.property('dueDate', '=someDate');
       expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
     }));
+
   });
 
   describe('types', function() {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1673,6 +1673,86 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
   });
 
+  describe('zeebe:taskSchedule', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('UserTask_schedule');
+
+      // then
+      const dueEntry = findEntry('custom-entry-com.camunda.example.TaskSchedule-1', container),
+            dueInput = findEditor(dueEntry);
+
+
+      const followUpEntry = findEntry('custom-entry-com.camunda.example.TaskSchedule-2', container),
+            followUpInput = findInput('text', followUpEntry);
+
+      expect(dueEntry).to.exist;
+      expect(dueInput).to.exist;
+      expect(dueInput.textContent).to.equal('someDate');
+
+      expect(followUpEntry).to.exist;
+      expect(followUpInput).to.exist;
+      expect(followUpInput.value).to.equal('2023-02-05T12:00:00Z');
+    });
+
+
+    it('should change, setting followUpDate value', async function() {
+
+      // given
+      const element = await expectSelected('UserTask_schedule'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const followUpEntry = findEntry('custom-entry-com.camunda.example.TaskSchedule-2', container),
+            followUpInput = findInput('text', followUpEntry);
+
+      changeInput(followUpInput, '2023-03-10T15:00:00Z');
+
+      // then
+      expect(followUpInput.value).to.equal('2023-03-10T15:00:00Z');
+
+      const taskSchedule = findExtension(businessObject, 'zeebe:TaskSchedule');
+      expect(taskSchedule).to.exist;
+      expect(taskSchedule).to.have.property('followUpDate', '2023-03-10T15:00:00Z');
+    });
+
+
+    it('should change, creating zeebe:taskSchedule if non-existing', inject(async function(elementTemplates, elementRegistry) {
+
+      // given
+      const template = templates.find(t => t.id === 'com.camunda.example.TaskSchedule');
+      let task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        elementTemplates.applyTemplate(task, template);
+      });
+
+      // then
+      task = elementRegistry.get('Task_1');
+      const taskSchedule = findExtension(getBusinessObject(task), 'zeebe:TaskSchedule');
+
+      const dueEntry = findEntry('custom-entry-com.camunda.example.TaskSchedule-1', container),
+            dueInput = findEditor(dueEntry);
+
+      const followUpEntry = findEntry('custom-entry-com.camunda.example.TaskSchedule-2', container),
+            followUpInput = findInput('text', followUpEntry);
+
+      expect(dueEntry).to.exist;
+      expect(dueInput).to.exist;
+      expect(dueInput.textContent).to.equal('someDate');
+
+      expect(followUpEntry).to.exist;
+      expect(followUpInput).to.exist;
+      expect(followUpInput.value).to.equal('2023-02-05T12:00:00Z');
+
+      expect(taskSchedule).to.have.property('dueDate', '=someDate');
+      expect(taskSchedule).to.have.property('followUpDate', '2023-02-05T12:00:00Z');
+    }));
+  });
+
   describe('types', function() {
 
     describe('Dropdown', function() {


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

- Element `zeebe:taskSchedule` can be templated
- Property `zeebe:taskSchedule#dueDate` can be templated
- Property `zeebe:taskSchedule#followUpDate` can be templated
- Both properties are String/Text typed with FEEL support or a Dropdown or Hidden. 
- the `value` set in the template for these properties can only be ISO 8601 date time
- `zeebe:taskSchedule` can only be set if `zeebe:UserTask` is set. 
- `zeebe:taskSchedule` can only exist in a `bpmn:UserTask`
- At least one of the properties needs to be set. 

related to https://github.com/camunda/camunda-modeler/issues/5093


### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
