### PR TITLE
fix: remove support for `variableNames` binding

### DIFF
--- a/src/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.js
+++ b/src/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.js
@@ -25,9 +25,8 @@ export default class ConditionalEventTemplateBehavior extends CommandInterceptor
     ], ({ context }) => {
       const { element, properties } = context;
 
-      const isRelevantPropertyChange = (
-        properties && ('variableEvents' in properties)
-      );
+      const isRelevantPropertyChange =
+        properties?.values?.some(v => v?.variableEvents !== undefined);
 
       if (!isRelevantPropertyChange) {
         return;

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -1102,7 +1102,7 @@ export default class ChangeElementTemplateHandler {
         });
       } else if (bindingType === CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY) {
 
-        // For zeebe:conditionalFilter properties (variableNames, variableEvents)
+        // For zeebe:conditionalFilter properties (variableEvents)
         const conditionalFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
         if (conditionalFilter) {
           commandStack.execute('element.updateModdleProperties', {
@@ -1160,7 +1160,7 @@ export default class ChangeElementTemplateHandler {
 
       if (newBindingType === CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY) {
 
-        // Handle zeebe:conditionalFilter properties (variableNames, variableEvents)
+        // Handle zeebe:conditionalFilter properties (variableEvents)
         let conditionalFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
 
         if (oldProperty && shouldKeepValue(conditionalEventDefinition, oldProperty, newProperty)) {

--- a/src/cloud-element-templates/create/ConditionalEventBindingProvider.js
+++ b/src/cloud-element-templates/create/ConditionalEventBindingProvider.js
@@ -40,7 +40,7 @@ export class ConditionalEventDefinitionPropertyBindingProvider {
 
 /**
  * Provider for `bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property` bindings.
- * Handles `variableNames` and `variableEvents` properties.
+ * Handles `variableEvents` property.
  */
 export class ConditionalEventDefinitionZeebeConditionalFilterBindingProvider {
   static create(element, options) {

--- a/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.json
+++ b/test/spec/cloud-element-templates/behavior/ConditionalEventTemplateBehavior.json
@@ -23,15 +23,6 @@
         }
       },
       {
-        "label": "Variable Names",
-        "type": "String",
-        "value": "orderTotal,discount",
-        "binding": {
-          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-          "name": "variableNames"
-        }
-      },
-      {
         "label": "Variable Events",
         "type": "String",
         "value": "create,update",
@@ -64,15 +55,6 @@
           "type": "bpmn:ConditionalEventDefinition#property",
           "name": "condition"
         }
-      },
-      {
-        "label": "Variable Names",
-        "type": "String",
-        "value": "orderTotal",
-        "binding": {
-          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-          "name": "variableNames"
-        }
       }
     ]
   },
@@ -97,15 +79,6 @@
         "binding": {
           "type": "bpmn:ConditionalEventDefinition#property",
           "name": "condition"
-        }
-      },
-      {
-        "label": "Variable Names",
-        "type": "String",
-        "value": "orderTotal,discount",
-        "binding": {
-          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-          "name": "variableNames"
         }
       },
       {
@@ -140,15 +113,6 @@
         "binding": {
           "type": "bpmn:ConditionalEventDefinition#property",
           "name": "condition"
-        }
-      },
-      {
-        "label": "Variable Names",
-        "type": "String",
-        "value": "orderTotal,discount",
-        "binding": {
-          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-          "name": "variableNames"
         }
       },
       {

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2404,7 +2404,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const conditionalFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
         expect(conditionalFilter).to.exist;
-        expect(conditionalFilter.get('variableNames')).to.equal('orderTotal,discount');
         expect(conditionalFilter.get('variableEvents')).to.equal('create,update');
       }));
 
@@ -2457,7 +2456,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         const conditionalEventDefinition = findConditionalEventDefinition(event);
         const existingFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
         expect(existingFilter).to.exist;
-        expect(existingFilter.get('variableNames')).to.equal('foo,bar');
         expect(existingFilter.get('variableEvents')).to.equal('create,update');
 
         // when
@@ -2470,7 +2468,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const conditionalFilter = findExtension(newConditionalEventDefinition, 'zeebe:ConditionalFilter');
         expect(conditionalFilter).to.exist;
-        expect(conditionalFilter.get('variableNames')).to.equal('orderTotal,discount');
         expect(conditionalFilter.get('variableEvents')).to.equal('create,update');
       }));
 
@@ -2488,7 +2485,6 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const conditionalEventDefinition = findConditionalEventDefinition(event);
         const conditionalFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
-        expect(conditionalFilter.get('variableNames')).to.equal('orderTotal,discount');
         expect(conditionalFilter.get('variableEvents')).to.equal('create,update');
 
         // when
