### PR TITLE
feat: add `zeebe:adHoc` binding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support `zeebe:adHoc` binding property ([#175](https://github.com/bpmn-io/bpmn-js-element-templates/pull/175))
+
 ## 2.10.0
 
 * `FEAT`: support `zeebe:priorityDefinition` binding property ([#171](https://github.com/bpmn-io/bpmn-js-element-templates/pull/171))

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -37,7 +37,8 @@ import {
   ZEEBE_USER_TASK,
   ZEEBE_FORM_DEFINITION,
   ZEEBE_ASSIGNMENT_DEFINITION,
-  ZEEBE_PRIORITY_DEFINITION
+  ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_AD_HOC
 } from '../util/bindingTypes';
 
 import {
@@ -127,6 +128,8 @@ export default class ChangeElementTemplateHandler {
       this._updateZeebeAssignmentDefinition(element, oldTemplate, newTemplate);
 
       this._updateZeebePriorityDefinition(element, oldTemplate, newTemplate);
+
+      this._updateAdHoc(element, oldTemplate, newTemplate);
     }
   }
 
@@ -950,6 +953,19 @@ export default class ChangeElementTemplateHandler {
     );
   }
 
+  _updateAdHoc(element, oldTemplate, newTemplate) {
+    this._updateSingleExtensionElement(
+      element,
+      oldTemplate,
+      newTemplate,
+      {
+        bindingTypes: [ ZEEBE_AD_HOC ],
+        extensionType: 'zeebe:AdHoc',
+        getPropertyName: (binding) => binding.property
+      }
+    );
+  }
+
   /**
    * Replaces the element with the specified elementType.
    * Takes into account the eventDefinition for events.
@@ -1595,6 +1611,19 @@ export function findOldProperty(oldTemplate, newProperty) {
       return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
     });
   }
+
+  if (newBindingType === ZEEBE_AD_HOC) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_AD_HOC) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
 }
 
 /**
@@ -1721,6 +1750,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_PRIORITY_DEFINITION) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_AD_HOC) {
     return businessObject.get(bindingProperty);
   }
 }

--- a/src/cloud-element-templates/create/AdHocBindingProvider.js
+++ b/src/cloud-element-templates/create/AdHocBindingProvider.js
@@ -1,0 +1,22 @@
+import { ensureExtension } from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+/**
+ * Provider for the `zeebe:adHoc` binding. Ensures a single zeebe:AdHoc extension
+ * element exists and sets the configured property on it.
+ */
+export default class AdHocBindingProvider {
+  static create(element, options) {
+    const { property, bpmnFactory } = options;
+
+    const { binding } = property;
+    const { property: propertyName } = binding;
+
+    const value = getDefaultValue(property);
+
+    const adHoc = ensureExtension(element, 'zeebe:AdHoc', bpmnFactory);
+
+    adHoc.set(propertyName, value);
+  }
+}
+

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -20,6 +20,7 @@ import { ScriptTaskBindingProvider } from './ScriptTaskBindingProvider';
 import ZeebeFormDefinitionBindingProvider from './FormDefinitionBindingProvider';
 import ZeebeAssignmentDefinitionBindingProvider from './AssignmentDefinitionBindingProvider';
 import ZeebePriorityDefinitionBindingProvider from './PriorityDefinitionBindingProvider';
+import AdHocBindingProvider from './AdHocBindingProvider';
 
 import {
   MESSAGE_PROPERTY_TYPE,
@@ -38,7 +39,8 @@ import {
   ZEEBE_FORM_DEFINITION,
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
-  ZEEBE_PRIORITY_DEFINITION
+  ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_AD_HOC
 } from '../util/bindingTypes';
 
 import {
@@ -68,7 +70,8 @@ export default class TemplateElementFactory {
       [ZEEBE_FORM_DEFINITION]: ZeebeFormDefinitionBindingProvider,
       [ZEEBE_SCRIPT_TASK]: ScriptTaskBindingProvider,
       [ZEEBE_ASSIGNMENT_DEFINITION]: ZeebeAssignmentDefinitionBindingProvider,
-      [ZEEBE_PRIORITY_DEFINITION]: ZeebePriorityDefinitionBindingProvider
+      [ZEEBE_PRIORITY_DEFINITION]: ZeebePriorityDefinitionBindingProvider,
+      [ZEEBE_AD_HOC]: AdHocBindingProvider
     };
   }
 

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -17,6 +17,7 @@ export const ZEEBE_FORM_DEFINITION = 'zeebe:formDefinition';
 export const ZEEBE_SCRIPT_TASK = 'zeebe:script';
 export const ZEEBE_ASSIGNMENT_DEFINITION = 'zeebe:assignmentDefinition';
 export const ZEEBE_PRIORITY_DEFINITION = 'zeebe:priorityDefinition';
+export const ZEEBE_AD_HOC = 'zeebe:adHoc';
 
 export const EXTENSION_BINDING_TYPES = [
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
@@ -32,7 +33,8 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_FORM_DEFINITION,
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
-  ZEEBE_PRIORITY_DEFINITION
+  ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_AD_HOC
 ];
 
 export const TASK_DEFINITION_TYPES = [

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -29,7 +29,8 @@ import {
   ZEEBE_FORM_DEFINITION,
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
-  ZEEBE_PRIORITY_DEFINITION
+  ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_AD_HOC
 } from './bindingTypes';
 
 import {
@@ -270,6 +271,11 @@ function getRawPropertyValue(element, property) {
     const priorityDefinition = findExtension(businessObject, 'zeebe:PriorityDefinition');
 
     return priorityDefinition ? priorityDefinition.get(bindingProperty) : defaultValue;
+  }
+
+  if (type === ZEEBE_AD_HOC) {
+    const adHoc = findExtension(businessObject, 'zeebe:AdHoc');
+    return adHoc ? adHoc.get(bindingProperty) : defaultValue;
   }
 
   // should never throw as templates are validated beforehand
@@ -858,6 +864,39 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
       });
     }
   }
+
+  // zeebe:adHoc
+  if (type === ZEEBE_AD_HOC) {
+    let adHoc = findExtension(element, 'zeebe:AdHoc');
+    const propertyName = binding.property;
+
+    const properties = {
+      [ propertyName ]: value || ''
+    };
+
+    if (adHoc) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          properties,
+          moddleElement: adHoc
+        }
+      });
+    } else {
+      adHoc = createElement('zeebe:AdHoc', properties, extensionElements, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: extensionElements,
+          properties: { values: [ ...extensionElements.get('values'), adHoc ] }
+        }
+      });
+    }
+  }
+
 
 
   if (commands.length) {

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2141,6 +2141,86 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('zeebe:adHoc', function() {
+
+      beforeEach(bootstrap(require('./ad-hoc.bpmn').default));
+
+      const newTemplate = require('./ad-hoc.json');
+
+      it('should execute', inject(function(elementRegistry) {
+
+        // given
+        let subProcess = elementRegistry.get('AdHocSubProcess_1');
+
+        // when
+        changeTemplate(subProcess, newTemplate);
+
+        // then
+        expectElementTemplate(subProcess, 'com.camunda.example.AdHoc');
+
+        const adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+        expect(adHoc).to.exist;
+        expect(adHoc).to.have.property('outputCollection', 'toolCallResults');
+        expect(adHoc).to.have.property('outputElement', '={ id: toolCall._meta.id }');
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let subProcess = elementRegistry.get('AdHocSubProcess_1');
+        changeTemplate(subProcess, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        subProcess = elementRegistry.get('AdHocSubProcess_1');
+        expectNoElementTemplate(subProcess);
+        const adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+        expect(adHoc).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let subProcess = elementRegistry.get('AdHocSubProcess_1');
+        changeTemplate(subProcess, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        subProcess = elementRegistry.get('AdHocSubProcess_1');
+        expectElementTemplate(subProcess, 'com.camunda.example.AdHoc');
+        const adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+        expect(adHoc).to.exist;
+        expect(adHoc).to.have.property('outputCollection', 'toolCallResults');
+      }));
+
+
+      it('should not override existing', inject(function(elementRegistry) {
+
+        // given
+        let subProcess = elementRegistry.get('AdHocSubProcess_existing');
+
+        // when
+        changeTemplate(subProcess, newTemplate);
+
+        // then
+        const adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+        expect(adHoc).to.exist;
+
+        // existing values should be kept (non Hidden property types)
+        expect(adHoc).to.have.property('outputCollection', 'existingCollection');
+        expect(adHoc).to.have.property('outputElement', '={ existing: true }');
+      }));
+
+    });
+
+
     describe('update zeebe:LinkedElement', function() {
 
       beforeEach(bootstrap(require('./linked-resource.bpmn').default));
@@ -4902,6 +4982,127 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('update zeebe:adHoc', function() {
+
+      beforeEach(bootstrap(require('./ad-hoc.bpmn').default));
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given
+        const subProcess = elementRegistry.get('AdHocSubProcess_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'oldCollection',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputCollection'
+            }
+          },
+          {
+            value: '={ id: oldValue }',
+            feel: 'required',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputElement'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'newCollection',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputCollection'
+            }
+          },
+          {
+            value: '={ id: newValue }',
+            feel: 'required',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputElement'
+            }
+          }
+        ]);
+
+        changeTemplate('AdHocSubProcess_1', oldTemplate);
+
+        let adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+
+        updateBusinessObject('AdHocSubProcess_1', adHoc, {
+          outputCollection: 'manuallyChanged'
+        });
+
+        // when
+        changeTemplate(subProcess, newTemplate, oldTemplate);
+
+        // then
+        adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+
+        expect(adHoc).to.exist;
+        expect(adHoc.get('outputCollection')).to.equal('manuallyChanged');
+        expect(adHoc.get('outputElement')).to.equal('={ id: newValue }');
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given
+        const subProcess = elementRegistry.get('AdHocSubProcess_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'oldCollection',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputCollection'
+            }
+          },
+          {
+            value: '={ id: oldValue }',
+            feel: 'required',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputElement'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 'newCollection',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputCollection'
+            }
+          },
+          {
+            value: '={ id: newValue }',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputElement'
+            }
+          }
+        ]);
+
+        changeTemplate('AdHocSubProcess_1', oldTemplate);
+
+        // when
+        changeTemplate(subProcess, newTemplate, oldTemplate);
+
+        // then
+        const adHoc = findExtension(subProcess, 'zeebe:AdHoc');
+
+        expect(adHoc).to.exist;
+        expect(adHoc.get('outputCollection')).to.equal('newCollection');
+        expect(adHoc.get('outputElement')).to.equal('={ id: newValue }');
+      }));
+
+    });
+
+
     describe('update zeebe:LinkedResource', function() {
 
       beforeEach(bootstrap(require('./linked-resource.bpmn').default));
@@ -5506,7 +5707,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
       }));
     });
