### PR TITLE
feat(element-templates): resolve entry ids from a moddle path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.25.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
+        "@bpmn-io/moddle-utils": "^0.3.0",
         "@bpmn-io/semver-compat": "^0.1.0",
         "bpmnlint": "^11.12.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^2.25.0",
     "@bpmn-io/extract-process-variables": "^2.2.1",
+    "@bpmn-io/moddle-utils": "^0.3.0",
     "@bpmn-io/semver-compat": "^0.1.0",
     "bpmnlint": "^11.12.1",
     "classnames": "^2.5.1",

--- a/src/cloud-element-templates/linting/rules/element-templates-validate.js
+++ b/src/cloud-element-templates/linting/rules/element-templates-validate.js
@@ -14,6 +14,8 @@ import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import { getPropertyValue, validateProperty } from '../../util/propertyUtil';
 
+import { getPropertyEntryId } from '../../util/customPropertyEntryIds';
+
 import { applyConditions } from '../../Condition';
 
 export default function({ templates = [] }) {
@@ -70,7 +72,7 @@ export default function({ templates = [] }) {
         error,
         {
           propertiesPanel: {
-            entryIds: [ getEntryId(property, template) ]
+            entryIds: [ getPropertyEntryId(template, property) ]
           },
           name: node.name
         }
@@ -83,20 +85,3 @@ export default function({ templates = [] }) {
   };
 
 };
-
-// helpers //////////////////////
-
-function getEntryId(property, template) {
-  const index = template.properties
-    .filter(p => p.group === property.group)
-    .indexOf(property);
-
-  const path = [ 'custom-entry', template.id ];
-
-  if (property.group) {
-    path.push(property.group);
-  }
-
-  path.push(index);
-  return path.join('-');
-}

--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -17,6 +17,7 @@ import { pathEquals } from '@bpmn-io/moddle-utils';
 
 import { getBindingPath } from '../util/bindingPath';
 import { getPropertyEntryId } from '../util/customPropertyEntryIds';
+import { createCustomEntry } from './properties/custom-properties';
 import { has, isObject } from 'min-dash';
 
 const LOWER_PRIORITY = 300;
@@ -129,7 +130,13 @@ export default class ElementTemplatesPropertiesProvider {
       const bindingPath = getBindingPath(element, property.binding);
 
       if (bindingPath && pathEquals(bindingPath, path)) {
-        return getPropertyEntryId(conditioned, property);
+        const entryId = getPropertyEntryId(conditioned, property);
+
+        // only resolve to a property that actually renders an entry (e.g. not
+        // Hidden), so the resolved id is guaranteed to exist in the panel
+        if (createCustomEntry(entryId, element, property)) {
+          return entryId;
+        }
       }
     }
 

--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -13,6 +13,10 @@ import { getTemplateId, getTemplateVersion } from '../Helper';
 
 import { applyConditions } from '../Condition';
 import { getPropertyValue } from '../util/propertyUtil';
+import { pathEquals } from '@bpmn-io/moddle-utils';
+
+import { getBindingPath } from '../util/bindingPath';
+import { getPropertyEntryId } from '../util/customPropertyEntryIds';
 import { has, isObject } from 'min-dash';
 
 const LOWER_PRIORITY = 300;
@@ -99,6 +103,37 @@ export default class ElementTemplatesPropertiesProvider {
 
   _shouldShowTemplateProperties(element) {
     return getTemplateId(element) || this._elementTemplates.getAll(element).length;
+  }
+
+  /**
+   * Resolve the id of the entry that renders the given businessObject-relative
+   * moddle property path, if a templated property is bound to it. Used by
+   * `propertiesPanel#getEntryId` to shadow the standard entry with the
+   * template's `custom-entry-*` one when a template applies.
+   *
+   * @param {djs.model.Base} element
+   * @param {(string|number)[]} path
+   *
+   * @return {string|null}
+   */
+  getEntryId(element, path) {
+    const template = this._elementTemplates.get(element);
+
+    if (!template) {
+      return null;
+    }
+
+    const conditioned = applyConditions(element, template);
+
+    for (const property of conditioned.properties) {
+      const bindingPath = getBindingPath(element, property.binding);
+
+      if (bindingPath && pathEquals(bindingPath, path)) {
+        return getPropertyEntryId(conditioned, property);
+      }
+    }
+
+    return null;
   }
 }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
@@ -124,7 +124,14 @@ function addCustomGroup(groups, props) {
   }
 }
 
