### PR TITLE
Resolve entry ids for remaining elements

### DIFF
--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -17,6 +17,7 @@ import { pathEquals } from '@bpmn-io/moddle-utils';
 
 import { getBindingPath } from '../util/bindingPath';
 import { getPropertyEntryId } from '../util/customPropertyEntryIds';
+import { createCustomEntry } from './properties/custom-properties';
 import { has, isObject } from 'min-dash';
 
 const LOWER_PRIORITY = 300;
@@ -129,7 +130,13 @@ export default class ElementTemplatesPropertiesProvider {
       const bindingPath = getBindingPath(element, property.binding);
 
       if (bindingPath && pathEquals(bindingPath, path)) {
-        return getPropertyEntryId(conditioned, property);
+        const entryId = getPropertyEntryId(conditioned, property);
+
+        // only resolve to a property that actually renders an entry (e.g. not
+        // Hidden), so the resolved id is guaranteed to exist in the panel
+        if (createCustomEntry(entryId, element, property)) {
+          return entryId;
+        }
       }
     }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
@@ -124,7 +124,14 @@ function addCustomGroup(groups, props) {
   }
 }
 
-function createCustomEntry(id, element, property) {
+/**
+ * Build the properties panel entry descriptor for a template property, or
+ * `undefined` when the property renders no entry (e.g. a `Hidden` property or a
+ * binding without a renderable default type). Exported so the provider's
+ * `getEntryId` can use it as the single source of "does this property render",
+ * keeping id resolution in lock-step with what the panel actually shows.
+ */
+export function createCustomEntry(id, element, property) {
   let { type, feel, language } = property;
 
   if (!type) {

--- a/src/cloud-element-templates/util/bindingPath.js
+++ b/src/cloud-element-templates/util/bindingPath.js
@@ -14,6 +14,7 @@ import {
   MESSAGE_PROPERTY_TYPE,
   MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE,
   SIGNAL_PROPERTY_TYPE,
+  TIMER_EVENT_DEFINITION_PROPERTY_TYPE,
   CONDITIONAL_EVENT_DEFINITION_PROPERTY,
   CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY,
   ZEEBE_CALLED_ELEMENT,
@@ -23,8 +24,11 @@ import {
   ZEEBE_SCRIPT_TASK,
   ZEEBE_ASSIGNMENT_DEFINITION,
   ZEEBE_PRIORITY_DEFINITION,
+  ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
-  ZEEBE_TASK_SCHEDULE
+  ZEEBE_TASK_SCHEDULE,
+  ZEEBE_EXECUTION_LISTENER,
+  ZEEBE_TASK_LISTENER
 } from './bindingTypes';
 
 import {
@@ -39,6 +43,7 @@ import {
   findOutputParameter,
   findSignal,
   findTaskHeader,
+  findTimerEventDefinition,
   findZeebeProperty,
   findZeebeSubscription
 } from '../Helper';
@@ -110,11 +115,23 @@ export function getBindingPath(element, binding) {
   case ZEEBE_PRIORITY_DEFINITION:
     return getExtensionBindingPath(businessObject, 'zeebe:PriorityDefinition', binding.property);
 
+  case ZEEBE_JOB_PRIORITY_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:JobPriorityDefinition', binding.property);
+
   case ZEEBE_AD_HOC:
     return getExtensionBindingPath(businessObject, 'zeebe:AdHoc', binding.property);
 
   case ZEEBE_LINKED_RESOURCE_PROPERTY:
     return getLinkedResourceBindingPath(businessObject, binding);
+
+  case TIMER_EVENT_DEFINITION_PROPERTY_TYPE:
+    return getTimerBindingPath(businessObject, binding);
+
+  case ZEEBE_EXECUTION_LISTENER:
+    return getListenerBindingPath(businessObject, binding, 'zeebe:ExecutionListeners');
+
+  case ZEEBE_TASK_LISTENER:
+    return getListenerBindingPath(businessObject, binding, 'zeebe:TaskListeners');
 
   case CONDITIONAL_EVENT_DEFINITION_PROPERTY:
     return getConditionalEventDefinitionBindingPath(businessObject, binding);
@@ -123,8 +140,8 @@ export function getBindingPath(element, binding) {
     return getConditionalFilterBindingPath(businessObject, binding);
 
   // Not (yet) path-resolvable — the provider defers (returns null) so the
-  // standard entry answers. Known gaps: zeebe:userTask, zeebe:executionListener,
-  // zeebe:taskListener and bpmn:TimerEventDefinition#property.
+  // standard entry answers. Known gap: zeebe:userTask, a marker binding that
+  // has no bound property and renders no entry to resolve to.
   default:
     return null;
   }
@@ -147,6 +164,48 @@ function getExtensionBindingPath(businessObject, extensionType, field) {
   const extensionIndex = getExtensionIndex(businessObject, extension);
 
   return [ 'extensionElements', 'values', extensionIndex, field ];
+}
+
+/**
+ * Path to the (first) timer event definition's expression property, e.g.
+ * `[ 'eventDefinitions', <index>, 'timeDuration' ]`. Mirrors the leaf the Zeebe
+ * resolver keys on (`bpmn:TimerEventDefinition#<timeCycle|timeDate|timeDuration>`).
+ */
+function getTimerBindingPath(businessObject, binding) {
+  const timerEventDefinition = findTimerEventDefinition(businessObject);
+
+  if (!timerEventDefinition) {
+    return null;
+  }
+
+  const index = businessObject.get('eventDefinitions').indexOf(timerEventDefinition);
+
+  return [ 'eventDefinitions', index, binding.name ];
+}
+
+/**
+ * Path to a listener's `type` within its container's `listeners` collection,
+ * e.g. `[ 'extensionElements', 'values', <index>, 'listeners', <index>, 'type' ]`.
+ * The listener is matched by its `eventType`, mirroring `getListenerValue`.
+ */
+function getListenerBindingPath(businessObject, binding, containerType) {
+  const container = findExtension(businessObject, containerType);
+
+  if (!container) {
+    return null;
+  }
+
+  const listeners = container.get('listeners');
+
+  const index = listeners.findIndex(listener => listener.get('eventType') === binding.eventType);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const extensionIndex = getExtensionIndex(businessObject, container);
+
+  return [ 'extensionElements', 'values', extensionIndex, 'listeners', index, 'type' ];
 }
 
 function getIoBindingPath(businessObject, binding, type) {

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.bpmn
@@ -3,6 +3,10 @@
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="Task_1" />
     <bpmn:task id="Task_2" />
+    <bpmn:serviceTask id="ServiceTask_1" />
+    <bpmn:intermediateCatchEvent id="TimerEvent_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+    </bpmn:intermediateCatchEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -11,6 +15,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="160" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TimerEvent_1_di" bpmnElement="TimerEvent_1">
+        <dc:Bounds x="192" y="442" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
@@ -63,5 +63,74 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Job Priority Template",
+    "id": "job-priority-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "id": "priority-1",
+        "type": "Number",
+        "label": "Priority",
+        "value": 10,
+        "binding": {
+          "type": "zeebe:jobPriorityDefinition",
+          "property": "priority"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Timer Duration Template",
+    "id": "timer-duration-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:IntermediateCatchEvent"
+    ],
+    "elementType": {
+      "value": "bpmn:IntermediateCatchEvent",
+      "eventDefinition": "bpmn:TimerEventDefinition"
+    },
+    "properties": [
+      {
+        "id": "duration-1",
+        "type": "String",
+        "label": "Duration",
+        "value": "PT1H",
+        "binding": {
+          "type": "bpmn:TimerEventDefinition#property",
+          "name": "timeDuration"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Execution Listener Template",
+    "id": "execution-listener-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "entriesVisible": {
+      "executionListeners": false
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=template-start",
+        "binding": {
+          "type": "zeebe:executionListener",
+          "eventType": "start",
+          "retries": "=3"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -38,7 +38,8 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   findExtension,
-  findInputParameter
+  findInputParameter,
+  findTimerEventDefinition
 } from 'src/cloud-element-templates/Helper';
 
 import { getBindingPath } from 'src/cloud-element-templates/util/bindingPath';
@@ -1264,6 +1265,107 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
         // then (condition no longer met: the provider defers, even though the
         // moddle location referenced by `path` may still physically hold data)
         expect(elementTemplatesPropertiesProvider.getEntryId(task, path)).to.be.null;
+      })
+    );
+
+
+    it('should resolve a templated zeebe:jobPriorityDefinition to its rendered entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(serviceTask, getEntryIdTemplates[1]);
+        });
+        await act(() => selection.select(serviceTask));
+
+        const template = elementTemplates.get(serviceTask);
+
+        // when
+        const path = getBindingPath(serviceTask, {
+          type: 'zeebe:jobPriorityDefinition',
+          property: 'priority'
+        });
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(serviceTask, path);
+
+        // then (resolves to the same id the panel actually rendered)
+        const property = template.properties.find(p => p.id === 'priority-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+
+        expect(domQuery(`[data-entry-id="${entryId}"]`, container)).to.exist;
+      })
+    );
+
+
+    it('should resolve a templated bpmn:TimerEventDefinition property to its rendered entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const timerEvent = elementRegistry.get('TimerEvent_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(timerEvent, getEntryIdTemplates[2]);
+        });
+
+        // re-fetch as applying an elementType template morphs the element
+        const templatedEvent = elementRegistry.get('TimerEvent_1');
+
+        await act(() => selection.select(templatedEvent));
+
+        const template = elementTemplates.get(templatedEvent);
+        const businessObject = getBusinessObject(templatedEvent);
+
+        // independently locate the moddle node the duration is written to
+        const timerEventDefinition = findTimerEventDefinition(businessObject);
+        const definitionIndex = businessObject.get('eventDefinitions').indexOf(timerEventDefinition);
+        const expectedPath = [ 'eventDefinitions', definitionIndex, 'timeDuration' ];
+
+        // when
+        const path = getBindingPath(templatedEvent, {
+          type: 'bpmn:TimerEventDefinition#property',
+          name: 'timeDuration'
+        });
+
+        // then (path shape matches the contract, independent of getEntryId)
+        expect(path).to.eql(expectedPath);
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(templatedEvent, path);
+
+        // then (resolves to the same id the panel actually rendered)
+        const property = template.properties.find(p => p.id === 'duration-1');
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+
+        expect(domQuery(`[data-entry-id="${entryId}"]`, container)).to.exist;
+      })
+    );
+
+
+    it('should defer a Hidden zeebe:executionListener binding (no rendered entry)', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given a template whose listener binding is Hidden (renders nothing)
+        const task = elementRegistry.get('Task_2');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[3]);
+        });
+        await act(() => selection.select(task));
+
+        // the binding still inverts to a concrete moddle path...
+        const path = getBindingPath(task, {
+          type: 'zeebe:executionListener',
+          eventType: 'start'
+        });
+        expect(path).to.exist;
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, path);
+
+        // then (...but no entry renders, so the provider defers rather than
+        // resolving to an id that is not in the panel)
+        expect(entryId).to.be.null;
       })
     );
 