-
 
   });
 

--- a/test/spec/cloud-element-templates/cmd/ad-hoc.bpmn
+++ b/test/spec/cloud-element-templates/cmd/ad-hoc.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess_existing">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="existingCollection" outputElement="={ existing: true }" />
+      </bpmn:extensionElements>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="AdHocSubProcess_1_di" bpmnElement="AdHocSubProcess_1">
+        <dc:Bounds x="100" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcess_existing_di" bpmnElement="AdHocSubProcess_existing">
+        <dc:Bounds x="350" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/test/spec/cloud-element-templates/cmd/ad-hoc.json
+++ b/test/spec/cloud-element-templates/cmd/ad-hoc.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "AdHoc",
+  "id": "com.camunda.example.AdHoc",
+  "appliesTo": [
+    "bpmn:AdHocSubProcess"
+  ],
+  "properties": [
+    {
+      "type": "Text",
+      "value": "toolCallResults",
+      "binding": {
+        "type": "zeebe:adHoc",
+        "property": "outputCollection"
+      }
+    },
+    {
+      "type": "Text",
+      "value": "={ id: toolCall._meta.id }",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:adHoc",
+        "property": "outputElement"
+      }
+    }
+  ]
+}
+

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -636,6 +636,23 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
       });
     }));
 
