### PR TITLE
feat: cache templates between linter plugin setups

### DIFF
--- a/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
@@ -11,18 +11,9 @@
 import ElementTemplates from '../../ElementTemplates';
 import EventBus from 'diagram-js/lib/core/EventBus';
 
-import BpmnModdle from 'bpmn-moddle';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
-import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
-
-import { Validator } from '../../Validator';
-
 export default function({ templates = [] }) {
-  const moddle = new BpmnModdle({ zeebe: zeebeModdle });
-
-  const validator = new Validator(moddle).addAll(templates);
-  const validTemplates = validator.getValidTemplates();
 
   // We use the ElementTemplates Module without the required bpmn-js modules
   // As we only use it to facilitate template ID and version lookup,
@@ -30,7 +21,7 @@ export default function({ templates = [] }) {
   const eventBus = new EventBus();
   const elementTemplates = new ElementTemplates(null, null, eventBus, null, null);
 
-  elementTemplates.set(validTemplates);
+  elementTemplates.set(templates);
 
   function isUpdateAvailable(template) {
 

--- a/src/cloud-element-templates/linting/rules/element-templates-validate.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-validate.js
@@ -10,23 +10,13 @@
 
 import ElementTemplates from '../../ElementTemplates';
 import EventBus from 'diagram-js/lib/core/EventBus';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import { getPropertyValue, validateProperty } from '../../util/propertyUtil';
 
 import { applyConditions } from '../../Condition';
 
-import BpmnModdle from 'bpmn-moddle';
-import { is } from 'bpmn-js/lib/util/ModelUtil';
-
-import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
-
-import { Validator } from '../../Validator';
-
 export default function({ templates = [] }) {
-  const moddle = new BpmnModdle({ zeebe: zeebeModdle });
-
-  const validator = new Validator(moddle).addAll(templates);
-  const validTemplates = validator.getValidTemplates();
 
   // We use the ElementTemplates Module without the required bpmn-js modules
   // As we only use it to facilitate template ID and version lookup,
@@ -34,7 +24,7 @@ export default function({ templates = [] }) {
   const eventBus = new EventBus();
   const elementTemplates = new ElementTemplates(null, null, eventBus, null, null);
 
-  elementTemplates.set(validTemplates);
+  elementTemplates.set(templates);
 
   function check(node, reporter) {
 

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
@@ -1,5 +1,7 @@
+import { Linter } from 'bpmnlint';
 import RuleTester from 'bpmnlint/lib/testers/rule-tester';
 
+import { ElementTemplateLinterPlugin } from 'src/cloud-element-templates/linting';
 import validateRule from 'src/cloud-element-templates/linting/rules/element-templates-validate';
 import compatibilityRule from 'src/cloud-element-templates/linting/rules/element-templates-compatibility';
 
@@ -231,6 +233,82 @@ describe('cloud-element-templates/linting', function() {
     invalid: incompatible
   });
 
+
+  it('should create the plugin within performance constraints', function() {
+
+    // given
+    this.timeout(100);
+
+    let i = 0;
+    while (i < 1000) {
+
+      // when
+      ElementTemplateLinterPlugin(templates);
+      i++;
+    }
+
+    // then
+    // no error (timeout)
+  });
+
+
+  it('should create `validate` rule within performance constraints', function() {
+
+    // given
+    this.timeout(100);
+
+    let i = 0;
+    while (i < 1000) {
+
+      // when
+      validateRule({ templates });
+      i++;
+    }
+
+    // then
+    // no error (timeout)
+  });
+
+
+  it('should create `compatibility` rule within performance constraints', function() {
+
+    // given
+    this.timeout(100);
+
+    let i = 0;
+    while (i < 1000) {
+
+      // when
+      compatibilityRule({ templates });
+      i++;
+    }
+
+    // then
+    // no error (timeout)
+  });
+
+
+  it('should lint correctly when templates configuration changes', async function() {
+
+    // given
+    let linter = new Linter(ElementTemplateLinterPlugin(templates));
+    const moddleElement = (await createProcess('<bpmn:task id="Task_1" zeebe:modelerTemplate="constraints.empty" />')).root;
+
+    // when
+    const result = await linter.lint(moddleElement);
+
+    // assume
+    expect(Object.keys(result)).to.be.empty;
+
+    // and when
+    linter = new Linter(ElementTemplateLinterPlugin([]));
+    const secondResult = await linter.lint(moddleElement);
+
+    // then
+    const report = secondResult['element-templates/validate'][0];
+    expect(report).to.have.property('id', 'Task_1');
+    expect(report).to.have.property('message', 'Linked element template not found');
+  });
 });
 
 


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/178, this PR sets up a simple memoization so that we don't validate the templates with each rule setup, but rather once when the resolver starts.
Since we only expose the linter plugin from this library, for an end user it's transparent whether we perform the validation in the resolver, or in the rule setup.

Related to https://github.com/camunda/web-modeler/issues/16538

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
