### PR TITLE
chore: fix incorrect getAll deprecated option (needs input)

### DIFF
--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -95,7 +95,7 @@ export default class ElementTemplates {
    * @return {Array<ElementTemplate>}
    */
   getAll(elementOrTemplateId) {
-    return findTemplates(elementOrTemplateId, this._templatesById, { includeDeprecated: true });
+    return findTemplates(elementOrTemplateId, this._templatesById, { deprecated: true });
   }
 
 


### PR DESCRIPTION
### Proposed Changes

This is not a bug, and this was not introduced by my recent refactors (I intentionally preserved this oversight so that we can treat it separately.

The option name has never matched here, but the current execution path for the deprecated option does nothing on its own, it only does something when latest is set to true, so this parameter never did anything even if it didn't match the downstream object destructuring. 

We can go forward in multiple ways:
- adjust it for now for semantics more than anything and prevent this from becoming a bug in the future if we change the template finding logic (**ie just merge this pr**)
- completely remove it
- implement what this parameter would do on its own in the template finding logic
- add options to getAll on top of the previous to support getAll(filter, { deprecated: false })

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
