### PR TITLE
feat: support `zeebe:adHoc` bindings

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -36,7 +36,8 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_USER_TASK,
   ZEEBE_FORM_DEFINITION,
-  ZEEBE_ASSIGNMENT_DEFINITION
+  ZEEBE_ASSIGNMENT_DEFINITION,
+  ZEEBE_AD_HOC
 } from '../util/bindingTypes';
 
 import {
@@ -124,6 +125,8 @@ export default class ChangeElementTemplateHandler {
       this._updateScriptTask(element, oldTemplate, newTemplate);
 
       this._updateZeebeAssignmentDefinition(element, oldTemplate, newTemplate);
+
+      this._updateAdHoc(element, oldTemplate, newTemplate);
     }
   }
 
@@ -934,6 +937,19 @@ export default class ChangeElementTemplateHandler {
     );
   }
 
+  _updateAdHoc(element, oldTemplate, newTemplate) {
+    this._updateSingleExtensionElement(
+      element,
+      oldTemplate,
+      newTemplate,
+      {
+        bindingTypes: [ ZEEBE_AD_HOC ],
+        extensionType: 'zeebe:AdHoc',
+        getPropertyName: (binding) => binding.property
+      }
+    );
+  }
+
   /**
    * Replaces the element with the specified elementType.
    * Takes into account the eventDefinition for events.
@@ -1566,6 +1582,19 @@ export function findOldProperty(oldTemplate, newProperty) {
       return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
     });
   }
+
+  if (newBindingType === ZEEBE_AD_HOC) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_AD_HOC) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
 }
 
 /**
@@ -1688,6 +1717,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_ASSIGNMENT_DEFINITION) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_AD_HOC) {
     return businessObject.get(bindingProperty);
   }
 }

--- a/src/cloud-element-templates/create/AdHocBindingProvider.js
+++ b/src/cloud-element-templates/create/AdHocBindingProvider.js
@@ -1,0 +1,22 @@
+import { ensureExtension } from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+/**
+ * Provider for the `zeebe:adHoc` binding. Ensures a single zeebe:AdHoc extension
+ * element exists and sets the configured property on it.
+ */
+export default class AdHocBindingProvider {
+  static create(element, options) {
+    const { property, bpmnFactory } = options;
+
+    const { binding } = property;
+    const { property: propertyName } = binding;
+
+    const value = getDefaultValue(property);
+
+    const adHoc = ensureExtension(element, 'zeebe:AdHoc', bpmnFactory);
+
+    adHoc.set(propertyName, value);
+  }
+}
+

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -19,6 +19,7 @@ import { CalledDecisionBindingProvider } from './CalledDecisionBindingProvider';
 import { ScriptTaskBindingProvider } from './ScriptTaskBindingProvider';
 import ZeebeFormDefinitionBindingProvider from './FormDefinitionBindingProvider';
 import ZeebeAssignmentDefinitionBindingProvider from './AssignmentDefinitionBindingProvider';
+import AdHocBindingProvider from './AdHocBindingProvider';
 
 import {
   MESSAGE_PROPERTY_TYPE,
@@ -35,7 +36,9 @@ import {
   ZEEBE_USER_TASK,
   ZEEBE_CALLED_DECISION,
   ZEEBE_FORM_DEFINITION,
-  ZEEBE_SCRIPT_TASK, ZEEBE_ASSIGNMENT_DEFINITION
+  ZEEBE_SCRIPT_TASK,
+  ZEEBE_ASSIGNMENT_DEFINITION,
+  ZEEBE_AD_HOC
 } from '../util/bindingTypes';
 
 import {
@@ -64,7 +67,8 @@ export default class TemplateElementFactory {
       [ZEEBE_CALLED_DECISION]: CalledDecisionBindingProvider,
       [ZEEBE_FORM_DEFINITION]: ZeebeFormDefinitionBindingProvider,
       [ZEEBE_SCRIPT_TASK]: ScriptTaskBindingProvider,
-      [ZEEBE_ASSIGNMENT_DEFINITION]: ZeebeAssignmentDefinitionBindingProvider
+      [ZEEBE_ASSIGNMENT_DEFINITION]: ZeebeAssignmentDefinitionBindingProvider,
+      [ZEEBE_AD_HOC]: AdHocBindingProvider
     };
   }
 

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -16,6 +16,7 @@ export const ZEEBE_CALLED_DECISION = 'zeebe:calledDecision';
 export const ZEEBE_FORM_DEFINITION = 'zeebe:formDefinition';
 export const ZEEBE_SCRIPT_TASK = 'zeebe:script';
 export const ZEEBE_ASSIGNMENT_DEFINITION = 'zeebe:assignmentDefinition';
+export const ZEEBE_AD_HOC = 'zeebe:adHoc';
 
 export const EXTENSION_BINDING_TYPES = [
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
@@ -30,7 +31,8 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_CALLED_DECISION,
   ZEEBE_FORM_DEFINITION,
   ZEEBE_SCRIPT_TASK,
-  ZEEBE_ASSIGNMENT_DEFINITION
+  ZEEBE_ASSIGNMENT_DEFINITION,
+  ZEEBE_AD_HOC
 ];
 
 export const TASK_DEFINITION_TYPES = [

--- a/test/spec/cloud-element-templates/cmd/ad-hoc.bpmn
+++ b/test/spec/cloud-element-templates/cmd/ad-hoc.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess_existing">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults" outputElement="={id: toolCall._meta.id,  name: toolCall._meta.name,  content: toolCallResult}" />
+      </bpmn:extensionElements>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="AdHocSubProcess_1_di" bpmnElement="AdHocSubProcess_1">
+        <dc:Bounds x="100" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcess_existing_di" bpmnElement="AdHocSubProcess_existing">
+        <dc:Bounds x="350" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/test/spec/cloud-element-templates/cmd/ad-hoc.json
+++ b/test/spec/cloud-element-templates/cmd/ad-hoc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "AdHoc",
+  "id": "com.camunda.example.AdHoc",
+  "appliesTo": [
+    "bpmn:AdHocSubProcess"
+  ],
+  "properties": [
+    {
+      "type": "Text",
+      "value": "toolCallResults",
+      "binding": {
+        "type": "zeebe:adHoc",
+        "property": "outputCollection"
+      }
+    },
+    {
+      "type": "Text",
+      "value": "={ id: toolCall._meta.id }",
+      "binding": {
+        "type": "zeebe:adHoc",
+        "property": "outputElement"
+      }
+    }
+  ]
+}
+

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -615,6 +615,24 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
         candidateUsers: 'aCandidateUser'
       });
     }));
