### PR TITLE
fix: 'Call Activity' `propagateAllChildVariables` and `propagateAllParentVariables` templates properties change

### DIFF
--- a/src/cloud-element-templates/behavior/CalledElementBehavior.js
+++ b/src/cloud-element-templates/behavior/CalledElementBehavior.js
@@ -27,7 +27,9 @@ export class CalledElementBehavior extends CommandInterceptor {
   _ensureNoPropagation(context) {
     const { element } = context;
 
-    if (!this._elementTemplates.get(element)) {
+    const template = this._elementTemplates.get(element);
+
+    if (!template) {
       return;
     }
 
@@ -45,6 +47,10 @@ export class CalledElementBehavior extends CommandInterceptor {
       'propagateAllChildVariables',
       'propagateAllParentVariables'
     ]) {
+      if (hasTemplateBinding(template, property)) {
+        continue;
+      }
+
       if (calledElement.get(property) !== false) {
         this._modeling.updateModdleProperties(element, calledElement, {
           [property]: false
@@ -59,3 +65,12 @@ CalledElementBehavior.$inject = [
   'modeling',
   'elementTemplates'
 ];
+
+
+// helpers /////////////////
+
+function hasTemplateBinding(template, property) {
+  return template.properties.some(
+    p => p.binding.type === 'zeebe:calledElement' && p.binding.property === property
+  );
+}

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -2436,6 +2436,12 @@ function shouldKeepValue(element, oldProperty, newProperty) {
     return propertyChanged(element, oldProperty);
   }
 
+  // For Boolean type `!!value` check below would keep moddle schema defaults
+  // (e.g. propagateAllParentVariables=true), preventing the template from overriding.
+  if (newProperty.type === 'Boolean') {
+    return false;
+  }
+
   // keep existing property value
   return !!(getPropertyValue(element, newProperty));
 }

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -827,7 +827,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
     const propertyName = binding.property;
 
     const properties = {
-      [ propertyName ]: value || ''
+      [ propertyName ]: property.type === 'Boolean' ? value : value || ''
     };
 
     if (calledElement) {

--- a/test/spec/cloud-element-templates/behavior/CalledElementBehavior.bpmn
+++ b/test/spec/cloud-element-templates/behavior/CalledElementBehavior.bpmn
@@ -13,6 +13,11 @@
       </bpmn:extensionElements>
     </bpmn:callActivity>
     <bpmn:task id="Task" name="foo" />
+    <bpmn:callActivity id="TemplatedWithPropagation" zeebe:modelerTemplate="io.camunda.examples.PaymentWithPropagation">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="myProcess" propagateAllChildVariables="false" propagateAllParentVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0kgt465">
@@ -30,6 +35,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
         <dc:Bounds x="310" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TemplatedWithPropagation_di" bpmnElement="TemplatedWithPropagation">
+        <dc:Bounds x="460" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/cloud-element-templates/behavior/CalledElementBehavior.json
+++ b/test/spec/cloud-element-templates/behavior/CalledElementBehavior.json
@@ -46,5 +46,46 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "io.camunda.examples.PaymentWithPropagation",
+    "name": "Payment with propagation",
+    "description": "Payment process with propagation property",
+    "appliesTo": [
+      "bpmn:CallActivity"
+    ],
+    "elementType": {
+      "value": "bpmn:CallActivity"
+    },
+    "properties": [
+      {
+        "label": "Process ID",
+        "type": "String",
+        "value": "myProcess",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      },
+      {
+        "label": "Propagate all parent variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllParentVariables"
+        }
+      },
+      {
+        "label": "Propagate all child variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllChildVariables"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/behavior/CalledElementBehavior.spec.js
+++ b/test/spec/cloud-element-templates/behavior/CalledElementBehavior.spec.js
@@ -135,6 +135,28 @@ describe('CalledElementBehavior', function() {
         expect(getPropagation(task)).to.be.null;
       })
     );
+
+
+    it('should NOT enforce propagation=false when template binds to property', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        const callActivity = elementRegistry.get('TemplatedWithPropagation');
+        const calledElement = getCalledElement(callActivity);
+
+        // when - toggle propagateAllParentVariables to true
+        modeling.updateModdleProperties(callActivity, calledElement, {
+          propagateAllParentVariables: true,
+          propagateAllChildVariables: true,
+        });
+
+        // then
+        expect(getPropagation(callActivity)).to.eql({
+          propagateAllParentVariables: true,
+          propagateAllChildVariables: true,
+        });
+      })
+    );
   });
 });
 

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2572,6 +2572,31 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('apply zeebe:calledElement Boolean binding', function() {
+
+      beforeEach(bootstrap(require('./called-element-propagate.bpmn').default));
+
+      const newTemplate = require('./called-element-propagate.json');
+
+
+      it('should override moddle default <propagateAllParentVariables=true> with template <false>',
+        inject(function(elementRegistry) {
+
+          // given
+          let callActivity = elementRegistry.get('CallActivity_1');
+
+          // when
+          changeTemplate(callActivity, newTemplate);
+
+          // then
+          callActivity = elementRegistry.get('CallActivity_1');
+          const calledElement = findExtension(callActivity, 'zeebe:CalledElement');
+
+          expect(calledElement).to.have.property('propagateAllParentVariables', false);
+        }));
+    });
+
+
     describe('create message with zeebe:modelerTemplate', function() {
 
       beforeEach(bootstrap(require('./event.bpmn').default));

--- a/test/spec/cloud-element-templates/cmd/called-element-propagate.bpmn
+++ b/test/spec/cloud-element-templates/cmd/called-element-propagate.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="paymentProcess" propagateAllParentVariables="true" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/cmd/called-element-propagate.json
+++ b/test/spec/cloud-element-templates/cmd/called-element-propagate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "id": "calledElement-propagate",
+  "name": "Call Activity with propagation",
+  "appliesTo": [
+    "bpmn:CallActivity"
+  ],
+  "properties": [
+    {
+      "label": "Propagate all parent variables",
+      "type": "Boolean",
+      "value": false,
+      "binding": {
+        "type": "zeebe:calledElement",
+        "property": "propagateAllParentVariables"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/fixtures/complex.json
+++ b/test/spec/cloud-element-templates/fixtures/complex.json
@@ -1880,5 +1880,43 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "calledElement-propagate",
+    "name": "Call Activity with propagate",
+    "description": "Call activity with propagation variable bindings",
+    "appliesTo": [
+      "bpmn:CallActivity"
+    ],
+    "properties": [
+      {
+        "label": "Process ID",
+        "type": "String",
+        "value": "paymentProcess",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      },
+      {
+        "label": "Propagate all parent variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllParentVariables"
+        }
+      },
+      {
+        "label": "Propagate all child variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllChildVariables"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -78,6 +78,11 @@
       </bpmn:extensionElements>
     </bpmn:callActivity>
     <bpmn:callActivity id="CalledElement_empty" name="Called Element empty" zeebe:modelerTemplate="calledElement" />
+    <bpmn:callActivity id="CalledElement_propagate" name="Called Element Propagate" zeebe:modelerTemplate="calledElement-propagate">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="paymentProcess" propagateAllParentVariables="false" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
     <bpmn:userTask id="CamundaUserTask" name="Camunda User Task" zeebe:modelerTemplate="form-definition-template">
       <bpmn:extensionElements>
         <zeebe:userTask />
@@ -227,6 +232,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_di" bpmnElement="CalledElement_empty">
         <dc:Bounds x="610" y="630" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_propagate_di" bpmnElement="CalledElement_propagate">
+        <dc:Bounds x="730" y="630" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kv4zcr_di" bpmnElement="CamundaUserTask">

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -788,6 +788,44 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "calledElement-propagate",
+    "name": "Call Activity with propagate",
+    "description": "Call activity with propagation variable bindings",
+    "appliesTo": [
+      "bpmn:CallActivity"
+    ],
+    "properties": [
+      {
+        "label": "Process ID",
+        "type": "String",
+        "value": "paymentProcess",
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "processId"
+        }
+      },
+      {
+        "label": "Propagate all parent variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllParentVariables"
+        }
+      },
+      {
+        "label": "Propagate all child variables",
+        "type": "Boolean",
+        "value": false,
+        "binding": {
+          "type": "zeebe:calledElement",
+          "property": "propagateAllChildVariables"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Decision with zeebe:calledDecision",
     "id": "calledDecision",
     "description": "A reusable rule template",

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1422,6 +1422,58 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(calledElement).to.exist;
       expect(calledElement).to.have.property('processId', '');
     }));
+
+
+    it('should toggle calledElement propagateAllParentVariables', async function() {
+
+      // given
+      const element = await expectSelected('CalledElement_propagate'),
+            businessObject = getBusinessObject(element);
+
+      const entry = findEntry('custom-entry-calledElement-propagate-1', container),
+            input = findInput('checkbox', entry);
+
+      // when - toggle to true
+      fireEvent.click(input);
+
+      // then
+      const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('propagateAllParentVariables', true);
+
+      // when - toggle back to false
+      fireEvent.click(input);
+
+      // then
+      expect(calledElement).to.have.property('propagateAllParentVariables', false);
+    });
+
+
+    it('should toggle calledElement propagateAllChildVariables', async function() {
+
+      // given
+      const element = await expectSelected('CalledElement_propagate'),
+            businessObject = getBusinessObject(element);
+
+      const entry = findEntry('custom-entry-calledElement-propagate-2', container),
+            input = findInput('checkbox', entry);
+
+      // when - toggle to true
+      fireEvent.click(input);
+
+      // then
+      const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+
+      expect(calledElement).to.exist;
+      expect(calledElement).to.have.property('propagateAllChildVariables', true);
+
+      // when - toggle back to false
+      fireEvent.click(input);
+
+      // then
+      expect(calledElement).to.have.property('propagateAllChildVariables', false);
+    });
   });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5969

### Proposed Changes

Fixes following issues with Boolean `zeebe:calledElement` template properties (`propagateAllParentVariables`, `propagateAllChildVariables`), which brakes this properties applying and change:

- Value conversion — `setPropertyValue` used `value || ''` which turned false into empty string, breaking the toggle.
- `CalledElementBehavior` override — The behavior unconditionally forced propagation to false after every update, even when the template explicitly binds to that property.
- Template application on existing elements — `shouldKeepValue` used a truthiness check (`!!value`) that kept moddle schema defaults (e.g. `propagateAllParentVariables=true`), preventing the template from setting false when applied to a plain call activity.


https://github.com/user-attachments/assets/168501ad-1cc8-463f-a4f7-d910c62205a5



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