+
+    it('should handle <zeebe:adHoc>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('ad-hoc-template');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      const adHoc = findExtension(element, 'zeebe:AdHoc');
+
+      // then
+      expect(adHoc).to.exist;
+      expect(adHoc.get('outputCollection')).to.equal('toolCallResults');
+      expect(adHoc.get('outputElement')).to.equal('={ id: toolCall._meta.id }');
+    }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -759,5 +759,32 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AdHoc Template",
+    "id": "ad-hoc-template",
+    "appliesTo": [
+      "bpmn:AdHocSubProcess"
+    ],
+    "version": 1,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "toolCallResults",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputCollection"
+        }
+      },
+      {
+        "type": "Text",
+        "value": "={ id: toolCall._meta.id }",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputElement"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/fixtures/ad-hoc.json
+++ b/test/spec/cloud-element-templates/fixtures/ad-hoc.json
@@ -1,0 +1,1542 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AdHoc",
+    "id": "com.camunda.example.AdHoc",
+    "appliesTo": [
+      "bpmn:Activity"
+    ],
+    "elementType": {
+      "value": "bpmn:AdHocSubProcess"
+    },
+    "properties": [
+      {
+        "label": "Ad-Hoc Job Worker",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskDefinition",
+          "property": "type"
+        },
+        "value": "ad-hoc-job-worker"
+      },
+      {
+        "label": "Output Collection",
+        "type": "String",
+        "value": "toolCallResults",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputCollection"
+        }
+      },
+      {
+        "label": "Output Element",
+        "type": "String",
+        "value": "=element.result",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputElement"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AI Agent",
+    "id": "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
+    "description": "Provides a generic AI agent implementation handling the feedback loop between user requests, tool calls and LLM responses. Compatible with 8.8.0-alpha7 or later.",
+    "metadata": {
+      "keywords": []
+    },
+    "documentationRef": "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
+    "version": 2,
+    "category": {
+      "id": "connectors",
+      "name": "Connectors"
+    },
+    "appliesTo": [
+      "bpmn:SubProcess"
+    ],
+    "elementType": {
+      "value": "bpmn:AdHocSubProcess"
+    },
+    "engines": {
+      "camunda": "^8.8"
+    },
+    "groups": [
+      {
+        "id": "provider",
+        "label": "Model provider",
+        "openByDefault": false
+      },
+      {
+        "id": "model",
+        "label": "Model",
+        "openByDefault": false
+      },
+      {
+        "id": "systemPrompt",
+        "label": "System prompt",
+        "tooltip": "A system prompt is a set of foundational instructions given to a model before any user interaction begins. It defines the AI agent’s role, behavior, tone, and communication style, ensuring that responses remain consistent and aligned with the AI agent’s intended purpose. These instructions help shape how the model interprets and responds to user input throughout the conversation.",
+        "openByDefault": false
+      },
+      {
+        "id": "userPrompt",
+        "label": "User prompt",
+        "tooltip": "A user prompt is the message or question you give to the AI to start or continue a conversation. It tells the AI what you need, whether it's information, help with a task, or just a chat. The AI uses your prompt to understand how to respond.",
+        "openByDefault": false
+      },
+      {
+        "id": "tools",
+        "label": "Tools",
+        "tooltip": "Tools are optional features the AI Agent can use to perform specific tasks. Configure this if the agent should participate in a tools feedback loop.",
+        "openByDefault": false
+      },
+      {
+        "id": "memory",
+        "label": "Memory",
+        "tooltip": "Configuration of the Agent's short-term/conversational memory.",
+        "openByDefault": false
+      },
+      {
+        "id": "limits",
+        "label": "Limits",
+        "openByDefault": false
+      },
+      {
+        "id": "response",
+        "label": "Response",
+        "tooltip": "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/#response\">documentation</a> for details.",
+        "openByDefault": false
+      },
+      {
+        "id": "connector",
+        "label": "Connector"
+      },
+      {
+        "id": "output",
+        "label": "Output mapping"
+      }
+    ],
+    "properties": [
+      {
+        "value": "io.camunda.agenticai:aiagent-job-worker:1",
+        "binding": {
+          "property": "type",
+          "type": "zeebe:taskDefinition"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "toolCallResults",
+        "binding": {
+          "name": "toolCallResults",
+          "type": "zeebe:input"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "outputCollection",
+        "binding": {
+          "property": "outputCollection",
+          "type": "zeebe:adHoc"
+        },
+        "value": "toolCallResults",
+        "type": "Hidden"
+      },
+      {
+        "id": "outputElement",
+        "binding": {
+          "property": "outputElement",
+          "type": "zeebe:adHoc"
+        },
+        "value": "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
+        "type": "Hidden"
+      },
+      {
+        "id": "provider.type",
+        "label": "Provider",
+        "description": "Specify the LLM provider to use.",
+        "value": "anthropic",
+        "group": "provider",
+        "binding": {
+          "name": "provider.type",
+          "type": "zeebe:input"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Anthropic",
+            "value": "anthropic"
+          },
+          {
+            "name": "AWS Bedrock",
+            "value": "bedrock"
+          },
+          {
+            "name": "Azure OpenAI",
+            "value": "azureOpenAi"
+          },
+          {
+            "name": "Google Vertex AI",
+            "value": "google-vertex-ai"
+          },
+          {
+            "name": "OpenAI",
+            "value": "openai"
+          }
+        ]
+      },
+      {
+        "id": "provider.anthropic.endpoint",
+        "label": "Endpoint",
+        "description": "Optional custom API endpoint",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.anthropic.endpoint",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.anthropic.authentication.apiKey",
+        "label": "Anthropic API key",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.anthropic.authentication.apiKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.bedrock.region",
+        "label": "Region",
+        "description": "Specify the AWS region (example: <code>eu-west-1</code>)",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.bedrock.region",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.bedrock.endpoint",
+        "label": "Endpoint",
+        "description": "Optional custom API endpoint",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.bedrock.endpoint",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.bedrock.authentication.type",
+        "label": "Authentication",
+        "description": "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>",
+        "value": "credentials",
+        "group": "provider",
+        "binding": {
+          "name": "provider.bedrock.authentication.type",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Credentials",
+            "value": "credentials"
+          },
+          {
+            "name": "Default Credentials Chain (Hybrid/Self-Managed only)",
+            "value": "defaultCredentialsChain"
+          }
+        ]
+      },
+      {
+        "id": "provider.bedrock.authentication.accessKey",
+        "label": "Access key",
+        "description": "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.bedrock.authentication.accessKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.bedrock.authentication.type",
+              "equals": "credentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "bedrock",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.bedrock.authentication.secretKey",
+        "label": "Secret key",
+        "description": "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.bedrock.authentication.secretKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.bedrock.authentication.type",
+              "equals": "credentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "bedrock",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.endpoint",
+        "label": "Endpoint",
+        "description": "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.endpoint",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.type",
+        "label": "Authentication",
+        "description": "Specify the Azure OpenAI authentication strategy.",
+        "value": "apiKey",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.type",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "API key",
+            "value": "apiKey"
+          },
+          {
+            "name": "Client credentials",
+            "value": "clientCredentials"
+          }
+        ]
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.apiKey",
+        "label": "API key",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.apiKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.azureOpenAi.authentication.type",
+              "equals": "apiKey",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "azureOpenAi",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.clientId",
+        "label": "Client ID",
+        "description": "ID of a Microsoft Entra application",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.clientId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.azureOpenAi.authentication.type",
+              "equals": "clientCredentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "azureOpenAi",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.clientSecret",
+        "label": "Client secret",
+        "description": "Secret of a Microsoft Entra application",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.clientSecret",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.azureOpenAi.authentication.type",
+              "equals": "clientCredentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "azureOpenAi",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.tenantId",
+        "label": "Tenant ID",
+        "description": "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.tenantId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.azureOpenAi.authentication.type",
+              "equals": "clientCredentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "azureOpenAi",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.authentication.authorityHost",
+        "label": "Authority host",
+        "description": "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.azureOpenAi.authentication.authorityHost",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.azureOpenAi.authentication.type",
+              "equals": "clientCredentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "azureOpenAi",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.googleVertexAi.projectId",
+        "label": "Project ID",
+        "description": "Specify Google Cloud project ID",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.googleVertexAi.projectId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.googleVertexAi.region",
+        "label": "Region",
+        "description": "Specify the region where AI inference should take place",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.googleVertexAi.region",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.googleVertexAi.authentication.type",
+        "label": "Authentication",
+        "description": "Specify the Google Vertex AI authentication strategy.",
+        "value": "serviceAccountCredentials",
+        "group": "provider",
+        "binding": {
+          "name": "provider.googleVertexAi.authentication.type",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Service account credentials",
+            "value": "serviceAccountCredentials"
+          },
+          {
+            "name": "Application default credentials (Hybrid/Self-Managed only)",
+            "value": "applicationDefaultCredentials"
+          }
+        ]
+      },
+      {
+        "id": "provider.googleVertexAi.authentication.jsonKey",
+        "label": "JSON key of the service account",
+        "description": "This is the key of the service account in JSON format.",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.googleVertexAi.authentication.jsonKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "provider.googleVertexAi.authentication.type",
+              "equals": "serviceAccountCredentials",
+              "type": "simple"
+            },
+            {
+              "property": "provider.type",
+              "equals": "google-vertex-ai",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.authentication.apiKey",
+        "label": "OpenAI API key",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.openai.authentication.apiKey",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.authentication.organizationId",
+        "label": "Organization ID",
+        "description": "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.openai.authentication.organizationId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.authentication.projectId",
+        "label": "Project ID",
+        "description": "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.openai.authentication.projectId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.endpoint",
+        "label": "Custom API endpoint",
+        "description": "Optional custom API endpoint.",
+        "optional": true,
+        "feel": "optional",
+        "group": "provider",
+        "binding": {
+          "name": "provider.openai.endpoint",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "tooltip": "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.headers",
+        "label": "Custom headers",
+        "description": "Map of custom HTTP headers to add to the request.",
+        "optional": true,
+        "feel": "required",
+        "group": "provider",
+        "binding": {
+          "name": "provider.openai.headers",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.anthropic.model.model",
+        "label": "Model",
+        "description": "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "value": "claude-3-5-sonnet-20240620",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "model",
+        "binding": {
+          "name": "provider.anthropic.model.model",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.anthropic.model.parameters.maxTokens",
+        "label": "Maximum tokens",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.anthropic.model.parameters.maxTokens",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "tooltip": "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.anthropic.model.parameters.temperature",
+        "label": "Temperature",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.anthropic.model.parameters.temperature",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.anthropic.model.parameters.topP",
+        "label": "top P",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.anthropic.model.parameters.topP",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.anthropic.model.parameters.topK",
+        "label": "top K",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.anthropic.model.parameters.topK",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "anthropic",
+          "type": "simple"
+        },
+        "tooltip": "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.bedrock.model.model",
+        "label": "Model",
+        "description": "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "value": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "model",
+        "binding": {
+          "name": "provider.bedrock.model.model",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.bedrock.model.parameters.maxTokens",
+        "label": "Maximum tokens",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.bedrock.model.parameters.maxTokens",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "tooltip": "The maximum number of tokens per request to allow in the generated response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.bedrock.model.parameters.temperature",
+        "label": "Temperature",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.bedrock.model.parameters.temperature",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.bedrock.model.parameters.topP",
+        "label": "top P",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.bedrock.model.parameters.topP",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "bedrock",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.azureOpenAi.model.deploymentName",
+        "label": "Model deployment name",
+        "description": "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "model",
+        "binding": {
+          "name": "provider.azureOpenAi.model.deploymentName",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.azureOpenAi.model.parameters.maxTokens",
+        "label": "Maximum tokens",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.azureOpenAi.model.parameters.maxTokens",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "tooltip": "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.azureOpenAi.model.parameters.temperature",
+        "label": "Temperature",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.azureOpenAi.model.parameters.temperature",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.azureOpenAi.model.parameters.topP",
+        "label": "top P",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.azureOpenAi.model.parameters.topP",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "azureOpenAi",
+          "type": "simple"
+        },
+        "tooltip": "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.googleVertexAi.model.model",
+        "label": "Model",
+        "description": "Specify the model ID. Details in the <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/models\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "model",
+        "binding": {
+          "name": "provider.googleVertexAi.model.model",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.googleVertexAi.model.parameters.maxOutputTokens",
+        "label": "Maximum output tokens",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.googleVertexAi.model.parameters.maxOutputTokens",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "tooltip": "Maximum number of tokens that can be generated in the response. <br><br>Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.googleVertexAi.model.parameters.temperature",
+        "label": "Temperature",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.googleVertexAi.model.parameters.temperature",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "tooltip": "Controls the degree of randomness in token selection. <br><br>Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.googleVertexAi.model.parameters.topP",
+        "label": "top P",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.googleVertexAi.model.parameters.topP",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.googleVertexAi.model.parameters.topK",
+        "label": "top K",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.googleVertexAi.model.parameters.topK",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "google-vertex-ai",
+          "type": "simple"
+        },
+        "tooltip": "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.openai.model.model",
+        "label": "Model",
+        "description": "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+        "optional": false,
+        "value": "gpt-4o",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "model",
+        "binding": {
+          "name": "provider.openai.model.model",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "provider.openai.model.parameters.maxCompletionTokens",
+        "label": "Maximum completion tokens",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.openai.model.parameters.maxCompletionTokens",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "tooltip": "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.openai.model.parameters.temperature",
+        "label": "Temperature",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.openai.model.parameters.temperature",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "tooltip": "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "provider.openai.model.parameters.topP",
+        "label": "top P",
+        "optional": true,
+        "feel": "required",
+        "group": "model",
+        "binding": {
+          "name": "provider.openai.model.parameters.topP",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "provider.type",
+          "equals": "openai",
+          "type": "simple"
+        },
+        "tooltip": "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+        "type": "Number"
+      },
+      {
+        "id": "data.systemPrompt.prompt",
+        "label": "System prompt",
+        "optional": false,
+        "value": "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n<context>…briefly state the customer’s need and current state…</context>\n<reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "systemPrompt",
+        "binding": {
+          "name": "data.systemPrompt.prompt",
+          "type": "zeebe:input"
+        },
+        "type": "Text"
+      },
+      {
+        "id": "data.systemPrompt.parameters",
+        "label": "System prompt parameters",
+        "description": "Use <code>{{parameter}}</code> format in the prompt to insert values defined in this map.",
+        "optional": true,
+        "feel": "required",
+        "group": "systemPrompt",
+        "binding": {
+          "name": "data.systemPrompt.parameters",
+          "type": "zeebe:input"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.userPrompt.prompt",
+        "label": "User prompt",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "userPrompt",
+        "binding": {
+          "name": "data.userPrompt.prompt",
+          "type": "zeebe:input"
+        },
+        "type": "Text"
+      },
+      {
+        "id": "data.userPrompt.parameters",
+        "label": "User prompt parameters",
+        "description": "Use <code>{{parameter}}</code> format in the prompt to insert values defined in this map.",
+        "optional": true,
+        "feel": "required",
+        "group": "userPrompt",
+        "binding": {
+          "name": "data.userPrompt.parameters",
+          "type": "zeebe:input"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.userPrompt.documents",
+        "label": "Documents",
+        "description": "Documents to be included in the user prompt.",
+        "optional": true,
+        "feel": "required",
+        "group": "userPrompt",
+        "binding": {
+          "name": "data.userPrompt.documents",
+          "type": "zeebe:input"
+        },
+        "tooltip": "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+        "type": "String"
+      },
+      {
+        "id": "agentContext",
+        "label": "Agent context",
+        "description": "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+        "optional": true,
+        "feel": "required",
+        "group": "memory",
+        "binding": {
+          "name": "agentContext",
+          "type": "zeebe:input"
+        },
+        "tooltip": "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/\" target=\"_blank\">See documentation</a> for details.",
+        "type": "Text"
+      },
+      {
+        "id": "data.memory.storage.type",
+        "label": "Memory storage type",
+        "description": "Specify how to store the conversation memory.",
+        "value": "in-process",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.storage.type",
+          "type": "zeebe:input"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "In Process (part of agent context)",
+            "value": "in-process"
+          },
+          {
+            "name": "Camunda Document Storage",
+            "value": "camunda-document"
+          },
+          {
+            "name": "Custom Implementation (Hybrid/Self-Managed only)",
+            "value": "custom"
+          }
+        ]
+      },
+      {
+        "id": "data.memory.storage.timeToLive",
+        "label": "Document TTL",
+        "description": "How long to retain the conversation document as ISO-8601 duration (example: <code>P14D</code>).",
+        "optional": true,
+        "feel": "optional",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.storage.timeToLive",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.memory.storage.type",
+          "equals": "camunda-document",
+          "type": "simple"
+        },
+        "tooltip": "Will use the cluster default TTL (time-to-live) if not specified. Make sure to set this value to a reasonable duration matching your process lifecycle.",
+        "type": "String"
+      },
+      {
+        "id": "data.memory.storage.customProperties",
+        "label": "Custom document properties",
+        "description": "An optional map of custom properties to be stored with the conversation document.",
+        "optional": true,
+        "feel": "required",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.storage.customProperties",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.memory.storage.type",
+          "equals": "camunda-document",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.memory.storage.storeType",
+        "label": "Implementation type",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.storage.storeType",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.memory.storage.type",
+          "equals": "custom",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.memory.storage.parameters",
+        "label": "Parameters",
+        "description": "Parameters for the custom memory storage implementation.",
+        "optional": true,
+        "feel": "required",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.storage.parameters",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.memory.storage.type",
+          "equals": "custom",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.memory.contextWindowSize",
+        "label": "Context window size",
+        "description": "Maximum number of recent conversation messages which are passed to the model.",
+        "optional": false,
+        "value": 20,
+        "feel": "static",
+        "group": "memory",
+        "binding": {
+          "name": "data.memory.contextWindowSize",
+          "type": "zeebe:input"
+        },
+        "tooltip": "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/\" target=\"_blank\">See documentation</a> for details.",
+        "type": "Number"
+      },
+      {
+        "id": "data.limits.maxModelCalls",
+        "label": "Maximum model calls",
+        "description": "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
+        "optional": false,
+        "value": 10,
+        "feel": "static",
+        "group": "limits",
+        "binding": {
+          "name": "data.limits.maxModelCalls",
+          "type": "zeebe:input"
+        },
+        "type": "Number"
+      },
+      {
+        "id": "data.response.format.type",
+        "label": "Response format",
+        "description": "Specify the response format. Support for JSON mode varies by provider.",
+        "value": "text",
+        "group": "response",
+        "binding": {
+          "name": "data.response.format.type",
+          "type": "zeebe:input"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Text",
+            "value": "text"
+          },
+          {
+            "name": "JSON",
+            "value": "json"
+          }
+        ]
+      },
+      {
+        "id": "data.response.format.parseJson",
+        "label": "Parse text as JSON",
+        "description": "Tries to parse the LLM response text as JSON object.",
+        "optional": true,
+        "feel": "static",
+        "group": "response",
+        "binding": {
+          "name": "data.response.format.parseJson",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.response.format.type",
+          "equals": "text",
+          "type": "simple"
+        },
+        "tooltip": "Use this option in combination with models which don't support native JSON mode/structured tool calling (e.g. Anthropic). Make sure to instruct the model to return valid JSON in the system prompt. The parsed JSON will be available as <code>response.responseJson</code>.<br><br>If parsing fails, <code>null</code> will be returned as JSON response, but the text content will still be available as <code>response.responseText</code>.",
+        "type": "Boolean"
+      },
+      {
+        "id": "data.response.format.schema",
+        "label": "Response JSON schema",
+        "description": "An optional response <a href=\"https://json-schema.org/\" target=\"_blank\">JSON Schema</a> to instruct the model how to structure the JSON output.",
+        "optional": true,
+        "feel": "required",
+        "group": "response",
+        "binding": {
+          "name": "data.response.format.schema",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.response.format.type",
+          "equals": "json",
+          "type": "simple"
+        },
+        "tooltip": "If supported by the model, the response will be structured according to the provided schema. A parsed version of the response will be available as <code>response.responseJson</code>.",
+        "type": "String"
+      },
+      {
+        "id": "data.response.format.schemaName",
+        "label": "Response JSON schema name",
+        "description": "An optional name for the response JSON Schema to make the model aware of the expected output.",
+        "optional": true,
+        "value": "Response",
+        "feel": "optional",
+        "group": "response",
+        "binding": {
+          "name": "data.response.format.schemaName",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "data.response.format.type",
+          "equals": "json",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.response.includeAssistantMessage",
+        "label": "Include assistant message",
+        "description": "Include the full assistant message as part of the result object.",
+        "optional": true,
+        "feel": "static",
+        "group": "response",
+        "binding": {
+          "name": "data.response.includeAssistantMessage",
+          "type": "zeebe:input"
+        },
+        "tooltip": "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
+        "type": "Boolean"
+      },
+      {
+        "id": "data.response.includeAgentContext",
+        "label": "Include agent context",
+        "description": "Include the agent context as part of the result object.",
+        "optional": true,
+        "feel": "static",
+        "group": "response",
+        "binding": {
+          "name": "data.response.includeAgentContext",
+          "type": "zeebe:input"
+        },
+        "tooltip": "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
+        "type": "Boolean"
+      },
+      {
+        "id": "version",
+        "label": "Version",
+        "description": "Version of the element template",
+        "value": "2",
+        "group": "connector",
+        "binding": {
+          "key": "elementTemplateVersion",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "id",
+        "label": "ID",
+        "description": "ID of the element template",
+        "value": "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
+        "group": "connector",
+        "binding": {
+          "key": "elementTemplateId",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "resultVariable",
+        "label": "Result variable",
+        "description": "Name of variable to store the response in",
+        "value": "agent",
+        "group": "output",
+        "binding": {
+          "source": "=agent",
+          "type": "zeebe:output"
+        },
+        "type": "String"
+      },
+      {
+        "id": "retryCount",
+        "label": "Retries",
+        "description": "Number of retries",
+        "value": "3",
+        "feel": "optional",
+        "group": "retries",
+        "binding": {
+          "property": "retries",
+          "type": "zeebe:taskDefinition"
+        },
+        "type": "String"
+      },
+      {
+        "id": "retryBackoff",
+        "label": "Retry backoff",
+        "description": "ISO-8601 duration to wait between retries",
+        "value": "PT0S",
+        "group": "retries",
+        "binding": {
+          "key": "retryBackoff",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "String"
+      }
+    ],
+    "icon": {
+      "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"
+    }
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -110,6 +110,13 @@
         <zeebe:priorityDefinition priority="10" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="zeebe:adHoc" zeebe:modelerTemplate="com.camunda.example.AdHoc">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="ad-hoc-job-worker" />
+        <zeebe:adHoc outputCollection="toolCallResults" outputElement="=element.result" />
+      </bpmn:extensionElements>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="AdHocSubProcess_empty" name="AdHocSubProcess" />
   </bpmn:process>
   <bpmn:message id="Message" name="name">
     <bpmn:extensionElements>
@@ -222,6 +229,16 @@
         <dc:Bounds x="290" y="1030" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kj2zmg_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
+        <dc:Bounds x="290" y="1190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1q9rek1_di" bpmnElement="AdHocSubProcess_empty">
+        <dc:Bounds x="415" y="1490" width="100" height="80" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1b44hfv">
+    <bpmndi:BPMNPlane id="BPMNPlane_0xregwg" bpmnElement="AdHocSubProcess_empty" />
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -865,6 +865,41 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AdHoc",
+    "id": "com.camunda.example.AdHoc",
+    "appliesTo": [
+      "bpmn:AdHocSubProcess"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:taskDefinition",
+          "property": "type"
+        },
+        "value": "ad-hoc-job-worker"
+      },
+      {
+        "type": "String",
+        "value": "toolCallResults",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputCollection"
+        }
+      },
+      {
+        "type": "String",
+        "value": "=element.result",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:adHoc",
+          "property": "outputElement"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Non-existing property",
     "id": "my.example.non-existing-property",
     "appliesTo": [


### PR DESCRIPTION
### Proposed Changes

Support zeebe:adHoc with outputCollection and outputElement properties.

Related to https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/2 (Issue content is partially outdated)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
