### PR TITLE
feat: support `zeebe:jobPriorityDefinition` binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support job priority via `zeebe:jobPriorityDefinition` binding
+
 ## 2.27.0
 
 * `FEAT`: support `isEmpty` condition for `zeebe` element templates ([#259](https://github.com/bpmn-io/bpmn-js-element-templates/pull/259))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.27.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.23.0",
+        "@bpmn-io/element-templates-validator": "^2.24.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
         "@bpmn-io/semver-compat": "^0.1.0",
         "bpmnlint": "^11.12.1",
@@ -475,13 +475,14 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.23.0.tgz",
-      "integrity": "sha512-ppdw2aD3oZFkmls4lYx2WecaMuzQs2XtrgKMEzLNOWd+ig56Gpml9/RRXsmIdG1RYA0qnlOHD6aIZy1aEb4DwQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.24.0.tgz",
+      "integrity": "sha512-tSj6W6qHFJf27FqfdxU7uKHl/OBghLLQ5lwf643d+z7RaxF7A+OR2s1s4D5GuRpCOVjZGpUXGYVZajQK8Jv5Mg==",
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.22.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.42.0",
+        "@camunda/zeebe-configuration-templates-json-schema": "^0.2.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.44.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       }
@@ -726,10 +727,16 @@
         }
       }
     },
