### PR TITLE
fix: remove unnecessary title

### DIFF
--- a/src/components/ElementTemplatesGroup.js
+++ b/src/components/ElementTemplatesGroup.js
@@ -83,7 +83,7 @@ export function createElementTemplatesGroup(props = {}) {
         }
       ) } onClick={ toggleOpen }
       >
-        <div title={ label } class="bio-properties-panel-group-header-title">
+        <div class="bio-properties-panel-group-header-title">
           { label }
         </div>
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/properties-panel/pull/455/

### Proposed Changes

get rid of more unnecessary titles. https://github.com/bpmn-io/properties-panel/pull/455/ started to get rid of most. just a bit inconsistent to still have that one (cf. https://github.com/camunda/camunda-bpmn-js/pull/427#issuecomment-3563237739)

<img width="292" height="152" alt="image" src="https://github.com/user-attachments/assets/143e3f79-4d00-4df2-9afd-86cf14b2fc28" />

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
