### PR TITLE
feat: appended subprocesses should be always expanded

### DIFF
--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -42,7 +42,7 @@ import {
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
-  ZEEBE_TASK_SCHEDULE,
+  ZEEBE_TASK_SCHEDULE
 } from '../util/bindingTypes';
 
 import { isConditionMet } from '../Condition';

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -114,7 +114,7 @@ export default class TemplateElementFactory {
     const elementFactory = this._elementFactory;
 
     const attrs = {
-      type: elementType.value || appliesTo[0],
+      type: elementType.value || appliesTo[0]
     };
 
     if (isSubprocess(attrs.type)) {

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -42,12 +42,11 @@ import {
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
-  ZEEBE_TASK_SCHEDULE
+  ZEEBE_TASK_SCHEDULE,
 } from '../util/bindingTypes';
 
-import {
-  isConditionMet
-} from '../Condition';
+import { isConditionMet } from '../Condition';
+import { isSubprocess } from '../../utils/ElementUtil';
 
 export default class TemplateElementFactory {
 
@@ -115,8 +114,12 @@ export default class TemplateElementFactory {
     const elementFactory = this._elementFactory;
 
     const attrs = {
-      type: elementType.value || appliesTo[0]
+      type: elementType.value || appliesTo[0],
     };
+
+    if (isSubprocess(attrs.type)) {
+      attrs.isExpanded = true;
+    }
 
     // apply eventDefinition
     if (elementType.eventDefinition) {

--- a/src/utils/ElementUtil.js
+++ b/src/utils/ElementUtil.js
@@ -68,5 +68,5 @@ export function findRootElementById(businessObject, type, id) {
  * @returns {boolean}
  */
 export function isSubprocess(elementType) {
-  return elementType === 'bpmn:SubProcess' || elementType === 'bpmn:AdHocSubProcess';
+  return elementType === 'bpmn:SubProcess' || elementType === 'bpmn:AdHocSubProcess' || elementType === 'bpmn:Transaction';
 }

--- a/src/utils/ElementUtil.js
+++ b/src/utils/ElementUtil.js
@@ -60,3 +60,13 @@ export function findRootElementById(businessObject, type, id) {
 
   return elements.find(element => element.id === id);
 }
+
+/**
+ * Check if element type is a subprocess (either regular or AdHoc).
+ *
+ * @param {string} elementType
+ * @returns {boolean}
+ */
+export function isSubprocess(elementType) {
+  return elementType === 'bpmn:SubProcess' || elementType === 'bpmn:AdHocSubProcess';
+}

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -36,6 +36,8 @@ import conditionTemplates from './TemplateElementFactory.conditions.json';
 
 import completionConditionTemplates from '../fixtures/completion-condition.json';
 
+import subprocessTemplates from '../fixtures/subprocess.json';
+
 
 describe('provider/cloud-element-templates - TemplateElementFactory', function() {
 
@@ -133,6 +135,41 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
     // then
     expect(icon).to.exist;
     expect(icon).to.equal("data:image/svg+xml,%3Csvg width='24' height='24'%3C/svg%3E");
+  }));
+
+
+  it('should create expanded subprocess elements', inject(function(templateElementFactory) {
+
+    // given
+    const subprocessTemplate = subprocessTemplates[0]; // 'subprocess' template
+
+    // when
+    const element = templateElementFactory.create(subprocessTemplate);
+
+    // then
+    expect(element.type).to.equal('bpmn:SubProcess');
+    expect(element.collapsed).to.be.false; // subprocess should be expanded
+  }));
+
+
+  it('should create expanded AdHoc subprocess elements', inject(function(templateElementFactory) {
+
+    // given
+    const adHocSubprocessTemplate = {
+      '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+      'id': 'adhocsubprocess',
+      'name': 'AdHocSubProcess',
+      'version': 1,
+      'appliesTo': [ 'bpmn:AdHocSubProcess' ],
+      'properties': []
+    };
+
+    // when
+    const element = templateElementFactory.create(adHocSubprocessTemplate);
+
+    // then
+    expect(element.type).to.equal('bpmn:AdHocSubProcess');
+    expect(element.collapsed).to.be.false; // AdHoc subprocess should also be expanded
   }));
 
 


### PR DESCRIPTION
### Proposed Changes

This PR implements automatic expansion of subprocess elements when they are created from element templates, addressing issue https://github.com/camunda/camunda-modeler/issues/5273.

https://github.com/user-attachments/assets/a5f83ff5-f583-470a-8c40-a5b91b5328ed

Closes https://github.com/camunda/camunda-modeler/issues/5273

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
