### PR TITLE
feat: add element-templates/update linting rule

### DIFF
--- a/src/cloud-element-templates/linting/index.js
+++ b/src/cloud-element-templates/linting/index.js
@@ -12,6 +12,7 @@ import StaticResolver from 'bpmnlint/lib/resolver/static-resolver';
 
 import validate from './rules/element-templates-validate';
 import compatibility from './rules/element-templates-compatibility';
+import update from './rules/element-templates-update';
 
 
 import { BpmnModdle } from 'bpmn-moddle';
@@ -38,12 +39,14 @@ export const ElementTemplateLinterPlugin = function(templates) {
     config: {
       rules: {
         'element-templates/validate': [ 'error', { templates: lastValidTemplates } ],
-        'element-templates/compatibility': [ 'warn', { templates: lastValidTemplates } ]
+        'element-templates/compatibility': [ 'warn', { templates: lastValidTemplates } ],
+        'element-templates/update': [ 'info', { templates: lastValidTemplates } ]
       }
     },
     resolver: new StaticResolver({
       'rule:bpmnlint-plugin-element-templates/validate': validate,
-      'rule:bpmnlint-plugin-element-templates/compatibility': compatibility
+      'rule:bpmnlint-plugin-element-templates/compatibility': compatibility,
+      'rule:bpmnlint-plugin-element-templates/update': update
     })
   };
 };

--- a/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-compatibility.js
@@ -12,6 +12,7 @@ import ElementTemplates from '../../ElementTemplates';
 import EventBus from 'diagram-js/lib/core/EventBus';
 
 import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getEnginesConfig } from './utils';
 
 export default function({ templates = [] }) {
 
@@ -72,20 +73,6 @@ export default function({ templates = [] }) {
 };
 
 // helpers //////////////////////
-
-function getEnginesConfig(definitions) {
-  const engines = {};
-
-  const executionPlatform = definitions.get('modeler:executionPlatform');
-  const executionPlatformVersion = definitions.get('modeler:executionPlatformVersion');
-
-  if (executionPlatform === 'Camunda Cloud' && executionPlatformVersion) {
-    engines.camunda = executionPlatformVersion;
-  }
-
-  return engines;
-}
-
 
 function getIncompatibilityText(engine, { actual, required }, updateAvailable) {
   const message =

--- a/src/cloud-element-templates/linting/rules/element-templates-update.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-update.js
@@ -11,6 +11,7 @@
 import ElementTemplates from '../../ElementTemplates';
 import EventBus from 'diagram-js/lib/core/EventBus';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
+import { getEnginesConfig } from './utils';
 
 export default function({ templates = [] }) {
 
@@ -23,6 +24,10 @@ export default function({ templates = [] }) {
   elementTemplates.set(templates);
 
   function check(node, reporter) {
+
+    if (is(node, 'bpmn:Definitions')) {
+      elementTemplates.setEngines(getEnginesConfig(node));
+    }
 
     if (!is(node, 'bpmn:FlowElement')) {
       return;

--- a/src/cloud-element-templates/linting/rules/element-templates-update.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-update.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import ElementTemplates from '../../ElementTemplates';
+import EventBus from 'diagram-js/lib/core/EventBus';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+export default function({ templates = [] }) {
+
+  // We use the ElementTemplates Module without the required bpmn-js modules
+  // As we only use it to facilitate template ID and version lookup,
+  // access to commandstack etc. is not required
+  const eventBus = new EventBus();
+  const elementTemplates = new ElementTemplates(null, null, eventBus, null, null);
+
+  elementTemplates.set(templates);
+
+  function check(node, reporter) {
+
+    if (!is(node, 'bpmn:FlowElement')) {
+      return;
+    }
+
+    const template = elementTemplates.get(node);
+
+    if (!template) {
+      return;
+    }
+
+    const latestTemplate = elementTemplates.getLatest(template.id, { deprecated: true })[0];
+
+    if (latestTemplate && latestTemplate !== template) {
+      reporter.report(node.id, 'Element has updated template available.', {
+        name: node.name
+      });
+    }
+  }
+
+  return {
+    check
+  };
+}

--- a/src/cloud-element-templates/linting/rules/utils.js
+++ b/src/cloud-element-templates/linting/rules/utils.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export function getEnginesConfig(definitions) {
+  const engines = {};
+
+  const executionPlatform = definitions.get('modeler:executionPlatform');
+  const executionPlatformVersion = definitions.get('modeler:executionPlatformVersion');
+
+  if (executionPlatform === 'Camunda Cloud' && executionPlatformVersion) {
+    engines.camunda = executionPlatformVersion;
+  }
+
+  return engines;
+}

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.json
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.json
@@ -389,5 +389,28 @@
       "bpmn:Task"
     ],
     "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "updatable-incompatible-update",
+    "id": "updatable-incompatible-update",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "updatable-incompatible-update",
+    "id": "updatable-incompatible-update",
+    "version": 2,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "engines": {
+      "camunda": ">=9.0"
+    },
+    "properties": []
   }
 ]

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.json
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.json
@@ -369,5 +369,25 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "updatable",
+    "id": "updatable",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "updatable",
+    "id": "updatable",
+    "version": 2,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": []
   }
 ]

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
@@ -4,6 +4,7 @@ import RuleTester from 'bpmnlint/lib/testers/rule-tester';
 import { ElementTemplateLinterPlugin } from 'src/cloud-element-templates/linting';
 import validateRule from 'src/cloud-element-templates/linting/rules/element-templates-validate';
 import compatibilityRule from 'src/cloud-element-templates/linting/rules/element-templates-compatibility';
+import updateRule from 'src/cloud-element-templates/linting/rules/element-templates-update';
 
 import templates from './LinterPlugin.json';
 
@@ -227,6 +228,44 @@ const invalid = [
   }
 ];
 