+    "node_modules/@camunda/zeebe-configuration-templates-json-schema": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-configuration-templates-json-schema/-/zeebe-configuration-templates-json-schema-0.2.0.tgz",
+      "integrity": "sha512-H/ej903ai3dGDuZqYsr9pbCbkoseztoGvjo22Op+Ac8ZO3iS0pk38+I8DCqdtC80mQ7WAI7ZzHsv7hU1XLMyNA==",
+      "license": "MIT"
+    },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.42.0.tgz",
-      "integrity": "sha512-sH17vgRCAA4fuY18EipXRVHPHDDbfGppmPsNR/vitJbAevHt+ytWS/oJD6tma3xrCImGaevsRGuftJYwgQsoEA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.44.0.tgz",
+      "integrity": "sha512-dlfHr/XwQdF2Rgksk7dTb9/pv9nAvcPEz4cKZYfqj0L/i6AWcC4t1r+1GaK6PmBHOideHdAM4j95s0r917gTkg==",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.23.0",
+    "@bpmn-io/element-templates-validator": "^2.24.0",
     "@bpmn-io/extract-process-variables": "^2.2.1",
     "@bpmn-io/semver-compat": "^0.1.0",
     "bpmnlint": "^11.12.1",

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -47,6 +47,7 @@ import {
   ZEEBE_FORM_DEFINITION,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
@@ -165,6 +166,8 @@ export default class ChangeElementTemplateHandler {
     this._updateZeebeAssignmentDefinition(element, oldTemplate, newTemplate);
 
     this._updateZeebePriorityDefinition(element, oldTemplate, newTemplate);
+
+    this._updateZeebeJobPriorityDefinition(element, oldTemplate, newTemplate);
 
     this._updateAdHoc(element, oldTemplate, newTemplate);
 
@@ -1539,6 +1542,19 @@ export default class ChangeElementTemplateHandler {
     );
   }
 
+  _updateZeebeJobPriorityDefinition(element, oldTemplate, newTemplate) {
+    this._updateSingleExtensionElement(
+      element,
+      oldTemplate,
+      newTemplate,
+      {
+        bindingTypes: [ ZEEBE_JOB_PRIORITY_DEFINITION ],
+        extensionType: 'zeebe:JobPriorityDefinition',
+        getPropertyName: (binding) => binding.property
+      }
+    );
+  }
+
   _updateAdHoc(element, oldTemplate, newTemplate) {
     this._updateSingleExtensionElement(
       element,
@@ -2341,6 +2357,19 @@ export function findOldProperty(oldTemplate, newProperty) {
     });
   }
 
+  if (newBindingType === ZEEBE_JOB_PRIORITY_DEFINITION) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_JOB_PRIORITY_DEFINITION) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
+
   if (newBindingType === ZEEBE_AD_HOC) {
     return oldProperties.find(oldProperty => {
       const oldBinding = oldProperty.binding,
@@ -2546,6 +2575,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_PRIORITY_DEFINITION) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_JOB_PRIORITY_DEFINITION) {
     return businessObject.get(bindingProperty);
   }
 

--- a/src/cloud-element-templates/create/JobPriorityDefinitionBindingProvider.js
+++ b/src/cloud-element-templates/create/JobPriorityDefinitionBindingProvider.js
@@ -1,0 +1,28 @@
+import {
+  ensureExtension,
+} from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+
+export default class JobPriorityDefinitionBindingProvider {
+  static create(element, options) {
+    const {
+      property,
+      bpmnFactory
+    } = options;
+
+    const {
+      binding
+    } = property;
+
+    const {
+      property: propertyName
+    } = binding;
+
+    const value = getDefaultValue(property);
+
+    const jobPriorityDefinition = ensureExtension(element, 'zeebe:JobPriorityDefinition', bpmnFactory);
+
+    jobPriorityDefinition.set(propertyName, value);
+  }
+}

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -26,6 +26,7 @@ import { ScriptTaskBindingProvider } from './ScriptTaskBindingProvider';
 import ZeebeFormDefinitionBindingProvider from './FormDefinitionBindingProvider';
 import ZeebeAssignmentDefinitionBindingProvider from './AssignmentDefinitionBindingProvider';
 import ZeebePriorityDefinitionBindingProvider from './PriorityDefinitionBindingProvider';
+import ZeebeJobPriorityDefinitionBindingProvider from './JobPriorityDefinitionBindingProvider';
 import AdHocBindingProvider from './AdHocBindingProvider';
 import TaskScheduleBindingProvider from './TaskScheduleBindingProvider';
 import {
@@ -55,6 +56,7 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
@@ -97,6 +99,7 @@ export default class TemplateElementFactory {
       [ZEEBE_SCRIPT_TASK]: ScriptTaskBindingProvider,
       [ZEEBE_ASSIGNMENT_DEFINITION]: ZeebeAssignmentDefinitionBindingProvider,
       [ZEEBE_PRIORITY_DEFINITION]: ZeebePriorityDefinitionBindingProvider,
+      [ZEEBE_JOB_PRIORITY_DEFINITION]: ZeebeJobPriorityDefinitionBindingProvider,
       [ZEEBE_AD_HOC]: AdHocBindingProvider,
       [ZEEBE_TASK_SCHEDULE]: TaskScheduleBindingProvider,
       [ZEEBE_EXECUTION_LISTENER]: ExecutionListenerBindingProvider,

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -21,6 +21,7 @@ export const ZEEBE_FORM_DEFINITION = 'zeebe:formDefinition';
 export const ZEEBE_SCRIPT_TASK = 'zeebe:script';
 export const ZEEBE_ASSIGNMENT_DEFINITION = 'zeebe:assignmentDefinition';
 export const ZEEBE_PRIORITY_DEFINITION = 'zeebe:priorityDefinition';
+export const ZEEBE_JOB_PRIORITY_DEFINITION = 'zeebe:jobPriorityDefinition';
 export const ZEEBE_AD_HOC = 'zeebe:adHoc';
 export const ZEEBE_TASK_SCHEDULE = 'zeebe:taskSchedule';
 export const ZEEBE_EXECUTION_LISTENER = 'zeebe:executionListener';
@@ -41,6 +42,7 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -34,6 +34,7 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
@@ -340,6 +341,12 @@ function getRawPropertyValue(element, property) {
     const priorityDefinition = findExtension(businessObject, 'zeebe:PriorityDefinition');
 
     return priorityDefinition ? priorityDefinition.get(bindingProperty) : defaultValue;
+  }
+
+  if (type === ZEEBE_JOB_PRIORITY_DEFINITION) {
+    const jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+
+    return jobPriorityDefinition ? jobPriorityDefinition.get(bindingProperty) : defaultValue;
   }
 
   if (type === ZEEBE_AD_HOC) {
@@ -1082,6 +1089,38 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
           ...context,
           moddleElement: extensionElements,
           properties: { values: [ ...extensionElements.get('values'), priorityDefinition ] }
+        }
+      });
+    }
+  }
+
+  // zeebe:jobPriorityDefinition
+  if (type === ZEEBE_JOB_PRIORITY_DEFINITION) {
+    let jobPriorityDefinition = findExtension(element, 'zeebe:JobPriorityDefinition');
+    const propertyName = binding.property;
+
+    const properties = {
+      [ propertyName ]: value || ''
+    };
+
+    if (jobPriorityDefinition) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          properties,
+          moddleElement: jobPriorityDefinition
+        }
+      });
+    } else {
+      jobPriorityDefinition = createElement('zeebe:JobPriorityDefinition', properties, extensionElements, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: extensionElements,
+          properties: { values: [ ...extensionElements.get('values'), jobPriorityDefinition ] }
         }
       });
     }

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -1100,7 +1100,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
     const propertyName = binding.property;
 
     const properties = {
-      [ propertyName ]: value || ''
+      [ propertyName ]: value ?? ''
     };
 
     if (jobPriorityDefinition) {

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -301,6 +301,23 @@ describe('provider/cloud-element-templates - Validator', function() {
     });
 
 
+    it('should accept zeebe:jobPriorityDefinition binding', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/job-priority-definition');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
     it('should reject missing name', function() {
 
       // given

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -3717,6 +3717,119 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('zeebe:jobPriorityDefinition', function() {
+
+      beforeEach(bootstrap(require('./job-priority-definition.bpmn').default));
+
+      const newTemplate = require('./job-priority-definition.json');
+
+      it('should execute', inject(function(elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('ServiceTask_1');
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        expectElementTemplate(task, 'com.camunda.example.JobPriorityDefinition');
+
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+        expect(jobPriorityDefinition).to.have.property('priority', 10);
+      }));
+
+
+      it('should store FEEL value', inject(function(elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('ServiceTask_1');
+
+        const template = createTemplate([
+          {
+            value: '=myVar',
+            binding: {
+              type: 'zeebe:jobPriorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        // when
+        changeTemplate(task, template);
+
+        // then
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+        expect(jobPriorityDefinition).to.have.property('priority', '=myVar');
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        task = elementRegistry.get('ServiceTask_1');
+        expectNoElementTemplate(task);
+
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).not.to.exist;
+
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(task, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        task = elementRegistry.get('ServiceTask_1');
+        expectElementTemplate(task, 'com.camunda.example.JobPriorityDefinition');
+
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+        expect(jobPriorityDefinition).to.have.property('priority', 10);
+      }));
+
+
+      it('should not override existing', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('ServiceTask_jobPriorityDefinition');
+
+        // when
+        changeTemplate(task, newTemplate);
+
+        // then
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+
+        // Should keep the old values, not override with newTemplate's values
+        expect(jobPriorityDefinition).to.have.property('priority', '5');
+
+      }));
+    });
+
+
     describe('zeebe:taskSchedule', function() {
 
       beforeEach(bootstrap(require('./task-schedule.bpmn').default));
@@ -6884,6 +6997,96 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
         expect(priorityDefinition).to.exist;
         expect(priorityDefinition.get('priority')).to.equal(10);
+      }));
+    });
+
+
+    describe('update zeebe:JobPriorityDefinition', function() {
+
+      beforeEach(bootstrap(require('./job-priority-definition.bpmn').default));
+
+      it('property changed', inject(function(elementRegistry) {
+
+        // given a user applies a template and updates a property
+        let task = elementRegistry.get('ServiceTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 5,
+            binding: {
+              type: 'zeebe:jobPriorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 10,
+            binding: {
+              type: 'zeebe:jobPriorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('ServiceTask_1');
+        let jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        updateBusinessObject('ServiceTask_1', jobPriorityDefinition, {
+          priority: 7
+        });
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+        expect(jobPriorityDefinition.get('priority')).to.equal(7);
+      }));
+
+
+      it('property unchanged', inject(function(elementRegistry) {
+
+        // given a user applies a template and does not update a property
+        let task = elementRegistry.get('ServiceTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 5,
+            binding: {
+              type: 'zeebe:jobPriorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        const newTemplate = createTemplate([
+          {
+            value: 10,
+            binding: {
+              type: 'zeebe:jobPriorityDefinition',
+              property: 'priority'
+            }
+          }
+        ]);
+
+        changeTemplate(task, oldTemplate);
+
+        task = elementRegistry.get('ServiceTask_1');
+
+        // when
+        changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        const jobPriorityDefinition = findExtension(task, 'zeebe:JobPriorityDefinition');
+
+        expect(jobPriorityDefinition).to.exist;
+        expect(jobPriorityDefinition.get('priority')).to.equal(10);
       }));
     });
 

--- a/test/spec/cloud-element-templates/cmd/job-priority-definition.bpmn
+++ b/test/spec/cloud-element-templates/cmd/job-priority-definition.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1dvk1qu" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_10shw5p" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" name="" />
+    <bpmn:serviceTask id="ServiceTask_jobPriorityDefinition" name="">
+      <bpmn:extensionElements>
+        <zeebe:jobPriorityDefinition priority="5" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_10shw5p">
+      <bpmndi:BPMNShape id="Activity_1phbbua_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cwyzhq_di" bpmnElement="ServiceTask_jobPriorityDefinition">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/cmd/job-priority-definition.json
+++ b/test/spec/cloud-element-templates/cmd/job-priority-definition.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "JobPriorityDefinition",
+  "id": "com.camunda.example.JobPriorityDefinition",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "myTask",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "label": "Priority",
+      "description": "Priority for job",
+      "type": "Number",
+      "value": 10,
+      "binding": {
+        "type": "zeebe:jobPriorityDefinition",
+        "property": "priority"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -853,6 +853,26 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
     }));
 
 
+    it('should handle <zeebe:jobPriorityDefinition>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('com.camunda.example.JobPriorityDefinition');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      // then
+      const bo = getBusinessObject(element);
+      const jobPriorityDefinition = findExtension(bo, 'zeebe:JobPriorityDefinition');
+
+      expect(jobPriorityDefinition).to.exist;
+      expect(jobPriorityDefinition).to.jsonEqual({
+        $type: 'zeebe:JobPriorityDefinition',
+        priority: 10
+      });
+    }));
+
+
     it('should handle <zeebe:adHoc>', inject(function(templateElementFactory) {
 
       // given

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -762,6 +762,36 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "JobPriorityDefinition",
+    "id": "com.camunda.example.JobPriorityDefinition",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "myTask",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Priority",
+        "description": "Priority for job",
+        "type": "Number",
+        "value": 10,
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "AdHoc Template",
     "id": "ad-hoc-template",
     "appliesTo": [

--- a/test/spec/cloud-element-templates/fixtures/job-priority-definition.json
+++ b/test/spec/cloud-element-templates/fixtures/job-priority-definition.json
@@ -1,0 +1,22 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "JobPriorityDefinition",
+    "id": "com.camunda.example.JobPriorityDefinition",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "Priority",
+        "description": "Priority for job",
+        "type": "Number",
+        "value": 10,
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -124,6 +124,12 @@
         <zeebe:priorityDefinition priority="10" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:serviceTask id="ServiceTask_jobPriority" name="jobPriority" zeebe:modelerTemplate="com.camunda.example.JobPriorityDefinition">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="myTask" />
+        <zeebe:jobPriorityDefinition priority="10" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
     <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="zeebe:adHoc" zeebe:modelerTemplate="com.camunda.example.AdHoc">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="ad-hoc-job-worker" />
@@ -271,6 +277,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_priority_di" bpmnElement="UserTask_priority">
         <dc:Bounds x="290" y="1030" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_jobPriority_di" bpmnElement="ServiceTask_jobPriority">
+        <dc:Bounds x="450" y="1030" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kj2zmg_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -1104,6 +1104,49 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "ConditionalJobPriorityDefinition",
+    "id": "com.camunda.example.ConditionalJobPriorityDefinition",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "myTask",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "id": "set-priority",
+        "label": "Set Priority",
+        "type": "String",
+        "value": "off",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "setPriority"
+        }
+      },
+      {
+        "label": "Priority",
+        "description": "Priority for job",
+        "type": "Number",
+        "condition": {
+          "property": "set-priority",
+          "equals": "on"
+        },
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Custom Properties",
     "id": "com.camunda.example.TaskSchedule",
     "appliesTo": [

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -1074,6 +1074,36 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "JobPriorityDefinition",
+    "id": "com.camunda.example.JobPriorityDefinition",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "myTask",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Priority",
+        "description": "Priority for job",
+        "type": "Number",
+        "value": 10,
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "Custom Properties",
     "id": "com.camunda.example.TaskSchedule",
     "appliesTo": [

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1829,6 +1829,71 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('zeebe:jobPriorityDefinition', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('ServiceTask_jobPriority');
+
+      // then
+      const entry = findEntry('custom-entry-com.camunda.example.JobPriorityDefinition-1', container),
+            input = findInput('number', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('10');
+    });
+
+
+    it('should change, setting priority value', async function() {
+
+      // given
+      const element = await expectSelected('ServiceTask_jobPriority'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const entry = findEntry('custom-entry-com.camunda.example.JobPriorityDefinition-1', container),
+            input = findInput('number', entry);
+
+      changeInput(input, '20');
+
+      // then
+      expect(input.value).to.equal('20');
+
+      const jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+      expect(jobPriorityDefinition).to.exist;
+      expect(jobPriorityDefinition).to.have.property('priority', 20);
+    });
+
+
+    it('should change, creating zeebe:jobPriorityDefinition if non-existing', inject(async function(elementTemplates, elementRegistry) {
+
+      // given
+      const template = templates.find(t => t.id === 'com.camunda.example.JobPriorityDefinition');
+      let task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        elementTemplates.applyTemplate(task, template);
+      });
+
+      // then
+      task = elementRegistry.get('Task_1');
+      const jobPriorityDefinition = findExtension(getBusinessObject(task), 'zeebe:JobPriorityDefinition');
+
+      const entry = findEntry('custom-entry-com.camunda.example.JobPriorityDefinition-1', container),
+            input = findInput('number', entry);
+
+      expect(entry).to.exist;
+      expect(input).to.exist;
+      expect(input.value).to.equal('10');
+      expect(jobPriorityDefinition).to.have.property('priority', 10);
+    }));
+
+  });
+
+
   describe('zeebe:taskSchedule', function() {
 
     it('should display', async function() {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1866,6 +1866,24 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(jobPriorityDefinition).to.have.property('priority', 20);
     });
 
+    it('should change, setting priority value to 0', async function() {
+
+      // given
+      const element = await expectSelected('ServiceTask_jobPriority'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const entry = findEntry('custom-entry-com.camunda.example.JobPriorityDefinition-1', container),
+            input = findInput('number', entry);
+
+      changeInput(input, '0');
+
+      // then
+      const jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+      expect(jobPriorityDefinition).to.exist;
+      expect(jobPriorityDefinition).to.have.property('priority', 0);
+    });
+
 
     it('should change, creating zeebe:jobPriorityDefinition if non-existing', inject(async function(elementTemplates, elementRegistry) {
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1909,6 +1909,63 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(jobPriorityDefinition).to.have.property('priority', 10);
     }));
 
+    it('should create zeebe:jobPriorityDefinition for conditioned property', inject(async function(commandStack, elementTemplates, elementRegistry) {
+
+      // given
+      const template = templates.find(t => t.id === 'com.camunda.example.ConditionalJobPriorityDefinition');
+      let task = elementRegistry.get('Task_1');
+
+      // when
+      await act(() => {
+        elementTemplates.applyTemplate(task, template);
+      });
+
+      // then
+      task = elementRegistry.get('Task_1');
+      const businessObject = getBusinessObject(task);
+      let jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+
+      expect(jobPriorityDefinition).not.to.exist;
+
+      // when
+      const setPriorityEntry = findEntry('custom-entry-com.camunda.example.ConditionalJobPriorityDefinition-1', container),
+            setPriorityInput = findInput('text', setPriorityEntry);
+
+      changeInput(setPriorityInput, 'on');
+
+      await waitFor(() => {
+        const priorityEntry = findEntry('custom-entry-com.camunda.example.ConditionalJobPriorityDefinition-2', container);
+
+        expect(priorityEntry).to.exist;
+      });
+
+      jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+      expect(jobPriorityDefinition).to.exist;
+
+      const extensionElements = businessObject.get('extensionElements');
+
+      commandStack.execute('element.updateModdleProperties', {
+        element: task,
+        moddleElement: extensionElements,
+        properties: {
+          values: extensionElements.get('values').filter((value) => value !== jobPriorityDefinition)
+        }
+      });
+
+      jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+      expect(jobPriorityDefinition).not.to.exist;
+
+      const priorityEntry = findEntry('custom-entry-com.camunda.example.ConditionalJobPriorityDefinition-2', container),
+            priorityInput = findInput('number', priorityEntry);
+
+      changeInput(priorityInput, '0');
+
+      // then
+      jobPriorityDefinition = findExtension(businessObject, 'zeebe:JobPriorityDefinition');
+      expect(jobPriorityDefinition).to.exist;
+      expect(jobPriorityDefinition).to.have.property('priority', 0);
+    }));
+
   });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5889

### Proposed Changes

This PR adds support for `zeebe:jobPriorityDefinition` binding.

<img width="1728" height="993" alt="image" src="https://github.com/user-attachments/assets/3d691d12-f17e-45bf-890b-cc094ec59703" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