-function createCustomEntry(id, element, property) {
+/**
+ * Build the properties panel entry descriptor for a template property, or
+ * `undefined` when the property renders no entry (e.g. a `Hidden` property or a
+ * binding without a renderable default type). Exported so the provider's
+ * `getEntryId` can use it as the single source of "does this property render",
+ * keeping id resolution in lock-step with what the panel actually shows.
+ */
+export function createCustomEntry(id, element, property) {
   let { type, feel, language } = property;
 
   if (!type) {

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
@@ -26,6 +26,7 @@ import {
 
 import { groupByGroupId, findCustomGroup } from './util';
 import { getPropertyValue } from '../../../util/propertyUtil';
+import { getPropertyEntryId } from '../../../util/customPropertyEntryIds';
 import { TextAreaProperty } from './TextAreaProperty';
 import { StringProperty } from './StringProperty';
 import { FeelProperty } from './FeelProperty';
@@ -48,7 +49,6 @@ export function CustomProperties(props) {
   const groups = [];
 
   const {
-    id,
     properties,
     groups: propertyGroups
   } = elementTemplate;
@@ -67,11 +67,11 @@ export function CustomProperties(props) {
 
     addCustomGroup(groups, {
       element,
+      elementTemplate,
       id: `ElementTemplates__CustomProperties-${groupId}`,
       label: translate(group.label),
       openByDefault: group.openByDefault,
       properties: properties,
-      templateId: `${id}-${groupId}`,
       tooltip: PropertyTooltip({ tooltip: group.tooltip })
     });
   });
@@ -82,8 +82,8 @@ export function CustomProperties(props) {
       id: 'ElementTemplates__CustomProperties',
       label: translate('Custom properties'),
       element,
-      properties: defaultProps,
-      templateId: id
+      elementTemplate,
+      properties: defaultProps
     });
   }
 
@@ -94,11 +94,11 @@ function addCustomGroup(groups, props) {
 
   const {
     element,
+    elementTemplate,
     id,
     label,
     openByDefault = false,
     properties,
-    templateId,
     tooltip
   } = props;
 
@@ -111,8 +111,8 @@ function addCustomGroup(groups, props) {
     tooltip
   };
 
-  properties.forEach((property, index) => {
-    const entry = createCustomEntry(`custom-entry-${ templateId }-${ index }`, element, property);
+  properties.forEach((property) => {
+    const entry = createCustomEntry(getPropertyEntryId(elementTemplate, property), element, property);
 
     if (entry) {
       customPropertiesGroup.entries.push(entry);

--- a/src/cloud-element-templates/util/bindingPath.js
+++ b/src/cloud-element-templates/util/bindingPath.js
@@ -14,6 +14,7 @@ import {
   MESSAGE_PROPERTY_TYPE,
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
   SIGNAL_PROPERTY_TYPE,
+  TIMER_EVENT_DEFINITION_PROPERTY_TYPE,
   CONDITIONAL_EVENT_DEFINITION_PROPERTY,
   CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY,
   ZEEBE_CALLED_ELEMENT,
@@ -23,8 +24,11 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
-  ZEEBE_TASK_SCHEDULE
+  ZEEBE_TASK_SCHEDULE,
+  ZEEBE_EXECUTION_LISTENER,
+  ZEEBE_TASK_LISTENER
 } from './bindingTypes';
 
 import {
@@ -39,6 +43,7 @@ import {
   findOutputParameter,
   findSignal,
   findTaskHeader,
+  findTimerEventDefinition,
   findZeebeProperty,
   findZeebeSubscription
 } from '../Helper';
@@ -110,11 +115,23 @@ export function getBindingPath(element, binding) {
   case ZEEBE_PRIORITY_DEFINITION:
     return getExtensionBindingPath(businessObject, 'zeebe:PriorityDefinition', binding.property);
 
+  case ZEEBE_JOB_PRIORITY_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:JobPriorityDefinition', binding.property);
+
   case ZEEBE_AD_HOC:
     return getExtensionBindingPath(businessObject, 'zeebe:AdHoc', binding.property);
 
   case ZEEBE_LINKED_RESOURCE_PROPERTY:
     return getLinkedResourceBindingPath(businessObject, binding);
+
+  case TIMER_EVENT_DEFINITION_PROPERTY_TYPE:
+    return getTimerBindingPath(businessObject, binding);
+
+  case ZEEBE_EXECUTION_LISTENER:
+    return getListenerBindingPath(businessObject, binding, 'zeebe:ExecutionListeners');
+
+  case ZEEBE_TASK_LISTENER:
+    return getListenerBindingPath(businessObject, binding, 'zeebe:TaskListeners');
 
   case CONDITIONAL_EVENT_DEFINITION_PROPERTY:
     return getConditionalEventDefinitionBindingPath(businessObject, binding);
@@ -123,8 +140,8 @@ export function getBindingPath(element, binding) {
     return getConditionalFilterBindingPath(businessObject, binding);
 
   // Not (yet) path-resolvable — the provider defers (returns null) so the
-  // standard entry answers. Known gaps: zeebe:userTask, zeebe:executionListener,
-  // zeebe:taskListener and bpmn:TimerEventDefinition#property.
+  // standard entry answers. Known gap: zeebe:userTask, a marker binding that
+  // has no bound property and renders no entry to resolve to.
   default:
     return null;
   }
@@ -147,6 +164,48 @@ function getExtensionBindingPath(businessObject, extensionType, field) {
   const extensionIndex = getExtensionIndex(businessObject, extension);
 
   return [ 'extensionElements', 'values', extensionIndex, field ];
+}
+
+/**
+ * Path to the (first) timer event definition's expression property, e.g.
+ * `[ 'eventDefinitions', <index>, 'timeDuration' ]`. Mirrors the leaf the Zeebe
+ * resolver keys on (`bpmn:TimerEventDefinition#<timeCycle|timeDate|timeDuration>`).
+ */
+function getTimerBindingPath(businessObject, binding) {
+  const timerEventDefinition = findTimerEventDefinition(businessObject);
+
+  if (!timerEventDefinition) {
+    return null;
+  }
+
+  const index = businessObject.get('eventDefinitions').indexOf(timerEventDefinition);
+
+  return [ 'eventDefinitions', index, binding.name ];
+}
+
+/**
+ * Path to a listener's `type` within its container's `listeners` collection,
+ * e.g. `[ 'extensionElements', 'values', <index>, 'listeners', <index>, 'type' ]`.
+ * The listener is matched by its `eventType`, mirroring `getListenerValue`.
+ */
+function getListenerBindingPath(businessObject, binding, containerType) {
+  const container = findExtension(businessObject, containerType);
+
+  if (!container) {
+    return null;
+  }
+
+  const listeners = container.get('listeners');
+
+  const index = listeners.findIndex(listener => listener.get('eventType') === binding.eventType);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, container);
+
+  return [ 'extensionElements', 'values', extensionIndex, 'listeners', index, 'type' ];
 }
 
 function getIoBindingPath(businessObject, binding, type) {

--- a/src/cloud-element-templates/util/bindingPath.js
+++ b/src/cloud-element-templates/util/bindingPath.js
@@ -1,0 +1,342 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  PROPERTY_TYPE,
+  ZEBBE_INPUT_TYPE,
+  ZEEBE_OUTPUT_TYPE,
+  ZEEBE_PROPERTY_TYPE,
+  ZEEBE_TASK_DEFINITION_TYPE_TYPE,
+  ZEEBE_TASK_DEFINITION,
+  ZEEBE_TASK_HEADER_TYPE,
+  MESSAGE_PROPERTY_TYPE,
+  MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
+  SIGNAL_PROPERTY_TYPE,
+  CONDITIONAL_EVENT_DEFINITION_PROPERTY,
+  CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY,
+  ZEEBE_CALLED_ELEMENT,
+  ZEEBE_LINKED_RESOURCE_PROPERTY,
+  ZEEBE_CALLED_DECISION,
+  ZEEBE_FORM_DEFINITION,
+  ZEEBE_SCRIPT_TASK,
+  ZEEBE_ASSIGNMENT_DEFINITION,
+  ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_AD_HOC,
+  ZEEBE_TASK_SCHEDULE
+} from './bindingTypes';
+
+import {
+  getTaskDefinitionPropertyName
+} from './taskDefinition';
+
+import {
+  findConditionalEventDefinition,
+  findExtension,
+  findInputParameter,
+  findMessage,
+  findOutputParameter,
+  findSignal,
+  findTaskHeader,
+  findZeebeProperty,
+  findZeebeSubscription
+} from '../Helper';
+
+/**
+ * Resolve the businessObject-relative moddle property path targeted by a
+ * template property's binding. The returned path uses the same convention
+ * as `bpmnlint-plugin-camunda-compat` findings and the Zeebe properties
+ * panel's entry id resolver (`EntryIdUtil#getZeebeEntryId`): string segments
+ * are moddle `get()` calls, numeric segments index into the array returned
+ * by the previous segment.
+ *
+ * @param {djs.model.Base} element
+ * @param {Object} binding a template property's `binding`
+ *
+ * @return {(string|number)[]|null} the path, or `null` if the binding is
+ * unsupported or does not (yet) resolve to a moddle location on the element
+ */
+export function getBindingPath(element, binding) {
+  const businessObject = getBusinessObject(element);
+
+  const { type } = binding;
+
+  switch (type) {
+  case PROPERTY_TYPE:
+    return [ binding.name ];
+
+  case ZEBBE_INPUT_TYPE:
+  case ZEEBE_OUTPUT_TYPE:
+    return getIoBindingPath(businessObject, binding, type);
+
+  case ZEEBE_TASK_HEADER_TYPE:
+    return getTaskHeaderBindingPath(businessObject, binding);
+
+  case ZEEBE_PROPERTY_TYPE:
+    return getZeebePropertyBindingPath(businessObject, binding);
+
+  case ZEEBE_TASK_DEFINITION_TYPE_TYPE:
+  case ZEEBE_TASK_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:TaskDefinition', getTaskDefinitionPropertyName(binding));
+
+  case MESSAGE_PROPERTY_TYPE:
+    return getMessageBindingPath(businessObject, binding);
+
+  case MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE:
+    return getMessageSubscriptionBindingPath(businessObject, binding);
+
+  case SIGNAL_PROPERTY_TYPE:
+    return getSignalBindingPath(businessObject, binding);
+
+  case ZEEBE_CALLED_ELEMENT:
+    return getExtensionBindingPath(businessObject, 'zeebe:CalledElement', binding.property);
+
+  case ZEEBE_CALLED_DECISION:
+    return getExtensionBindingPath(businessObject, 'zeebe:CalledDecision', binding.property);
+
+  case ZEEBE_FORM_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:FormDefinition', binding.property);
+
+  case ZEEBE_SCRIPT_TASK:
+    return getExtensionBindingPath(businessObject, 'zeebe:Script', binding.property);
+
+  case ZEEBE_ASSIGNMENT_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:AssignmentDefinition', binding.property);
+
+  case ZEEBE_TASK_SCHEDULE:
+    return getExtensionBindingPath(businessObject, 'zeebe:TaskSchedule', binding.property);
+
+  case ZEEBE_PRIORITY_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:PriorityDefinition', binding.property);
+
+  case ZEEBE_AD_HOC:
+    return getExtensionBindingPath(businessObject, 'zeebe:AdHoc', binding.property);
+
+  case ZEEBE_LINKED_RESOURCE_PROPERTY:
+    return getLinkedResourceBindingPath(businessObject, binding);
+
+  case CONDITIONAL_EVENT_DEFINITION_PROPERTY:
+    return getConditionalEventDefinitionBindingPath(businessObject, binding);
+
+  case CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY:
+    return getConditionalFilterBindingPath(businessObject, binding);
+
+  // Not (yet) path-resolvable — the provider defers (returns null) so the
+  // standard entry answers. Known gaps: zeebe:userTask, zeebe:executionListener,
+  // zeebe:taskListener and bpmn:TimerEventDefinition#property.
+  default:
+    return null;
+  }
+}
+
+
+// helpers //////////////////
+
+/**
+ * Path to a singleton extension element's property, e.g.
+ * `[ 'extensionElements', 'values', <index>, <field> ]`.
+ */
+function getExtensionBindingPath(businessObject, extensionType, field) {
+  const extension = findExtension(businessObject, extensionType);
+
+  if (!extension) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, extension);
+
+  return [ 'extensionElements', 'values', extensionIndex, field ];
+}
+
+function getIoBindingPath(businessObject, binding, type) {
+  const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+
+  if (!ioMapping) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, ioMapping);
+
+  if (type === ZEBBE_INPUT_TYPE) {
+    const inputParameter = findInputParameter(ioMapping, binding);
+
+    if (!inputParameter) {
+      return null;
+    }
+
+    const index = ioMapping.get('inputParameters').indexOf(inputParameter);
+
+    return [ 'extensionElements', 'values', extensionIndex, 'inputParameters', index, 'source' ];
+  }
+
+  // zeebe:output
+  const outputParameter = findOutputParameter(ioMapping, binding);
+
+  if (!outputParameter) {
+    return null;
+  }
+
+  const index = ioMapping.get('outputParameters').indexOf(outputParameter);
+
+  return [ 'extensionElements', 'values', extensionIndex, 'outputParameters', index, 'target' ];
+}
+
+function getTaskHeaderBindingPath(businessObject, binding) {
+  const taskHeaders = findExtension(businessObject, 'zeebe:TaskHeaders');
+
+  if (!taskHeaders) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, taskHeaders);
+
+  const header = findTaskHeader(taskHeaders, binding);
+
+  if (!header) {
+    return null;
+  }
+
+  const index = taskHeaders.get('values').indexOf(header);
+
+  return [ 'extensionElements', 'values', extensionIndex, 'values', index, 'value' ];
+}
+
+function getZeebePropertyBindingPath(businessObject, binding) {
+  const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+
+  if (!zeebeProperties) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, zeebeProperties);
+
+  const zeebeProperty = findZeebeProperty(zeebeProperties, binding);
+
+  if (!zeebeProperty) {
+    return null;
+  }
+
+  const index = zeebeProperties.get('properties').indexOf(zeebeProperty);
+
+  return [ 'extensionElements', 'values', extensionIndex, 'properties', index, 'value' ];
+}
+
+function getLinkedResourceBindingPath(businessObject, binding) {
+  const linkedResources = findExtension(businessObject, 'zeebe:LinkedResources');
+
+  if (!linkedResources) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, linkedResources);
+
+  const values = linkedResources.get('values');
+  const index = values.findIndex((value) => value.get('linkName') === binding.linkName);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return [ 'extensionElements', 'values', extensionIndex, 'values', index, binding.property ];
+}
+
+/**
+ * Path prefix to reach the element referenced by `refProperty`
+ * (`messageRef` or `signalRef`), mirroring `findMessage`/`findSignal`:
+ * events reference through their (first) event definition, other elements
+ * (e.g. receive tasks) hold the reference directly. Only called once the
+ * reference is known to exist (so an event has event definitions).
+ */
+function getReferencedElementPrefix(businessObject, refProperty) {
+  if (is(businessObject, 'bpmn:Event')) {
+    return [ 'eventDefinitions', 0, refProperty ];
+  }
+
+  return [ refProperty ];
+}
+
+function getMessageBindingPath(businessObject, binding) {
+  const message = findMessage(businessObject);
+
+  if (!message) {
+    return null;
+  }
+
+  const prefix = getReferencedElementPrefix(businessObject, 'messageRef');
+
+  return [ ...prefix, binding.name ];
+}
+
+function getMessageSubscriptionBindingPath(businessObject, binding) {
+  const message = findMessage(businessObject);
+
+  if (!message) {
+    return null;
+  }
+
+  const subscription = findZeebeSubscription(message);
+
+  if (!subscription) {
+    return null;
+  }
+
+  const prefix = getReferencedElementPrefix(businessObject, 'messageRef');
+
+  const extensionIndex = getExtensionIndex(message, subscription);
+
+  return [ ...prefix, 'extensionElements', 'values', extensionIndex, binding.name ];
+}
+
+function getSignalBindingPath(businessObject, binding) {
+  const signal = findSignal(businessObject);
+
+  if (!signal) {
+    return null;
+  }
+
+  const prefix = getReferencedElementPrefix(businessObject, 'signalRef');
+
+  return [ ...prefix, binding.name ];
+}
+
+function getConditionalEventDefinitionBindingPath(businessObject, binding) {
+  const conditionalEventDefinition = findConditionalEventDefinition(businessObject);
+
+  if (!conditionalEventDefinition) {
+    return null;
+  }
+
+  const eventDefinitions = businessObject.get('eventDefinitions');
+  const index = eventDefinitions.indexOf(conditionalEventDefinition);
+
+  return [ 'eventDefinitions', index, binding.name ];
+}
+
+function getConditionalFilterBindingPath(businessObject, binding) {
+  const conditionalEventDefinition = findConditionalEventDefinition(businessObject);
+
+  if (!conditionalEventDefinition) {
+    return null;
+  }
+
+  const eventDefinitions = businessObject.get('eventDefinitions');
+  const defIndex = eventDefinitions.indexOf(conditionalEventDefinition);
+
+  const conditionalFilter = findExtension(conditionalEventDefinition, 'zeebe:ConditionalFilter');
+
+  if (!conditionalFilter) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(conditionalEventDefinition, conditionalFilter);
+
+  return [ 'eventDefinitions', defIndex, 'extensionElements', 'values', extensionIndex, binding.name ];
+}
+
+/**
+ * Index of an extension within its owner's `extensionElements.values`.
+ */
+function getExtensionIndex(owner, extension) {
+  return owner.get('extensionElements').get('values').indexOf(extension);
+}

--- a/src/cloud-element-templates/util/customPropertyEntryIds.js
+++ b/src/cloud-element-templates/util/customPropertyEntryIds.js
@@ -1,0 +1,67 @@
+import { find, forEach, groupBy } from 'min-dash';
+
+/**
+ * Resolve the id of the custom property entry that renders the given template
+ * property. This mirrors how `CustomProperties` groups properties into
+ * (custom group | default group) buckets, and is the single source for the
+ * `custom-entry-*` id scheme, shared by the properties panel (rendering) and
+ * the element-templates lint rule (navigation).
+ *
+ * The grouping (`groupBy(properties, 'group')` + custom-group lookup) is kept
+ * in sync with `custom-properties/util.js`; it is inlined here so this module
+ * stays free of the properties panel's preact dependencies and can be used
+ * from the headless lint rule.
+ *
+ * @param {Object} elementTemplate the applied template (conditions already applied)
+ * @param {Object} property a property of that template
+ *
+ * @return {string|null} the entry id, or `null` if the property is not rendered
+ */
+export function getPropertyEntryId(elementTemplate, property) {
+  const {
+    id,
+    properties,
+    groups
+  } = elementTemplate;
+
+  const groupedProperties = groupBy(properties, 'group');
+
+  const defaultProperties = [];
+
+  let entryId = null;
+
+  forEach(groupedProperties, (groupProperties, groupId) => {
+
+    // already found
+    if (entryId) {
+      return;
+    }
+
+    // properties of an undefined group render in the default group
+    const group = find(groups, group => group.id === groupId);
+
+    if (!group) {
+      defaultProperties.push(...groupProperties);
+
+      return;
+    }
+
+    const index = groupProperties.indexOf(property);
+
+    if (index !== -1) {
+      entryId = `custom-entry-${id}-${groupId}-${index}`;
+    }
+  });
+
+  if (entryId) {
+    return entryId;
+  }
+
+  const defaultIndex = defaultProperties.indexOf(property);
+
+  if (defaultIndex !== -1) {
+    return `custom-entry-${id}-${defaultIndex}`;
+  }
+
+  return null;
+}

--- a/src/cloud-element-templates/util/customPropertyEntryIds.js
+++ b/src/cloud-element-templates/util/customPropertyEntryIds.js
@@ -15,7 +15,8 @@ import { find, forEach, groupBy } from 'min-dash';
  * @param {Object} elementTemplate the applied template (conditions already applied)
  * @param {Object} property a property of that template
  *
- * @return {string|null} the entry id, or `null` if the property is not rendered
+ * @return {string|null} the entry id, or `null` if the property is not part of
+ *   the template
  */
 export function getPropertyEntryId(elementTemplate, property) {
   const {

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
@@ -3,6 +3,10 @@
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="Task_1" />
     <bpmn:task id="Task_2" />
+    <bpmn:serviceTask id="ServiceTask_1" />
+    <bpmn:intermediateCatchEvent id="TimerEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+    </bpmn:intermediateCatchEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -11,6 +15,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TimerEvent_1_di" bpmnElement="TimerEvent_1">
+        <dc:Bounds x="192" y="442" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_entry_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
@@ -63,5 +63,74 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Job Priority Template",
+    "id": "job-priority-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "id": "priority-1",
+        "type": "Number",
+        "label": "Priority",
+        "value": 10,
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Timer Duration Template",
+    "id": "timer-duration-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:IntermediateCatchEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:IntermediateCatchEvent",
+      "eventDefinition": "bpmn:TimerEventDefinition"
+    },
+    "properties": [
+      {
+        "id": "duration-1",
+        "type": "String",
+        "label": "Duration",
+        "value": "PT1H",
+        "binding": {
+          "type": "bpmn:TimerEventDefinition#property",
+          "name": "timeDuration"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Execution Listener Template",
+    "id": "execution-listener-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "entriesVisible": {
+      "executionListeners": false
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=template-start",
+        "binding": {
+          "type": "zeebe:executionListener",
+          "eventType": "start",
+          "retries": "=3"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
@@ -1,0 +1,67 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Entry Id Template",
+    "id": "entry-id-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "id": "input-1",
+        "type": "String",
+        "label": "Input",
+        "value": "=defaultInput",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "inputVar"
+        }
+      },
+      {
+        "id": "header-1",
+        "type": "String",
+        "label": "Header",
+        "value": "headerValue",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "headerKey"
+        }
+      },
+      {
+        "id": "toggle",
+        "type": "Boolean",
+        "label": "Toggle",
+        "value": true,
+        "binding": {
+          "type": "zeebe:property",
+          "name": "toggle"
+        }
+      },
+      {
+        "id": "conditional-1",
+        "type": "String",
+        "label": "Conditional",
+        "value": "conditionalValue",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "conditionalProp"
+        },
+        "condition": {
+          "property": "toggle",
+          "equals": true
+        }
+      },
+      {
+        "id": "name-1",
+        "type": "String",
+        "label": "Name",
+        "value": "templated-name",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -38,7 +38,8 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   findExtension,
-  findInputParameter
+  findInputParameter,
+  findTimerEventDefinition
 } from 'src/cloud-element-templates/Helper';
 
 import { getBindingPath } from 'src/cloud-element-templates/util/bindingPath';
@@ -1264,6 +1265,107 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         // then (condition no longer met: the provider defers, even though the
         // moddle location referenced by `path` may still physically hold data)
         expect(elementTemplatesPropertiesProvider.getEntryId(task, path)).to.be.null;
+      })
+    );
+
+
+    it('should resolve a templated zeebe:jobPriorityDefinition to its rendered entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(serviceTask, getEntryIdTemplates[1]);
+        });
+        await act(() => selection.select(serviceTask));
+
+        const template = elementTemplates.get(serviceTask);
+
+        // when
+        const path = getBindingPath(serviceTask, {
+          type: 'zeebe:jobPriorityDefinition',
+          property: 'priority'
+        });
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(serviceTask, path);
+
+        // then (resolves to the same id the panel actually rendered)
+        const property = template.properties.find(p => p.id === 'priority-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+
+        expect(domQuery(`[data-entry-id="${entryId}"]`, container)).to.exist;
+      })
+    );
+
+
+    it('should resolve a templated bpmn:TimerEventDefinition property to its rendered entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const timerEvent = elementRegistry.get('TimerEvent_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(timerEvent, getEntryIdTemplates[2]);
+        });
+
+        // re-fetch as applying an elementType template morphs the element
+        const templatedEvent = elementRegistry.get('TimerEvent_1');
+
+        await act(() => selection.select(templatedEvent));
+
+        const template = elementTemplates.get(templatedEvent);
+        const businessObject = getBusinessObject(templatedEvent);
+
+        // independently locate the moddle node the duration is written to
+        const timerEventDefinition = findTimerEventDefinition(businessObject);
+        const definitionIndex = businessObject.get('eventDefinitions').indexOf(timerEventDefinition);
+        const expectedPath = [ 'eventDefinitions', definitionIndex, 'timeDuration' ];
+
+        // when
+        const path = getBindingPath(templatedEvent, {
+          type: 'bpmn:TimerEventDefinition#property',
+          name: 'timeDuration'
+        });
+
+        // then (path shape matches the contract, independent of getEntryId)
+        expect(path).to.eql(expectedPath);
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(templatedEvent, path);
+
+        // then (resolves to the same id the panel actually rendered)
+        const property = template.properties.find(p => p.id === 'duration-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+
+        expect(domQuery(`[data-entry-id="${entryId}"]`, container)).to.exist;
+      })
+    );
+
+
+    it('should defer a Hidden zeebe:executionListener binding (no rendered entry)', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given a template whose listener binding is Hidden (renders nothing)
+        const task = elementRegistry.get('Task_2');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[3]);
+        });
+        await act(() => selection.select(task));
+
+        // the binding still inverts to a concrete moddle path...
+        const path = getBindingPath(task, {
+          type: 'zeebe:executionListener',
+          eventType: 'start'
+        });
+        expect(path).to.exist;
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, path);
+
+        // then (...but no entry renders, so the provider defers rather than
+        // resolving to an id that is not in the panel)
+        expect(entryId).to.be.null;
       })
     );
 

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -34,12 +34,24 @@ import {
 } from 'bpmn-js-properties-panel';
 import elementTemplatesModule from 'src/cloud-element-templates';
 
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  findExtension,
+  findInputParameter
+} from 'src/cloud-element-templates/Helper';
+
+import { getBindingPath } from 'src/cloud-element-templates/util/bindingPath';
+import { getPropertyEntryId } from 'src/cloud-element-templates/util/customPropertyEntryIds';
+
 import diagramXML from './ElementTemplatesPropertiesProvider.bpmn';
 import templates from './ElementTemplatesPropertiesProvider.json';
 import entriesVisibleDiagramXML from './ElementTemplatesPropertiesProvider.entries-visible.bpmn';
 import entriesVisibleTemplates from './ElementTemplatesPropertiesProvider.entries-visible.json';
 import booleanXML from './ElementTemplatesPropertiesProvider.boolean.bpmn';
 import booleanTemplates from './ElementTemplatesPropertiesProvider.boolean.json';
