### PR TITLE
feat: export utility functions via bpmn-js-element-templates/util

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
       "import": "./dist/core.esm.js",
       "require": "./dist/core.js"
     },
+    "./util": {
+      "import": "./dist/util.esm.js",
+      "require": "./dist/util.js"
+    },
     "./dist/assets/*.css": "./dist/assets/*.css",
     "./dist/*.js": "./dist/*.js",
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
       "import": "./dist/core.esm.js",
       "require": "./dist/core.js"
     },
-    "./util": {
-      "import": "./dist/util.esm.js",
-      "require": "./dist/util.js"
+    "./cloud/util": {
+      "import": "./dist/cloud/util.esm.js",
+      "require": "./dist/cloud/util.js"
     },
     "./dist/assets/*.css": "./dist/assets/*.css",
     "./dist/*.js": "./dist/*.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -55,6 +55,23 @@ export default [
     ],
     external: externalDependencies(),
     plugins: corePlugins()
+  },
+  {
+    input: 'src/util.js',
+    output: [
+      {
+        sourcemap: true,
+        format: 'commonjs',
+        file: 'dist/util.js'
+      },
+      {
+        sourcemap: true,
+        format: 'esm',
+        file: 'dist/util.esm.js'
+      }
+    ],
+    external: externalDependencies(),
+    plugins: corePlugins()
   }
 ];
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -57,17 +57,17 @@ export default [
     plugins: corePlugins()
   },
   {
-    input: 'src/util.js',
+    input: 'src/cloud/util.js',
     output: [
       {
         sourcemap: true,
         format: 'commonjs',
-        file: 'dist/util.js'
+        file: 'dist/cloud/util.js'
       },
       {
         sourcemap: true,
         format: 'esm',
-        file: 'dist/util.esm.js'
+        file: 'dist/cloud/util.esm.js'
       }
     ],
     external: externalDependencies(),

--- a/src/cloud/util.js
+++ b/src/cloud/util.js
@@ -3,20 +3,20 @@ export {
   getPropertyValue,
   setPropertyValue,
   validateProperty
-} from './cloud-element-templates/util/propertyUtil';
+} from '../cloud-element-templates/util/propertyUtil';
 
 export {
   applyConditions,
   isConditionMet
-} from './cloud-element-templates/Condition';
+} from '../cloud-element-templates/Condition';
 
 export {
   shouldCastToFeel,
   toFeelExpression,
   fromFeelExpression,
   isFeel
-} from './cloud-element-templates/util/FeelUtil';
+} from '../cloud-element-templates/util/FeelUtil';
 
 export {
   getDefaultValue
-} from './cloud-element-templates/Helper';
+} from '../cloud-element-templates/Helper';

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,22 @@
+// Cloud element template utilities for headless/programmatic use
+export {
+  getPropertyValue,
+  setPropertyValue,
+  validateProperty
+} from './cloud-element-templates/util/propertyUtil';
+
+export {
+  applyConditions,
+  isConditionMet
+} from './cloud-element-templates/Condition';
+
+export {
+  shouldCastToFeel,
+  toFeelExpression,
+  fromFeelExpression,
+  isFeel
+} from './cloud-element-templates/util/FeelUtil';
+
+export {
+  getDefaultValue
+} from './cloud-element-templates/Helper';

--- a/test/distro/distro.spec.js
+++ b/test/distro/distro.spec.js
@@ -10,6 +10,7 @@ const DIST_DIR = path.join(__dirname, '../../dist');
 const EXPORTS = [
   'bpmn-js-element-templates',
   'bpmn-js-element-templates/core',
+  'bpmn-js-element-templates/util',
   'bpmn-js-element-templates/dist/assets/element-templates.css',
   'bpmn-js-element-templates/package.json'
 ];
@@ -17,6 +18,10 @@ const EXPORTS = [
 describe('modules', function() {
 
   it('should expose CJS bundle', verifyExists('index.js'));
+
+  it('should expose util CJS bundle', verifyExists('util.js'));
+
+  it('should expose util ESM bundle', verifyExists('util.esm.js'));
 
 });
 

--- a/test/distro/distro.spec.js
+++ b/test/distro/distro.spec.js
@@ -10,7 +10,7 @@ const DIST_DIR = path.join(__dirname, '../../dist');
 const EXPORTS = [
   'bpmn-js-element-templates',
   'bpmn-js-element-templates/core',
-  'bpmn-js-element-templates/util',
+  'bpmn-js-element-templates/cloud/util',
   'bpmn-js-element-templates/dist/assets/element-templates.css',
   'bpmn-js-element-templates/package.json'
 ];
@@ -19,9 +19,9 @@ describe('modules', function() {
 
   it('should expose CJS bundle', verifyExists('index.js'));
 
-  it('should expose util CJS bundle', verifyExists('util.js'));
+  it('should expose cloud/util CJS bundle', verifyExists('cloud/util.js'));
 
-  it('should expose util ESM bundle', verifyExists('util.esm.js'));
+  it('should expose cloud/util ESM bundle', verifyExists('cloud/util.esm.js'));
 
 });
 


### PR DESCRIPTION
## Summary

Closes #235.

Exports internal utility functions under a new `bpmn-js-element-templates/cloud/util` sub-path for headless/programmatic use:

- `getPropertyValue`, `setPropertyValue`, `validateProperty` from `propertyUtil`
- `applyConditions`, `isConditionMet` from `Condition`
- `shouldCastToFeel`, `toFeelExpression`, `fromFeelExpression`, `isFeel` from `FeelUtil`
- `getDefaultValue` from `Helper`

## Motivation

[camunda/c8ctl#467](https://github.com/camunda/c8ctl/issues/467) — the c8ctl element-template plugin currently maintains a hand-rolled binding dispatch table covering 5 binding types, and reimplements FEEL casting via a simplified `maybePrependFeel` helper. Both diverge from the canonical library logic, which handles 15+ binding types and correct Boolean/Number/required FEEL casting. This subpath export allows c8ctl to replace those reimplementations with the same code path the Modeler properties panel uses.

## Changes

- `src/cloud/util.js` — new entry point re-exporting the above utilities
- `rollup.config.mjs` — new build target producing `dist/cloud/util.js` and `dist/cloud/util.esm.js`
- `package.json` — new `./cloud/util` export map entry pointing to the built files

## Usage

```js
import {
  getPropertyValue,
  setPropertyValue,
  applyConditions,
  validateProperty,
  shouldCastToFeel,
  toFeelExpression
} from 'bpmn-js-element-templates/cloud/util';
```