--- a/test/spec/cloud-element-templates/util/bindingPath.spec.js
+++ b/test/spec/cloud-element-templates/util/bindingPath.spec.js
@@ -565,6 +565,111 @@ describe('cloud-element-templates/util - bindingPath', function() {
     });
 
 
+    describe('zeebe:jobPriorityDefinition', function() {
+
+      it('should resolve priority', function() {
+
+        // given
+        const jobPriorityDefinition = create('zeebe:JobPriorityDefinition', { priority: '50' });
+
+        const serviceTask = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ jobPriorityDefinition ])
+        });
+
+        const binding = { type: 'zeebe:jobPriorityDefinition', property: 'priority' };
+
+        // when
+        const path = getBindingPath(serviceTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'priority' ]);
+      });
+
+    });
+
+
+    describe('bpmn:TimerEventDefinition#property', function() {
+
+      it('should resolve the timer expression property', function() {
+
+        // given
+        const timerEventDefinition = create('bpmn:TimerEventDefinition', {
+          timeDuration: create('bpmn:FormalExpression', { body: 'PT1H' })
+        });
+
+        const catchEvent = create('bpmn:IntermediateCatchEvent', {
+          id: 'IntermediateCatchEvent_1',
+          eventDefinitions: [ timerEventDefinition ]
+        });
+
+        const binding = { type: 'bpmn:TimerEventDefinition#property', name: 'timeDuration' };
+
+        // when
+        const path = getBindingPath(catchEvent, binding);
+
+        // then
+        expect(path).to.eql([ 'eventDefinitions', 0, 'timeDuration' ]);
+      });
+
+    });
+
+
+    describe('zeebe:executionListener', function() {
+
+      it('should resolve the matching listener type', function() {
+
+        // given
+        const listeners = [
+          create('zeebe:ExecutionListener', { eventType: 'start', type: 'a' }),
+          create('zeebe:ExecutionListener', { eventType: 'end', type: 'b' })
+        ];
+
+        const executionListeners = create('zeebe:ExecutionListeners', { listeners });
+
+        const serviceTask = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+
+        const binding = { type: 'zeebe:executionListener', eventType: 'end' };
+
+        // when
+        const path = getBindingPath(serviceTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ]);
+      });
+
+    });
+
+
+    describe('zeebe:taskListener', function() {
+
+      it('should resolve the matching listener type', function() {
+
+        // given
+        const taskListeners = create('zeebe:TaskListeners', {
+          listeners: [ create('zeebe:TaskListener', { eventType: 'assigning', type: 'a' }) ]
+        });
+
+        const userTask = create('bpmn:UserTask', {
+          id: 'UserTask_1',
+          extensionElements: withExtensionElements([ taskListeners ])
+        });
+
+        const binding = { type: 'zeebe:taskListener', eventType: 'assigning' };
+
+        // when
+        const path = getBindingPath(userTask, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ]);
+      });
+
+    });
+
+
     describe('zeebe:linkedResource', function() {
 
       it('should resolve the property of the matching linked resource', function() {
@@ -650,12 +755,12 @@ describe('cloud-element-templates/util - bindingPath', function() {
 
     describe('unsupported bindings', function() {
 
-      it('should return null for an unknown binding type', function() {
+      it('should return null for a deferred binding type (zeebe:userTask)', function() {
 
         // given
-        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+        const task = create('bpmn:UserTask', { id: 'UserTask_1' });
 
-        const binding = { type: 'zeebe:executionListener', eventType: 'start' };
+        const binding = { type: 'zeebe:userTask' };
 
         // when
         const path = getBindingPath(task, binding);
@@ -917,6 +1022,54 @@ describe('cloud-element-templates/util - bindingPath', function() {
         const path = getBindingPath(boundaryEvent, {
           type: 'bpmn:ConditionalEventDefinition#zeebe:conditionalFilter#property', name: 'variableEvents'
         });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('timer event definition missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, {
+          type: 'bpmn:TimerEventDefinition#property', name: 'timeDuration'
+        });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('execution listeners extension missing', function() {
+
+        // given
+        const task = create('bpmn:ServiceTask', { id: 'ServiceTask_1' });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:executionListener', eventType: 'start' });
+
+        // then
+        expect(path).to.be.null;
+      });
+
+
+      it('execution listener not matched', function() {
+
+        // given
+        const executionListeners = create('zeebe:ExecutionListeners', {
+          listeners: [ create('zeebe:ExecutionListener', { eventType: 'start', type: 'a' }) ]
+        });
+
+        const task = create('bpmn:ServiceTask', {
+          id: 'ServiceTask_1',
+          extensionElements: withExtensionElements([ executionListeners ])
+        });
+
+        // when
+        const path = getBindingPath(task, { type: 'zeebe:executionListener', eventType: 'end' });
 
         // then
         expect(path).to.be.null;


### PR DESCRIPTION
### Proposed Changes

Extend `getBindingPath` to invert four bindings that #266 deferred:

- `zeebe:jobPriorityDefinition`
- `bpmn:TimerEventDefinition#property`
- `zeebe:executionListener`
- `zeebe:taskListener`

`ElementTemplatesPropertiesProvider#getEntryId` now guards resolution through `createCustomEntry`, so it only returns an id for a property that actually renders an entry. This keeps id resolution in lock-step with the panel and makes Hidden bindings (e.g. execution/task listeners) correctly defer instead of resolving to an id that is not in the DOM.

`zeebe:userTask` stays deferred: it is a marker binding with no bound property and renders no entry to resolve to.

Related to https://github.com/bpmn-io/internal-docs/issues/1355

Builds on top of #266 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
