### PR TITLE
feat: show unknown element template id in linting and properties panel

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -114,4 +114,5 @@
 .bio-properties-panel-deprecated-template-text,
 .bio-properties-panel-template-incompatible-text {
   width: 216px;
+  overflow-wrap: break-word;
 }

--- a/src/cloud-element-templates/linting/rules/element-templates-validate.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-validate.js
@@ -40,7 +40,7 @@ export default function({ templates = [] }) {
     if (templateId && !template) {
       reporter.report(
         node.id,
-        'Linked element template not found',
+        `Linked element template '${templateId}' not found`,
         {
           name: node.name
         }

--- a/src/components/ElementTemplatesGroup.js
+++ b/src/components/ElementTemplatesGroup.js
@@ -146,7 +146,7 @@ function TemplateGroupButtons({ element, getTemplateId }) {
   } else if (templateState.type === 'KNOWN_TEMPLATE') {
     return <AppliedTemplate element={ element } />;
   } else if (templateState.type === 'UNKNOWN_TEMPLATE') {
-    return <UnknownTemplate element={ element } />;
+    return <UnknownTemplate element={ element } templateState={ templateState } />;
   } else if (templateState.type === 'DEPRECATED_TEMPLATE') {
     return <DeprecatedTemplate element={ element } templateState={ templateState } />;
   } else if (templateState.type === 'INCOMPATIBLE_TEMPLATE') {
@@ -203,12 +203,12 @@ function RemoveTemplate() {
   return <span class="bio-properties-panel-remove-template">{ translate('Remove') }</span>;
 }
 
-function UnknownTemplate({ element }) {
+function UnknownTemplate({ element, templateState }) {
   const translate = useService('translate'),
         elementTemplates = useService('elementTemplates');
 
   const menuItems = [
-    { entry: <NotFoundText /> },
+    { entry: <NotFoundText templateState={ templateState } /> },
     { separator: true },
     { entry: translate('Unlink'), action: () => elementTemplates.unlinkTemplate(element) },
     { entry: <RemoveTemplate />, action: () => elementTemplates.removeTemplate(element) }
@@ -224,14 +224,15 @@ function UnknownTemplate({ element }) {
   );
 }
 
-function NotFoundText() {
+function NotFoundText({ templateState }) {
   const translate = useService('translate');
+  const { templateId } = templateState;
 
   return (
     <div class="bio-properties-panel-template-not-found-text">
-      { translate(
-        'The template applied was not found. Therefore, its properties cannot be shown. Unlink to access the data.'
-      ) }
+      { (translate(
+        'The applied template with id \'{templateId}\' was not found. Its properties cannot be shown. Unlink to access the data.'
+      )).replace('{templateId}', `${templateId}`) }
     </div>
   );
 }

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
@@ -72,7 +72,7 @@ const invalid = [
     },
     report: {
       id: 'Task_1',
-      message: 'Linked element template not found'
+      message: 'Linked element template \'missing-template\' not found'
     }
   },
   {
@@ -307,7 +307,7 @@ describe('cloud-element-templates/linting', function() {
     // then
     const report = secondResult['element-templates/validate'][0];
     expect(report).to.have.property('id', 'Task_1');
-    expect(report).to.have.property('message', 'Linked element template not found');
+    expect(report).to.have.property('message', 'Linked element template \'constraints.empty\' not found');
   });
 });
 


### PR DESCRIPTION
### Proposed Changes

It is currently impossible to determine, without looking into the diagram, what element template is missing from your diagram on load. This is a particularly glaring issue when importing in marketplace in web modeler SM, if you haven't configured connectors. 

Kinda related to: https://github.com/camunda/camunda-modeler/issues/5109, I found this UX problem last minute so this is a super quick patch. Discussion is here: https://camunda.slack.com/archives/C097RLZP0MB/p1758793244155529.

Before:

<img width="720" height="272" alt="image" src="https://github.com/user-attachments/assets/e9243d91-1804-4e17-84a5-860c362ed90d" />

<img width="359" height="159" alt="image" src="https://github.com/user-attachments/assets/a84c8188-e42a-4995-a608-4a938d15cac9" />

After:

<img width="1906" height="719" alt="image" src="https://github.com/user-attachments/assets/281c0fe9-1f40-4073-a17b-aba0c71e4a8a" />


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