@@ -7155,20 +7151,20 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const oldTemplate = createTemplate([
           {
-            value: 'foo,bar',
+            value: 'create',
             binding: {
               type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property',
-              name: 'variableNames'
+              name: 'variableEvents'
             }
           }
         ]);
 
         const newTemplate = createTemplate([
           {
-            value: 'newFoo,newBar',
+            value: 'update',
             binding: {
               type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property',
-              name: 'variableNames'
+              name: 'variableEvents'
             }
           }
         ]);
@@ -7181,7 +7177,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         );
 
         updateBusinessObject('ConditionalEvent_1', conditionalFilter, {
-          variableNames: 'userModified,variables'
+          variableEvents: 'create,update'
         });
 
         // when
@@ -7194,7 +7190,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         );
 
         expect(updatedConditionalFilter).to.exist;
-        expect(updatedConditionalFilter.get('variableNames')).to.equal('userModified,variables');
+        expect(updatedConditionalFilter.get('variableEvents')).to.equal('create,update');
       }));
 
 
@@ -7205,20 +7201,20 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         const oldTemplate = createTemplate([
           {
-            value: 'foo,bar',
+            value: 'create',
             binding: {
               type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property',
-              name: 'variableNames'
+              name: 'variableEvents'
             }
           }
         ]);
 
         const newTemplate = createTemplate([
           {
-            value: 'newFoo,newBar',
+            value: 'update',
             binding: {
               type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property',
-              name: 'variableNames'
+              name: 'variableEvents'
             }
           }
         ]);
@@ -7235,7 +7231,7 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
         );
 
         expect(conditionalFilter).to.exist;
-        expect(conditionalFilter.get('variableNames')).to.equal('newFoo,newBar');
+        expect(conditionalFilter.get('variableEvents')).to.equal('update');
       }));
 
     });

--- a/test/spec/cloud-element-templates/cmd/conditional-event-template-filter.json
+++ b/test/spec/cloud-element-templates/cmd/conditional-event-template-filter.json
@@ -12,15 +12,6 @@
   },
   "properties": [
     {
-      "label": "Variable Names",
-      "type": "String",
-      "value": "orderTotal,discount",
-      "binding": {
-        "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-        "name": "variableNames"
-      }
-    },
-    {
       "label": "Variable Events",
       "type": "String",
       "value": "create,update",

--- a/test/spec/cloud-element-templates/cmd/conditional-event.bpmn
+++ b/test/spec/cloud-element-templates/cmd/conditional-event.bpmn
@@ -18,7 +18,7 @@
       <bpmn:intermediateCatchEvent id="ConditionalEvent_4">
         <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_4">
           <bpmn:extensionElements>
-          <zeebe:conditionalFilter variableNames="foo,bar" variableEvents="create,update" />
+          <zeebe:conditionalFilter variableEvents="create,update" />
         </bpmn:extensionElements>
           <bpmn:condition xsi:type="bpmn:tFormalExpression">=existingCondition</bpmn:condition>
         </bpmn:conditionalEventDefinition>

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -650,7 +650,7 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
     }));
 
 
-    it('should handle <bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property> - variableNames and variableEvents', inject(function(templateElementFactory) {
+    it('should handle <bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property> - variableEvents', inject(function(templateElementFactory) {
 
       // given
       const elementTemplate = findTemplate('example.camunda.ConditionalEventWithConditionalFilter');
@@ -666,7 +666,6 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
       const extensionElements = conditionalEventDefinition.get('extensionElements');
       const conditionalFilter = findExtension(extensionElements, 'zeebe:ConditionalFilter');
 
-      expect(conditionalFilter.get('variableNames')).to.equal('var1,var2,var3');
       expect(conditionalFilter.get('variableEvents')).to.equal('create,update');
     }));
 

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -979,15 +979,6 @@
         }
       },
       {
-        "label": "Variable Names",
-        "type": "String",
-        "value": "var1,var2,var3",
-        "binding": {
-          "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-          "name": "variableNames"
-        }
-      },
-      {
         "label": "Variable Events",
         "type": "String",
         "value": "create,update",

--- a/test/spec/cloud-element-templates/fixtures/conditional-event.json
+++ b/test/spec/cloud-element-templates/fixtures/conditional-event.json
@@ -22,15 +22,6 @@
       }
     },
     {
-      "label": "Variable Names",
-      "type": "String",
-      "value": "orderTotal,discount",
-      "binding": {
-        "type": "bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property",
-        "name": "variableNames"
-      }
-    },
-    {
       "label": "Variable Events",
       "type": "String",
       "value": "create,update",


### PR DESCRIPTION
### Proposed Changes

Remove behaviors related to the `variableNames` binding, reverting some of https://github.com/bpmn-io/bpmn-js-element-templates/pull/217

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
