### PR TITLE
Use `@bpmn-io/semver-compat` instead of `semver` for engines compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.21.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
+        "@bpmn-io/semver-compat": "^0.1.0",
         "bpmnlint": "^11.12.0",
         "classnames": "^2.5.1",
         "ids": "^3.0.0",
         "min-dash": "^5.0.0",
         "min-dom": "^5.3.0",
         "preact-markup": "^2.1.1",
-        "semver": "^7.7.4",
         "semver-compare": "^1.0.0",
         "uuid": "^14.0.0"
       },
@@ -625,6 +625,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2"
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
@@ -10879,6 +10888,14 @@
         "focus-trap": "^8.0.0",
         "min-dash": "^5.0.0",
         "min-dom": "^5.2.0"
+      }
+    },
+    "@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
+      "requires": {
+        "semver": "^7.7.2"
       }
     },
     "@camunda/element-templates-json-schema": {

--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^2.21.0",
     "@bpmn-io/extract-process-variables": "^2.2.1",
+    "@bpmn-io/semver-compat": "^0.1.0",
     "bpmnlint": "^11.12.0",
     "classnames": "^2.5.1",
     "ids": "^3.0.0",
     "min-dash": "^5.0.0",
     "min-dom": "^5.3.0",
     "preact-markup": "^2.1.1",
-    "semver": "^7.7.4",
     "semver-compare": "^1.0.0",
     "uuid": "^14.0.0"
   },

--- a/src/cloud-element-templates/Validator.js
+++ b/src/cloud-element-templates/Validator.js
@@ -7,15 +7,11 @@ import {
 import semverCompare from 'semver-compare';
 
 import {
-  validRange as isSemverRangeValid
-} from 'semver';
-
-import {
   validateZeebe as validateAgainstSchema,
   getZeebeSchemaPackage as getTemplateSchemaPackage,
   getZeebeSchemaVersion as getTemplateSchemaVersion
 } from '@bpmn-io/element-templates-validator';
-import { forEach, isNil } from 'min-dash';
+import { isNil } from 'min-dash';
 
 const SUPPORTED_SCHEMA_VERSION = getTemplateSchemaVersion();
 const SUPPORTED_SCHEMA_PACKAGE = getTemplateSchemaPackage();
@@ -108,21 +104,5 @@ export class Validator extends BaseValidator {
 
   isSchemaValid(schema) {
     return schema && schema.includes(SUPPORTED_SCHEMA_PACKAGE);
-  }
-
-  _validateEngines(template) {
-
-    let err;
-
-    forEach(template.engines, (rangeStr, engine) => {
-
-      if (!isSemverRangeValid(rangeStr)) {
-        err = this._logError(new Error(
-          `Engine <${engine}> specifies invalid semver range <${rangeStr}>`
-        ), template);
-      }
-    });
-
-    return err;
   }
 }

--- a/src/element-templates/ElementTemplates.js
+++ b/src/element-templates/ElementTemplates.js
@@ -1,8 +1,7 @@
 import {
   find,
   isString,
-  isUndefined,
-  reduce
+  isUndefined
 } from 'min-dash';
 
 import {
@@ -14,7 +13,7 @@ import {
   isCompatible as _isCompatible
 } from './Helper';
 
-import { coerce, valid as isSemverValid } from 'semver';
+import { getCoerced } from '@bpmn-io/semver-compat';
 
 { /* Required to break up imports, see https://github.com/babel/babel/issues/15156 */ }
 
@@ -132,7 +131,7 @@ export default class ElementTemplates {
    * @returns {Array<ElementTemplate>}
    */
   getCompatible(elementOrTemplateId, enginesOverrides = {}, options = {}) {
-    const overridenEngines = this._coerceEngines({ ...this._engines, ...enginesOverrides });
+    const overridenEngines = { ...this._engines, ...enginesOverrides };
     const templatesById = buildTemplatesById(this._templates, overridenEngines);
 
     return findTemplates(elementOrTemplateId, templatesById, {
@@ -174,28 +173,10 @@ export default class ElementTemplates {
     // we provide <elementTemplates> engine with the current
     // package version; templates may use that engine to declare
     // compatibility with this library
-    engines = {
+    return getCoerced({
       elementTemplates: packageVersion,
       ...engines
-    };
-
-    return reduce(engines, (validEngines, version, engine) => {
-
-      const coercedVersion = coerce(version);
-
-      if (!isSemverValid(coercedVersion)) {
-        console.error(
-          new Error(`Engine <${ engine }> specifies unparseable version <${version}>`)
-        );
-
-        return validEngines;
-      }
-
-      return {
-        ...validEngines,
-        [ engine ]: coercedVersion.raw
-      };
-    }, {});
+    });
   }
 
   /**
@@ -214,7 +195,7 @@ export default class ElementTemplates {
    *
    * @param {any} template
    *
-   * @return { Record<string, { required: string, found: string } } - incompatible engines along with their template and local versions
+   * @return { Record<string, { required: string, actual: string }> } - incompatible engines along with their template and local versions
    */
   getIncompatibleEngines(template) {
     return _getIncompatibleEngines(template, this._engines);

--- a/src/element-templates/Helper.js
+++ b/src/element-templates/Helper.js
@@ -5,7 +5,6 @@ import { is, isAny } from 'bpmn-js/lib/util/ModelUtil';
 import {
   filter,
   flatten,
-  has,
   isNil,
   isObject,
   isString,
@@ -14,9 +13,7 @@ import {
   values
 } from 'min-dash';
 
-import {
-  satisfies as isSemverCompatible
-} from 'semver';
+import { getCompatible } from '@bpmn-io/semver-compat';
 
 /**
  * The BPMN 2.0 extension attribute name under
@@ -40,21 +37,17 @@ export const TEMPLATE_VERSION_ATTR = 'camunda:modelerTemplateVersion';
  * @param {Object} template
  * @param {Object} checkEngines
  *
- * @return {Object}
+ * @return { Record<string, { required: string, actual: string }> } - incompatible engines along with their template and local versions
  */
 export function getIncompatibleEngines(template, checkEngines) {
-  const templateEngines = template.engines;
+  const templateEngines = template.engines || {};
+  const compatible = getCompatible(templateEngines, checkEngines);
 
-  return reduce(templateEngines, (result, _, engine) => {
-
-    if (!has(checkEngines, engine)) {
-      return result;
-    }
-
-    if (!isSemverCompatible(checkEngines[engine], templateEngines[engine])) {
+  return reduce(templateEngines, (result, required, engine) => {
+    if (engine in checkEngines && !(engine in compatible)) {
       result[engine] = {
         actual: checkEngines[engine],
-        required: templateEngines[engine]
+        required
       };
     }
 

--- a/src/element-templates/Validator.js
+++ b/src/element-templates/Validator.js
@@ -8,9 +8,7 @@ import {
 
 import semverCompare from 'semver-compare';
 
-import {
-  validRange as isSemverRangeValid
-} from 'semver';
+import { isSatisfied } from '@bpmn-io/semver-compat';
 
 import {
   validate as validateAgainstSchema,
@@ -146,7 +144,7 @@ export class Validator {
 
     forEach(template.engines, (rangeStr, engine) => {
 
-      if (!isSemverRangeValid(rangeStr)) {
+      if (isSatisfied(rangeStr, '0.0.0') === null) {
         err = this._logError(new Error(
           `Engine <${engine}> specifies invalid semver range <${rangeStr}>`
         ), template);


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Drop `semver` dependency and use our [semver-compat](https://github.com/jarekdanielak/semver-compat) to check element template compatibility with provided engines.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