+
+
+    it('should handle <zeebe:adHoc>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('ad-hoc-template');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      const adHoc = findExtension(element, 'zeebe:AdHoc');
+
+      // then
+      expect(adHoc).to.exist;
+      expect(adHoc.get('outputCollection')).to.equal('toolCallResults');
+      expect(adHoc.get('outputElement')).to.equal('={ id: toolCall._meta.id }');
+    }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -730,5 +730,32 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AdHoc Template",
+    "id": "ad-hoc-template",
+    "appliesTo": [
+      "bpmn:AdHocSubProcess"
+    ],
+    "version": 1,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "toolCallResults",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputCollection"
+        }
+      },
+      {
+        "type": "Text",
+        "value": "={ id: toolCall._meta.id }",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputElement"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Proposed Changes

## Summary
This PR adds first-class support for the `zeebe:adHoc` element‑template binding. When an element template is applied to a `bpmn:AdHocSubProcess`, the template engine now ensures a single `zeebe:AdHoc` extension element exists and assigns configured properties (e.g. `outputCollection`, `outputElement`).

## Why
Ad‑hoc subprocesses can produce dynamic outputs that are consumed downstream. Enabling these via element templates aligns `zeebe:AdHoc` with other Zeebe extension bindings (task definition, form/assignment/script, etc.) and lets modelers configure outputs at modeling time with a consistent pattern.

## What’s in this PR
- **New provider**: `AdHocBindingProvider` to manage `zeebe:AdHoc` extension creation and property assignment.
- **Factory wiring**: Registers the provider in `TemplateElementFactory`.
- **Binding type**: Introduces `ZEEBE_AD_HOC = 'zeebe:adHoc'` and adds it to `EXTENSION_BINDING_TYPES`.
- **Tests**: Adds an element template fixture and a spec covering creation + population of the `zeebe:AdHoc` extension.

## Files changed
```
5 files changed, 76 insertions(+), 3 deletions(-)

✔ NEW  src/cloud-element-templates/create/AdHocBindingProvider.js
~     src/cloud-element-templates/create/TemplateElementFactory.js
~     src/cloud-element-templates/util/bindingTypes.js
~     test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
~     test/spec/cloud-element-templates/create/TemplatesElementFactory.json
```

## Implementation details
- **Provider logic** (`AdHocBindingProvider#create`):
  - Resolves the property’s default/value via `getDefaultValue(property)`.
  - Ensures a single `zeebe:AdHoc` extension exists via `ensureExtension(element, 'zeebe:AdHoc', bpmnFactory)`.
  - Sets the configured property (`binding.property`) on that extension.
- **Factory mapping**: Adds `[ZEEBE_AD_HOC]: AdHocBindingProvider` to the binding‑type→provider registry.
- **Binding constants**: Adds `ZEEBE_AD_HOC` and includes it in `EXTENSION_BINDING_TYPES` so it’s treated like other extension bindings.

## Usage (template snippet)
```jsonc
{
  "type": "Hidden",
  "value": "toolCallResults",
  "binding": {
    "type": "zeebe:adHoc",
    "property": "outputCollection"
  }
},
{
  "type": "Text",
  "value": "={ id: toolCall._meta.id }",
  "binding": {
    "type": "zeebe:adHoc",
    "property": "outputElement"
  }
}
```
**Applies to:** `bpmn:AdHocSubProcess`

## Behavior
When a template with `zeebe:adHoc` bindings is applied:
1. Ensure a single `zeebe:AdHoc` extension on the target.
2. Assign each property defined by the template (`outputCollection`, `outputElement`, ...).
3. Respect the existing default/value resolution semantics used by other bindings.

## Tests
- **Spec:** `TemplateElementFactory.spec.js`
  - `should handle <zeebe:adHoc>`: creates an element from the `ad-hoc-template` fixture, asserts that a `zeebe:AdHoc` extension exists and that `outputCollection` and `outputElement` are set as expected.
- **Fixture:** `TemplatesElementFactory.json`
  - Adds `ad-hoc-template` targeting `bpmn:AdHocSubProcess`.

## Backward compatibility
- Additive change. No existing bindings or templates are affected.
- No behavior changes for templates that don’t use `zeebe:adHoc`.

## How to test locally
1. Build & run tests: `npm run test` (or your repo’s standard test command).
2. In Modeler (or consumer app), import a template using the snippet above and apply it to an `AdHocSubProcess`.
3. Inspect XML to verify a single `<zeebe:AdHoc ...>` with the configured properties.

## Follow‑ups / docs
- Document supported properties for `zeebe:AdHoc` (currently `outputCollection`, `outputElement`) in user docs.
- Consider adding schema/validator rules to restrict `zeebe:adHoc` to `bpmn:AdHocSubProcess` and validate allowed properties.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