+import getEntryIdXML from './ElementTemplatesPropertiesProvider.getEntryId.bpmn';
+import getEntryIdTemplates from './ElementTemplatesPropertiesProvider.getEntryId.json';
 
 import conditionTemplate from '../fixtures/condition.json';
 import multipleConditionTemplate from '../fixtures/multiple-conditions.json';
@@ -1065,6 +1077,193 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         const group = domQuery('[data-group-id="group-documentation"]', container);
 
         expect(group).to.exist;
+      })
+    );
+
+  });
+
+
+  describe('getEntryId', function() {
+
+    beforeEach(bootstrapPropertiesPanel(getEntryIdXML, {
+      container,
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        BpmnPropertiesProvider,
+        ZeebePropertiesProvider,
+        elementTemplatesModule,
+        modelingModule
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      debounceInput: false,
+      elementTemplates: getEntryIdTemplates
+    }));
+
+
+    it('should resolve a templated zeebe:input to its custom entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[0]);
+        });
+        await act(() => selection.select(task));
+
+        const template = elementTemplates.get(task);
+        const businessObject = getBusinessObject(task);
+
+        // independently locate the moddle node the input is written to,
+        // without going through `getBindingPath` itself
+        const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+        const extensionIndex = businessObject.get('extensionElements').get('values').indexOf(ioMapping);
+        const inputParameter = findInputParameter(ioMapping, { name: 'inputVar' });
+        const parameterIndex = ioMapping.get('inputParameters').indexOf(inputParameter);
+
+        const expectedPath = [
+          'extensionElements', 'values', extensionIndex, 'inputParameters', parameterIndex, 'source'
+        ];
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:input', name: 'inputVar' });
+
+        // then (path shape matches the contract, independent of getEntryId)
+        expect(path).to.eql(expectedPath);
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, path);
+
+        // then (resolves to the same id the panel actually rendered)
+        const property = template.properties.find(p => p.id === 'input-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+
+        const renderedEntry = domQuery(`[data-entry-id="${entryId}"]`, container);
+        expect(renderedEntry).to.exist;
+      })
+    );
+
+
+    it('should resolve a templated zeebe:taskHeader to its custom entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[0]);
+        });
+
+        const path = getBindingPath(task, { type: 'zeebe:taskHeader', key: 'headerKey' });
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, path);
+
+        // then
+        const template = elementTemplates.get(task);
+        const property = template.properties.find(p => p.id === 'header-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+      })
+    );
+
+
+    it('should resolve a templated plain property to its custom entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[0]);
+        });
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, [ 'name' ]);
+
+        // then
+        const template = elementTemplates.get(task);
+        const property = template.properties.find(p => p.id === 'name-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+      })
+    );
+
+
+    it('should return null when no template applies to the element', inject(
+      function(elementRegistry, elementTemplatesPropertiesProvider) {
+
+        // given
+        const task = elementRegistry.get('Task_2');
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, [ 'name' ]);
+
+        // then
+        expect(entryId).to.be.null;
+      })
+    );
+
+
+    it('should return null when the path is not bound by any template property', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[0]);
+        });
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, [ 'documentation', 0, 'text' ]);
+
+        // then
+        expect(entryId).to.be.null;
+      })
+    );
+
+
+    it('should return null once its condition becomes unmet', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[0]);
+        });
+        await act(() => selection.select(task));
+
+        const template = elementTemplates.get(task);
+        const toggleProperty = template.properties.find(p => p.id === 'toggle');
+        const conditionalProperty = template.properties.find(p => p.id === 'conditional-1');
+
+        const businessObject = getBusinessObject(task);
+        const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+        const conditionalNode = zeebeProperties.get('properties')
+          .find(p => p.get('name') === 'conditionalProp');
+
+        const extensionIndex = businessObject.get('extensionElements').get('values').indexOf(zeebeProperties);
+        const propertyIndex = zeebeProperties.get('properties').indexOf(conditionalNode);
+        const path = [ 'extensionElements', 'values', extensionIndex, 'properties', propertyIndex, 'value' ];
+
+        // assume (condition met: entry resolves to the templated property)
+        expect(elementTemplatesPropertiesProvider.getEntryId(task, path))
+          .to.equal(getPropertyEntryId(template, conditionalProperty));
+
+        // when (toggle off the condition-driving checkbox)
+        const toggleEntry = domQuery(
+          `[data-entry-id="${ getPropertyEntryId(template, toggleProperty) }"]`, container
+        );
+        const checkbox = domQuery('input[type=\'checkbox\']', toggleEntry);
+
+        await act(() => checkbox.click());
+
+        // then (condition no longer met: the provider defers, even though the
+        // moddle location referenced by `path` may still physically hold data)
+        expect(elementTemplatesPropertiesProvider.getEntryId(task, path)).to.be.null;
       })
     );
 