+const upToDate = [
+  {
+    name: 'Task with template at latest version',
+    moddleElement: createProcess('<bpmn:task id="Task_1" zeebe:modelerTemplate="updatable" zeebe:modelerTemplateVersion="2" />'),
+    config: {
+      templates
+    }
+  },
+  {
+    name: 'Task without template',
+    moddleElement: createProcess('<bpmn:task id="Task_1" />'),
+    config: {
+      templates
+    }
+  },
+  {
+    name: 'Template without version (unversioned)',
+    moddleElement: createProcess('<bpmn:task id="Task_1" zeebe:modelerTemplate="constraints.empty" />'),
+    config: {
+      templates
+    }
+  }
+];
+
+const outdated = [
+  {
+    name: 'Task with template at version 1 (newer version 2 available)',
+    moddleElement: createProcess('<bpmn:task id="Task_1" zeebe:modelerTemplate="updatable" zeebe:modelerTemplateVersion="1" />'),
+    config: {
+      templates
+    },
+    report: {
+      id: 'Task_1',
+      message: 'Element has updated template available.'
+    }
+  }
+];
+
 const compatible = [
   {
     name: 'Template compatible',
@@ -308,6 +347,11 @@ describe('cloud-element-templates/linting', function() {
     invalid: incompatible
   });
 
+  RuleTester.verify('element-templates/update', updateRule, {
+    valid: upToDate,
+    invalid: outdated
+  });
+
 
   it('should create the plugin within performance constraints', function() {
 
@@ -355,6 +399,24 @@ describe('cloud-element-templates/linting', function() {
 
       // when
       compatibilityRule({ templates });
+      i++;
+    }
+
+    // then
+    // no error (timeout)
+  });
+
+
+  it('should create `update` rule within performance constraints', function() {
+
+    // given
+    this.timeout(100);
+
+    let i = 0;
+    while (i < 1000) {
+
+      // when
+      updateRule({ templates });
       i++;
     }
 

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
@@ -249,6 +249,13 @@ const upToDate = [
     config: {
       templates
     }
+  },
+  {
+    name: 'Task with template at latest compatible version (newer version incompatible with platform)',
+    moddleElement: createProcess('<bpmn:task id="Task_1" zeebe:modelerTemplate="updatable-incompatible-update" zeebe:modelerTemplateVersion="1" />'),
+    config: {
+      templates
+    }
   }
 ];
 


### PR DESCRIPTION
### Proposed Changes

Reports an info-level notice on any element whose applied template version is lower than the highest version available in the provided templates set.

Follow-up from https://github.com/camunda/camunda-hub/pull/24428 , moving linting rule from Hub to core

<img width="579" height="274" alt="image" src="https://github.com/user-attachments/assets/a87cea37-cd17-4f05-bf83-35b35c988458" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
