### PR TITLE
fix: do not unlink templates with Variable Events for boundary events

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.js
@@ -77,7 +77,11 @@ export default class ConditionalEventTemplateBehavior extends CommandInterceptor
       return;
     }
 
-    if (isRootLevelEvent(element) && !is(element, 'bpmn:IntermediateCatchEvent')) {
+    if (
+      isRootLevelEvent(element) &&
+      !is(element, 'bpmn:IntermediateCatchEvent') &&
+      !is(element, 'bpmn:BoundaryEvent')
+    ) {
       elementTemplates.unlinkTemplate(element);
     }
   }

--- a/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.bpmn
+++ b/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.bpmn
@@ -15,23 +15,31 @@
         <bpmn:condition xsi:type="bpmn:tFormalExpression" />
       </bpmn:conditionalEventDefinition>
     </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_0np5h00" />
+    <bpmn:boundaryEvent id="Boundary_Event" attachedToRef="Activity_0np5h00" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Event_0q15ef0_di" bpmnElement="Root_CatchEvent">
-        <dc:Bounds x="152" y="62" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0np5h00_di" bpmnElement="Activity_0np5h00">
+        <dc:Bounds x="160" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EventSubProcess_1_di" bpmnElement="EventSubProcess_1" isExpanded="true">
-        <dc:Bounds x="240" y="80" width="200" height="120" />
+        <dc:Bounds x="390" y="80" width="200" height="120" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0q0r1y6_di" bpmnElement="Subprocess_Event">
-        <dc:Bounds x="262" y="122" width="36" height="36" />
+        <dc:Bounds x="412" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1rgdz7t" bpmnElement="Subprocess_CatchEvent">
-        <dc:Bounds x="352" y="122" width="36" height="36" />
+        <dc:Bounds x="502" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02q7n6e_di" bpmnElement="RootEvent">
-        <dc:Bounds x="152" y="122" width="36" height="36" />
+        <dc:Bounds x="302" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0q15ef0_di" bpmnElement="Root_CatchEvent">
+        <dc:Bounds x="302" y="62" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mkcuu9_di" bpmnElement="Boundary_Event">
+        <dc:Bounds x="212" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.json
+++ b/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.json
@@ -118,5 +118,48 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Conditional Boundary Event",
+    "id": "conditional-boundary-event-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:BoundaryEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:BoundaryEvent",
+      "eventDefinition": "bpmn:ConditionalEventDefinition"
+    },
+    "properties": [
+      {
+        "label": "Condition Expression",
+        "type": "String",
+        "value": "=orderTotal > 100",
+        "feel": "required",
+        "binding": {
+          "type": "bpmn:ConditionalEventDefinition#property",
+          "name": "condition"
+        }
+      },
+      {
+        "label": "Variable Names",
+        "type": "String",
+        "value": "orderTotal,discount",
+        "binding": {
+          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
+          "name": "variableNames"
+        }
+      },
+      {
+        "label": "Variable Events",
+        "type": "String",
+        "value": "create,update",
+        "binding": {
+          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
+          "name": "variableEvents"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.spec.js
@@ -97,6 +97,21 @@ describe('provider/cloud-element-templates - ConditionalEventTemplateBehavior', 
         expect(getBusinessObject(event).get('zeebe:modelerTemplate')).to.equal('conditional-catch-with-variable-events-template');
       }
     ));
+
+
+    it('should keep template with variableEvents for boundary catch event', inject(
+      function(elementRegistry, elementTemplates) {
+
+        // given
+        let event = elementRegistry.get('Boundary_Event');
+
+        // when
+        event = elementTemplates.applyTemplate(event, templates[3]);
+
+        // then
+        expect(getBusinessObject(event).get('zeebe:modelerTemplate')).to.equal('conditional-boundary-event-template');
+      }
+    ));
   });
 
 

--- a/test/spec/cloud-element-templates/fixtures/conditional-event.json
+++ b/test/spec/cloud-element-templates/fixtures/conditional-event.json
@@ -7,7 +7,7 @@
     "bpmn:Event"
   ],
   "elementType": {
-    "value": "bpmn:IntermediateCatchEvent",
+    "value": "bpmn:BoundaryEvent",
     "eventDefinition": "bpmn:ConditionalEventDefinition"
   },
   "properties": [


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5622

### Proposed Changes

Adjust `ConditionalEventTemplateBehavior` not to unlink a template with Variable Events mapping when it's applied to a boundary event.

<img width="515" height="450" alt="image" src="https://github.com/user-attachments/assets/d2804cf9-f340-41b3-b900-04d96cddc75c" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