--- a/test/spec/cloud-element-templates/util/bindingPath.spec.js
+++ b/test/spec/cloud-element-templates/util/bindingPath.spec.js
@@ -565,6 +565,111 @@ describe('cloud-element-templates/util - bindingPath', function() {
     });
 
 
+    describe('zeebe:jobPriorityDefinition', function() {
+
+      it('should resolve priority', function() {
+
+        // given
+        const jobPriorityDefinition = create('zeebe:JobPriorityDefinition', { priority: '50' });
+
+        const serviceTask = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ jobPriorityDefinition ])
+        });
+
+        const binding = { type: 'zeebe:jobPriorityDefinition', property: 'priority' };
+
+        // when
+        const path = getBindingPath(serviceTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'priority' ]);
+      });
+
+    });
+
+
+    describe('bpmn:TimerEventDefinition#property', function() {
+
+      it('should resolve the timer expression property', function() {
+
+        // given
+        const timerEventDefinition = create('bpmn:TimerEventDefinition', {
+          timeDuration: create('bpmn:FormalExpression', { body: 'PT1H' })
+        });
+
+        const catchEvent = create('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:TimerEventDefinition#property', name: 'timeDuration' };
+
+        // when
+        const path = getBindingPath(catchEvent, binding);
+
+        // then
+        expect(path).to.eql([ 'eventDefinitions', 0, 'timeDuration' ]);
+      });
+
+    });
+
+
+    describe('zeebe:executionListener', function() {
+
+      it('should resolve the matching listener type', function() {
+
+        // given
+        const listeners = [
+          create('zeebe:ExecutionListener', { eventType: 'start', type: 'a' }),
+          create('zeebe:ExecutionListener', { eventType: 'end', type: 'b' })
+        ];
+
+        const executionListeners = create('zeebe:ExecutionListeners', { listeners });
+
+        const serviceTask = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+
+        const binding = { type: 'zeebe:executionListener', eventType: 'end' };
+
+        // when
+        const path = getBindingPath(serviceTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ]);
+      });
+
+    });
+
+
+    describe('zeebe:taskListener', function() {
+
+      it('should resolve the matching listener type', function() {
+
+        // given
+        const taskListeners = create('zeebe:TaskListeners', {
+          listeners: [ create('zeebe:TaskListener', { eventType: 'assigning', type: 'a' }) ]
+        });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskListeners ])
+        });
+
+        const binding = { type: 'zeebe:taskListener', eventType: 'assigning' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ]);
+      });
+
+    });
+
+
     describe('zeebe:linkedResource', function() {
 
       it('should resolve the property of the matching linked resource', function() {
@@ -650,12 +755,12 @@ describe('cloud-element-templates/util - bindingPath', function() {
 
     describe('unsupported bindings', function() {
 
-      it('should return null for an unknown binding type', function() {
+      it('should return null for a deferred binding type (zeebe:userTask)', function() {
 
         // given
-        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+        const task = create('bpmn:UserTask', { id: 'UserTask_1' });
 
-        const binding = { type: 'zeebe:executionListener', eventType: 'start' };
+        const binding = { type: 'zeebe:userTask' };
 
         // when
         const path = getBindingPath(task, binding);
@@ -917,6 +1022,54 @@ describe('cloud-element-templates/util - bindingPath', function() {
         const path = getBindingPath(boundaryEvent, {
           type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', name: 'variableEvents'
         });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('timer event definition missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'bpmn:TimerEventDefinition#property', name: 'timeDuration'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('execution listeners extension missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:executionListener', eventType: 'start' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('execution listener not matched', function() {
+
+        // given
+        const executionListeners = create('zeebe:ExecutionListeners', {
+          listeners: [ create('zeebe:ExecutionListener', { eventType: 'start', type: 'a' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:executionListener', eventType: 'end' });
 
         // then
         expect(path).to.be.null;

--- a/test/spec/cloud-element-templates/util/bindingPath.spec.js
+++ b/test/spec/cloud-element-templates/util/bindingPath.spec.js
@@ -1,0 +1,929 @@
+import { expect } from 'chai';
+
+import { BpmnModdle } from 'bpmn-moddle';
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import { getBindingPath } from 'src/cloud-element-templates/util/bindingPath';
+
+
+describe('cloud-element-templates/util - bindingPath', function() {
+
+  const moddle = new BpmnModdle({
+    zeebe: zeebeModdlePackage
+  });
+
+  function create(type, properties) {
+    return moddle.create(type, properties);
+  }
+
+  function withExtensionElements(values) {
+    return create('bpmn:ExtensionElements', { values });
+  }
+
+
+  describe('#getBindingPath', function() {
+
+    describe('property', function() {
+
+      it('should resolve a plain BPMN property', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1', name: 'foo' });
+
+        const binding = { type: 'property', name: 'name' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'name' ]);
+      });
+
+
+      it('should resolve a FEEL expression property to its holding field', function() {
+
+        // given
+        const condition = create('bpmn:FormalExpression', { body: '=foo' });
+
+        const sequenceFlow = create('bpmn:SequenceFlow', {
+          id: 'SequenceFlow_1',
+          conditionExpression: condition
+        });
+
+        const binding = { type: 'property', name: 'conditionExpression' };
+
+        // when
+        const path = getBindingPath(sequenceFlow, binding);
+
+        // then
+        expect(path).to.eql([ 'conditionExpression' ]);
+      });
+
+    });
+
+
+    describe('zeebe:input', function() {
+
+      it('should resolve source', function() {
+
+        // given
+        const input = create('zeebe:Input', { source: '=foo', target: 'bar' });
+
+        const ioMapping = create('zeebe:IoMapping', { inputParameters: [ input ] });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        const binding = { type: 'zeebe:input', name: 'bar' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]);
+      });
+
+
+      it('should resolve the collection index of the matching input', function() {
+
+        // given
+        const inputs = [
+          create('zeebe:Input', { source: '=1', target: 'a' }),
+          create('zeebe:Input', { source: '=2', target: 'b' })
+        ];
+
+        const ioMapping = create('zeebe:IoMapping', { inputParameters: inputs });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        const binding = { type: 'zeebe:input', name: 'b' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'inputParameters', 1, 'source' ]);
+      });
+
+
+      it('should return null when unbound', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        const binding = { type: 'zeebe:input', name: 'bar' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.be.null;
+      });
+
+    });
+
+
+    describe('zeebe:output', function() {
+
+      it('should resolve target', function() {
+
+        // given
+        const output = create('zeebe:Output', { source: '=foo', target: 'bar' });
+
+        const ioMapping = create('zeebe:IoMapping', { outputParameters: [ output ] });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        const binding = { type: 'zeebe:output', source: '=foo' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'outputParameters', 0, 'target' ]);
+      });
+
+    });
+
+
+    describe('zeebe:taskHeader', function() {
+
+      it('should resolve value', function() {
+
+        // given
+        const header = create('zeebe:Header', { key: 'foo', value: 'bar' });
+
+        const taskHeaders = create('zeebe:TaskHeaders', { values: [ header ] });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskHeaders ])
+        });
+
+        const binding = { type: 'zeebe:taskHeader', key: 'foo' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'values', 0, 'value' ]);
+      });
+
+    });
+
+
+    describe('zeebe:property', function() {
+
+      it('should resolve value', function() {
+
+        // given
+        const property = create('zeebe:Property', { name: 'foo', value: 'bar' });
+
+        const properties = create('zeebe:Properties', { properties: [ property ] });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ properties ])
+        });
+
+        const binding = { type: 'zeebe:property', name: 'foo' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'properties', 0, 'value' ]);
+      });
+
+    });
+
+
+    describe('zeebe:taskDefinition', function() {
+
+      it('should resolve type', function() {
+
+        // given
+        const taskDefinition = create('zeebe:TaskDefinition', { type: 'foo' });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskDefinition ])
+        });
+
+        const binding = { type: 'zeebe:taskDefinition:type' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'type' ]);
+      });
+
+
+      it('should resolve a task definition property', function() {
+
+        // given
+        const taskDefinition = create('zeebe:TaskDefinition', { type: 'foo', retries: '3' });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskDefinition ])
+        });
+
+        const binding = { type: 'zeebe:taskDefinition', property: 'retries' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'retries' ]);
+      });
+
+    });
+
+
+    describe('bpmn:Message#property', function() {
+
+      it('should resolve name via an event definition', function() {
+
+        // given
+        const message = create('bpmn:Message', { name: 'foo' });
+
+        const messageEventDefinition = create('bpmn:MessageEventDefinition', { messageRef: message });
+
+        const startEvent = create('bpmn:StartEvent', {
+          id: 'StartEvent_1',
+          eventDefinitions: [ messageEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:Message#property', name: 'name' };
+
+        // when
+        const path = getBindingPath(startEvent, binding);
+
+        // then
+        expect(path).to.eql([ 'eventDefinitions', 0, 'messageRef', 'name' ]);
+      });
+
+
+      it('should resolve name directly on a non-event element (receive task)', function() {
+
+        // given
+        const message = create('bpmn:Message', { name: 'foo' });
+
+        const receiveTask = create('bpmn:ReceiveTask', {
+          id: 'ReceiveTask_1',
+          messageRef: message
+        });
+
+        const binding = { type: 'bpmn:Message#property', name: 'name' };
+
+        // when
+        const path = getBindingPath(receiveTask, binding);
+
+        // then
+        expect(path).to.eql([ 'messageRef', 'name' ]);
+      });
+
+
+      it('should return null when no message is referenced', function() {
+
+        // given
+        const startEvent = create('bpmn:StartEvent', {
+          id: 'StartEvent_1',
+          eventDefinitions: [ create('bpmn:MessageEventDefinition') ]
+        });
+
+        const binding = { type: 'bpmn:Message#property', name: 'name' };
+
+        // when
+        const path = getBindingPath(startEvent, binding);
+
+        // then
+        expect(path).to.be.null;
+      });
+
+    });
+
+
+    describe('bpmn:Message#zeebe:subscription#property', function() {
+
+      it('should resolve correlation key', function() {
+
+        // given
+        const subscription = create('zeebe:Subscription', { correlationKey: '=foo' });
+
+        const message = create('bpmn:Message', {
+          name: 'foo',
+          extensionElements: withExtensionElements([ subscription ])
+        });
+
+        const messageEventDefinition = create('bpmn:MessageEventDefinition', { messageRef: message });
+
+        const startEvent = create('bpmn:StartEvent', {
+          id: 'StartEvent_1',
+          eventDefinitions: [ messageEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:Message#zeebe:subscription#property', name: 'correlationKey' };
+
+        // when
+        const path = getBindingPath(startEvent, binding);
+
+        // then
+        expect(path).to.eql([
+          'eventDefinitions', 0, 'messageRef', 'extensionElements', 'values', 0, 'correlationKey'
+        ]);
+      });
+
+    });
+
+
+    describe('bpmn:Signal#property', function() {
+
+      it('should resolve name via an event definition', function() {
+
+        // given
+        const signal = create('bpmn:Signal', { name: 'foo' });
+
+        const signalEventDefinition = create('bpmn:SignalEventDefinition', { signalRef: signal });
+
+        const throwEvent = create('bpmn:IntermediateThrowEvent', {
+          id: 'IntermediateThrowEvent_1',
+          eventDefinitions: [ signalEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:Signal#property', name: 'name' };
+
+        // when
+        const path = getBindingPath(throwEvent, binding);
+
+        // then
+        expect(path).to.eql([ 'eventDefinitions', 0, 'signalRef', 'name' ]);
+      });
+
+    });
+
+
+    describe('zeebe:calledElement', function() {
+
+      it('should resolve processId', function() {
+
+        // given
+        const calledElement = create('zeebe:CalledElement', { processId: 'foo' });
+
+        const callActivity = create('bpmn:CallActivity', {
+          id: 'CallActivity_1',
+          extensionElements: withExtensionElements([ calledElement ])
+        });
+
+        const binding = { type: 'zeebe:calledElement', property: 'processId' };
+
+        // when
+        const path = getBindingPath(callActivity, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'processId' ]);
+      });
+
+    });
+
+
+    describe('zeebe:calledDecision', function() {
+
+      it('should resolve decisionId', function() {
+
+        // given
+        const calledDecision = create('zeebe:CalledDecision', { decisionId: 'foo' });
+
+        const businessRuleTask = create('bpmn:BusinessRuleTask', {
+          id: 'BusinessRuleTask_1',
+          extensionElements: withExtensionElements([ calledDecision ])
+        });
+
+        const binding = { type: 'zeebe:calledDecision', property: 'decisionId' };
+
+        // when
+        const path = getBindingPath(businessRuleTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'decisionId' ]);
+      });
+
+    });
+
+
+    describe('zeebe:formDefinition', function() {
+
+      it('should resolve formId', function() {
+
+        // given
+        const formDefinition = create('zeebe:FormDefinition', { formId: 'foo' });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ formDefinition ])
+        });
+
+        const binding = { type: 'zeebe:formDefinition', property: 'formId' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'formId' ]);
+      });
+
+    });
+
+
+    describe('zeebe:script', function() {
+
+      it('should resolve expression', function() {
+
+        // given
+        const script = create('zeebe:Script', { expression: '=foo' });
+
+        const scriptTask = create('bpmn:ScriptTask', {
+          id: 'ScriptTask_1',
+          extensionElements: withExtensionElements([ script ])
+        });
+
+        const binding = { type: 'zeebe:script', property: 'expression' };
+
+        // when
+        const path = getBindingPath(scriptTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'expression' ]);
+      });
+
+    });
+
+
+    describe('zeebe:assignmentDefinition', function() {
+
+      it('should resolve assignee', function() {
+
+        // given
+        const assignmentDefinition = create('zeebe:AssignmentDefinition', { assignee: 'foo' });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ assignmentDefinition ])
+        });
+
+        const binding = { type: 'zeebe:assignmentDefinition', property: 'assignee' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'assignee' ]);
+      });
+
+    });
+
+
+    describe('zeebe:taskSchedule', function() {
+
+      it('should resolve dueDate', function() {
+
+        // given
+        const taskSchedule = create('zeebe:TaskSchedule', { dueDate: '=foo' });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskSchedule ])
+        });
+
+        const binding = { type: 'zeebe:taskSchedule', property: 'dueDate' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'dueDate' ]);
+      });
+
+    });
+
+
+    describe('zeebe:priorityDefinition', function() {
+
+      it('should resolve priority', function() {
+
+        // given
+        const priorityDefinition = create('zeebe:PriorityDefinition', { priority: '50' });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ priorityDefinition ])
+        });
+
+        const binding = { type: 'zeebe:priorityDefinition', property: 'priority' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'priority' ]);
+      });
+
+    });
+
+
+    describe('zeebe:adHoc', function() {
+
+      it('should resolve activeElementsCollection', function() {
+
+        // given
+        const adHoc = create('zeebe:AdHoc', { activeElementsCollection: '=foo' });
+
+        const adHocSubProcess = create('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          extensionElements: withExtensionElements([ adHoc ])
+        });
+
+        const binding = { type: 'zeebe:adHoc', property: 'activeElementsCollection' };
+
+        // when
+        const path = getBindingPath(adHocSubProcess, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'activeElementsCollection' ]);
+      });
+
+    });
+
+
+    describe('zeebe:linkedResource', function() {
+
+      it('should resolve the property of the matching linked resource', function() {
+
+        // given
+        const resources = [
+          create('zeebe:LinkedResource', { linkName: 'link-1', resourceId: 'foo' }),
+          create('zeebe:LinkedResource', { linkName: 'link-2', resourceId: 'bar' })
+        ];
+
+        const linkedResources = create('zeebe:LinkedResources', { values: resources });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ linkedResources ])
+        });
+
+        const binding = { type: 'zeebe:linkedResource', linkName: 'link-2', property: 'resourceId' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'values', 1, 'resourceId' ]);
+      });
+
+    });
+
+
+    describe('bpmn:ConditionalEventDefinition#property', function() {
+
+      it('should resolve condition', function() {
+
+        // given
+        const conditionalEventDefinition = create('bpmn:ConditionalEventDefinition');
+
+        const boundaryEvent = create('bpmn:BoundaryEvent', {
+          id: 'BoundaryEvent_1',
+          eventDefinitions: [ conditionalEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:ConditionalEventDefinition#property', name: 'condition' };
+
+        // when
+        const path = getBindingPath(boundaryEvent, binding);
+
+        // then
+        expect(path).to.eql([ 'eventDefinitions', 0, 'condition' ]);
+      });
+
+    });
+
+
+    describe('bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', function() {
+
+      it('should resolve variableEvents', function() {
+
+        // given
+        const conditionalFilter = create('zeebe:ConditionalFilter', { variableEvents: 'foo' });
+
+        const conditionalEventDefinition = create('bpmn:ConditionalEventDefinition', {
+          extensionElements: withExtensionElements([ conditionalFilter ])
+        });
+
+        const boundaryEvent = create('bpmn:BoundaryEvent', {
+          id: 'BoundaryEvent_1',
+          eventDefinitions: [ conditionalEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', name: 'variableEvents' };
+
+        // when
+        const path = getBindingPath(boundaryEvent, binding);
+
+        // then
+        expect(path).to.eql([
+          'eventDefinitions', 0, 'extensionElements', 'values', 0, 'variableEvents'
+        ]);
+      });
+
+    });
+
+
+    describe('unsupported bindings', function() {
+
+      it('should return null for an unknown binding type', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        const binding = { type: 'zeebe:executionListener', eventType: 'start' };
+
+        // when
+        const path = getBindingPath(task, binding);
+
+        // then
+        expect(path).to.be.null;
+      });
+
+    });
+
+
+    describe('returns null when the bound location is absent', function() {
+
+      it('extension element missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:taskDefinition:type' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('input parameter not matched', function() {
+
+        // given
+        const ioMapping = create('zeebe:IoMapping', {
+          inputParameters: [ create('zeebe:Input', { target: 'other', source: '=x' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:input', name: 'bar' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('output parameter not matched', function() {
+
+        // given
+        const ioMapping = create('zeebe:IoMapping', {
+          outputParameters: [ create('zeebe:Output', { source: '=other', target: 'x' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ ioMapping ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:output', source: '=foo' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('task headers extension missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:taskHeader', key: 'foo' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('task header not matched', function() {
+
+        // given
+        const taskHeaders = create('zeebe:TaskHeaders', {
+          values: [ create('zeebe:Header', { key: 'other', value: 'x' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ taskHeaders ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:taskHeader', key: 'foo' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('zeebe properties extension missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:property', name: 'foo' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('zeebe property not matched', function() {
+
+        // given
+        const zeebeProperties = create('zeebe:Properties', {
+          properties: [ create('zeebe:Property', { name: 'other', value: 'x' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ zeebeProperties ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:property', name: 'foo' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('linked resources extension missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'zeebe:linkedResource', linkName: 'link-2', property: 'resourceId'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('linked resource not matched', function() {
+
+        // given
+        const linkedResources = create('zeebe:LinkedResources', {
+          values: [ create('zeebe:LinkedResource', { linkName: 'other', resourceId: 'x' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ linkedResources ])
+        });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'zeebe:linkedResource', linkName: 'link-2', property: 'resourceId'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('message missing (subscription binding)', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'bpmn:Message#zeebe:subscription#property', name: 'correlationKey'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('subscription missing on message', function() {
+
+        // given
+        const message = create('bpmn:Message', { name: 'foo' });
+
+        const receiveTask = create('bpmn:ReceiveTask', {
+          id: 'ReceiveTask_1',
+          messageRef: message
+        });
+
+        // when
+        const path = getBindingPath(receiveTask, {
+          type: 'bpmn:Message#zeebe:subscription#property', name: 'correlationKey'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('signal missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'bpmn:Signal#property', name: 'name' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('conditional event definition missing (condition binding)', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'bpmn:ConditionalEventDefinition#property', name: 'condition'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('conditional event definition missing (filter binding)', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', name: 'variableEvents'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('conditional filter missing', function() {
+
+        // given
+        const conditionalEventDefinition = create('bpmn:ConditionalEventDefinition');
+
+        const boundaryEvent = create('bpmn:BoundaryEvent', {
+          id: 'BoundaryEvent_1',
+          eventDefinitions: [ conditionalEventDefinition ]
+        });
+
+        // when
+        const path = getBindingPath(boundaryEvent, {
+          type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', name: 'variableEvents'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+    });
+
+  });
+
+});

--- a/test/spec/element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/element-templates/ElementTemplatesLoader.spec.js
@@ -175,9 +175,7 @@ describe('provider/element-templates - ElementTemplatesLoader', function() {
       inject(function(elementTemplatesLoader, eventBus) {
 
         // given
-        const errorListener = spy(function() {
-          console.log(arguments);
-        });
+        const errorListener = spy();
 
         eventBus.on('elementTemplates.errors', errorListener);
 


### PR DESCRIPTION
## What

Implements `ElementTemplatesPropertiesProvider#getEntryId(element, path)` so that a lint report anchored on a business-object-relative **moddle path** resolves to the `custom-entry-*` id of the template property bound to that location — or defers (`null`) when no template applies.

Consumed by the properties panel's new `propertiesPanel.getEntryId(element, path)` (see [bpmn-io/bpmn-js-properties-panel#1242](https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1242)), which asks providers in reverse render order. Since this provider registers at low priority (overrides `getGroups`), it is asked **first** — so a report on a field a template has replaced opens the template entry, while the same report on a standard element opens the standard entry, with no rule change.

Commits:
- **refactor** — extract `getPropertyEntryId(elementTemplate, property)` into a preact-free util, shared by the panel (rendering) and the element-templates lint rule (navigation), so the `custom-entry-*` id scheme is defined once. Pure refactor; also fixes a latent case where the rule's id disagreed with the panel for properties referencing an undefined group.
- **feat** — `getBindingPath(element, binding)` + `pathsEqual`, inverting a property binding to its moddle path (mirroring `getRawPropertyValue`'s locators), wired into `getEntryId`.
- **feat** — resolve entry ids for the timer, listener and job priority bindings that were initially deferred (incorporates #272, see below).
- **chore** — remove a leftover `console.log` in an unrelated spec.

## Binding coverage

`property` (incl. FEEL/FormalExpression-valued — resolves to the field holding the expression, not `.body`), `zeebe:input`/`output`, `zeebe:taskHeader`, `zeebe:property`, `zeebe:taskDefinition`, message name + `zeebe:subscription`, signal name, `zeebe:calledElement`/`calledDecision`, `zeebe:formDefinition`, `zeebe:script`, `zeebe:assignmentDefinition`, `zeebe:taskSchedule`, `zeebe:priorityDefinition`, `zeebe:jobPriorityDefinition`, `zeebe:adHoc`, `zeebe:linkedResource`, `bpmn:TimerEventDefinition#property`, `zeebe:executionListener`, `zeebe:taskListener`, conditional bindings.

`getEntryId` guards resolution through `createCustomEntry`, so it only returns an id for a property that actually renders an entry — Hidden bindings (e.g. execution/task listeners) correctly defer instead of resolving to an id that is not in the DOM.

Deferred (returns `null`, provider defers — marked in code): `zeebe:userTask`, a marker binding that has no bound property and renders no entry to resolve to.

## Incorporated

- **#272 (merged into this branch).** Extends `getBindingPath` to invert the four bindings this PR initially deferred — `zeebe:jobPriorityDefinition`, `bpmn:TimerEventDefinition#property`, `zeebe:executionListener`, `zeebe:taskListener` — and adds the `createCustomEntry` guard so id resolution stays in lock-step with the rendered panel. This body reflects the combined state of both changes.

## Scope / follow-ups

- **Additive.** The validate rule still authors `entryIds` (via the shared `getPropertyEntryId`). Switching it to path-based reporting is deferred until `@camunda/linting` consumes the resolver — dropping `entryIds` earlier would strip template-field navigation while linting falls back to its template-blind switch.
- **Cross-repo path parity is unverified.** `getBindingPath`'s path shapes were pinned against the properties-panel `EntryIdUtil` convention, not against what `bpmnlint-plugin-camunda-compat` actually emits. The end-to-end payoff ([camunda/linting#164](https://github.com/camunda/linting/pull/164)) needs a cross-repo integration test when `@camunda/linting` routes to `propertiesPanel.getEntryId`. Degrades safely (null → no shadow, never mis-navigation).

## Testing

- Unit: 49 `getBindingPath` cases asserting literal path arrays per binding type (independent ground truth), incl. null cases.
- Integration: round-trip through real `elementTemplates.applyTemplate` — path verified against an independently computed location, resolved id checked against both `getPropertyEntryId` and the actually-rendered `data-entry-id`; null cases incl. a condition becoming unmet live.
- `npm run lint` clean, `npm test` green.

Related to https://github.com/bpmn-io/internal-docs/issues/1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)