### PR TITLE
fix(element-templates): filter incompatible templates before validation

### DIFF
--- a/src/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/cloud-element-templates/ElementTemplatesLoader.js
@@ -16,20 +16,8 @@ export default class ElementTemplatesLoader extends TemplatesLoader {
     this._elementTemplates = elementTemplates;
   }
 
-  setTemplates(templates) {
-    const elementTemplates = this._elementTemplates,
-          moddle = this._moddle;
-
-    const validator = new Validator(moddle).addAll(templates);
-
-    const errors = validator.getErrors(),
-          validTemplates = validator.getValidTemplates();
-
-    elementTemplates.set(validTemplates);
-
-    if (errors.length) {
-      this._templateErrors(errors);
-    }
+  _createValidator() {
+    return new Validator(this._moddle);
   }
 }
 

--- a/src/element-templates/ElementTemplatesLoader.js
+++ b/src/element-templates/ElementTemplatesLoader.js
@@ -2,6 +2,9 @@ import {
   isFunction,
   isUndefined,
   isArray,
+  isObject,
+  isString,
+  isNil
 } from 'min-dash';
 
 import { Validator } from './Validator';
@@ -68,19 +71,53 @@ export default class ElementTemplatesLoader {
   }
 
   setTemplates(templates) {
-    const elementTemplates = this._elementTemplates,
-          moddle = this._moddle;
+    const elementTemplates = this._elementTemplates;
 
-    const validator = new Validator(moddle).addAll(templates);
+    const validator = this._createValidator().addAll(templates);
 
-    const errors = validator.getErrors(),
-          validTemplates = validator.getValidTemplates();
+    // load all schema-valid templates, including ones that are incompatible
+    // with the host engines: they may already be applied to elements and must
+    // keep working. Incompatible templates are merely excluded from _selection_,
+    // which happens later via the engine-aware `getLatest` / `getCompatible`
+    // lookups.
+    elementTemplates.set(validator.getValidTemplates());
 
-    elementTemplates.set(validTemplates);
+    // report validation errors, but suppress them for templates that are
+    // incompatible with the host engines: a template built for another
+    // environment (e.g. a newer modeler) must not surface intrusive "invalid
+    // template" errors for schema features this installation cannot understand.
+    //
+    // @see https://github.com/camunda/camunda-modeler/issues/6071
+    const errors = validator.getErrors().filter(
+      (error) => !this._isIncompatibleTemplateError(error)
+    );
 
     if (errors.length) {
       this._templateErrors(errors);
     }
+  }
+
+  /**
+   * Create the validator used to validate templates. Overridden by the cloud
+   * loader to plug in the Camunda Cloud validator.
+   *
+   * @return {Validator}
+   */
+  _createValidator() {
+    return new Validator(this._moddle);
+  }
+
+  /**
+   * Check whether a validation error was produced by a template that is
+   * incompatible with the host's configured engines and should therefore be
+   * suppressed.
+   *
+   * @param {Error} error
+   *
+   * @return {boolean}
+   */
+  _isIncompatibleTemplateError(error) {
+    return isEngineIncompatible(this._elementTemplates, error.template);
   }
 
   _templateErrors(errors) {
@@ -96,3 +133,49 @@ ElementTemplatesLoader.$inject = [
   'elementTemplates',
   'moddle'
 ];
+
+
+// helpers ///////////////////////////
+
+/**
+ * Check whether a template can be safely determined to be incompatible with
+ * the host's configured engines.
+ *
+ * Only well-formed `engines` declarations (a plain object of string ranges) are
+ * trusted; for anything malformed we return `false` so the template's errors are
+ * still reported by the validator, rather than silently suppressed.
+ *
+ * @param {ElementTemplates} elementTemplates
+ * @param {TemplateDescriptor} template
+ *
+ * @return {boolean}
+ */
+function isEngineIncompatible(elementTemplates, template) {
+  if (!isObject(template) || !hasValidEngines(template)) {
+    return false;
+  }
+
+  return !elementTemplates.isCompatible(template);
+}
+
+/**
+ * Check whether a template's `engines` are well-formed, i.e. absent or a plain
+ * object mapping engine names to string ranges.
+ *
+ * @param {TemplateDescriptor} template
+ *
+ * @return {boolean}
+ */
+function hasValidEngines(template) {
+  const engines = template.engines;
+
+  if (isNil(engines)) {
+    return true;
+  }
+
+  if (!isObject(engines)) {
+    return false;
+  }
+
+  return Object.values(engines).every(isString);
+}

--- a/src/element-templates/Helper.js
+++ b/src/element-templates/Helper.js
@@ -79,6 +79,13 @@ export function buildTemplatesById(templates, engines) {
   const templatesById = {};
 
   templates.forEach((template) => {
+
+    // templates are untrusted input and may have any shape; skip anything that
+    // is not a proper template object so we don't blow up on malformed entries
+    if (!isObject(template)) {
+      return;
+    }
+
     const id = template.id;
     const version = isUndefined(template.version) ? '_' : template.version;
 

--- a/src/element-templates/Validator.js
+++ b/src/element-templates/Validator.js
@@ -243,6 +243,13 @@ export class Validator {
       err = new Error(err);
     }
 
+    // keep a reference to the source template so consumers can associate an
+    // error with the template that produced it (e.g. to suppress errors for
+    // templates that are incompatible with the host environment)
+    if (template) {
+      err.template = template;
+    }
+
     this._errors.push(err);
 
     return err;

--- a/src/element-templates/Validator.js
+++ b/src/element-templates/Validator.js
@@ -3,6 +3,7 @@ import {
   forEach,
   isArray,
   isNil,
+  isObject,
   isString
 } from 'min-dash';
 
@@ -56,6 +57,15 @@ export class Validator {
    * @return {Validator}
    */
   add(template) {
+
+    // templates are untrusted input and may have any shape; reject anything
+    // that is not a proper template object rather than blowing up on it
+    if (!isObject(template)) {
+      this._logError('template must be an object');
+
+      return this;
+    }
+
     const err = this._validateTemplate(template);
 
     let id, version;

--- a/test/spec/cloud-element-templates/ElementTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplates.spec.js
@@ -1097,6 +1097,34 @@ describe('provider/cloud-element-templates - ElementTemplates', function() {
       expect(changeSpy).to.have.been.calledOnce;
     }));
 
+
+    it('should not blow up on malformed templates', inject(function(elementTemplates) {
+
+      // given
+      // templates are untrusted input and may have any shape
+      const malformed = [
+        null,
+        undefined,
+        'foo',
+        123,
+        true,
+        [],
+        {},
+        { id: 'no-engines' },
+        { id: 'broken-engines', engines: 'nope' },
+        { id: 'broken-engine-range', engines: { camunda: 123 } }
+      ];
+
+      // when
+      expect(function() {
+        elementTemplates.set(malformed);
+      }).not.to.throw();
+
+      // then
+      // well-formed entries are still indexed
+      expect(elementTemplates.get('no-engines')).to.exist;
+    }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
@@ -1,0 +1,288 @@
+import TestContainer from 'mocha-test-container-support';
+
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import { bootstrapModeler, inject } from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import elementTemplatesCoreModule from 'src/cloud-element-templates/core';
+
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './ElementTemplates.bpmn';
+
+const SCHEMA = 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json';
+
+// host engines used for the whole suite; template engines are only enforced
+// when the engine key is present here (unknown keys are treated compatible)
+const ENGINES = {
+  camundaDesktopModeler: '5.0.0'
+};
+
+// a valid template, compatible with the host engines
+const VALID_COMPATIBLE = {
+  $schema: SCHEMA,
+  name: 'Valid Compatible',
+  id: 'valid.compatible',
+  appliesTo: [ 'bpmn:Task' ],
+  properties: [
+    {
+      label: 'Name',
+      type: 'String',
+      binding: {
+        type: 'property',
+        name: 'name'
+      }
+    }
+  ]
+};
+
+// a schema-INVALID template (optional not supported for property binding),
+// compatible with the host engines
+const INVALID_COMPATIBLE = {
+  $schema: SCHEMA,
+  name: 'Invalid Compatible',
+  id: 'invalid.compatible',
+  appliesTo: [ 'bpmn:Task' ],
+  properties: [
+    {
+      type: 'String',
+      optional: true,
+      binding: {
+        type: 'property',
+        name: 'name'
+      }
+    }
+  ]
+};
+
+// a schema-INVALID template that is INCOMPATIBLE with the host engines
+// (requires a newer desktop modeler than the host provides)
+const INVALID_INCOMPATIBLE = {
+  $schema: SCHEMA,
+  name: 'Invalid Incompatible',
+  id: 'invalid.incompatible',
+  engines: {
+    camundaDesktopModeler: '>=999.0.0'
+  },
+  appliesTo: [ 'bpmn:Task' ],
+  properties: [
+    {
+      type: 'String',
+      optional: true,
+      binding: {
+        type: 'property',
+        name: 'name'
+      }
+    }
+  ]
+};
+
+// a schema-VALID template that is INCOMPATIBLE with the host engines
+const VALID_INCOMPATIBLE = {
+  $schema: SCHEMA,
+  name: 'Valid Incompatible',
+  id: 'valid.incompatible',
+  engines: {
+    camundaDesktopModeler: '>=999.0.0'
+  },
+  appliesTo: [ 'bpmn:Task' ],
+  properties: []
+};
+
+
+describe('provider/cloud-element-templates - ElementTemplatesLoader', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  function bootstrap(templates, engines = ENGINES, xml = diagramXML) {
+    return bootstrapModeler(xml, {
+      container: container,
+      modules: [
+        coreModule,
+        modelingModule,
+        elementTemplatesCoreModule
+      ],
+      moddleExtensions: {
+        zeebe: zeebeModdlePackage
+      },
+      elementTemplates: {
+        engines,
+        loadTemplates: templates
+      }
+    });
+  }
+
+
+  describe('engine-profile filtering before schema validation', function() {
+
+    describe('engine-INCOMPATIBLE + schema-INVALID template', function() {
+
+      beforeEach(bootstrap([ INVALID_INCOMPATIBLE ]));
+
+
+      it('should be excluded without producing an error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // schema-invalid, but incompatible => its error is suppressed
+          expect(errorListener).not.to.have.been.called;
+
+          // and not loaded
+          expect(elementTemplates.getAll()).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('engine-INCOMPATIBLE + schema-VALID template', function() {
+
+      beforeEach(bootstrap([ VALID_INCOMPATIBLE ]));
+
+
+      it('should load without error but be excluded from selection', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // no intrusive error for a template built for another environment
+          expect(errorListener).not.to.have.been.called;
+
+          // but it is still loaded, so elements it is applied to keep working
+          expect(elementTemplates.get('valid.incompatible')).to.exist;
+          expect(elementTemplates.getAll()).to.have.length(1);
+
+          // and excluded from selection (not offered as a compatible template)
+          expect(elementTemplates.getLatest('valid.incompatible')).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('engine-COMPATIBLE + schema-INVALID template', function() {
+
+      beforeEach(bootstrap([ INVALID_COMPATIBLE ]));
+
+
+      it('should still report its validation error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          expect(errorListener).to.have.been.called;
+
+          const { errors } = errorListener.getCall(0).args[0];
+
+          expect(errors).to.have.length.above(0);
+
+          // and not loaded
+          expect(elementTemplates.getAll()).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('engine-COMPATIBLE + schema-VALID template', function() {
+
+      beforeEach(bootstrap([ VALID_COMPATIBLE ]));
+
+
+      it('should load without producing an error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          expect(errorListener).not.to.have.been.called;
+
+          const loaded = elementTemplates.getAll();
+
+          expect(loaded).to.have.length(1);
+          expect(loaded[0].id).to.eql('valid.compatible');
+        }
+      ));
+
+    });
+
+
+    describe('malformed <engines> for a known key', function() {
+
+      // a malformed template with a non-string range for a _known_ engine key;
+      // it must not be silently treated as "incompatible" and suppressed, but
+      // handed to the validator (which reports it)
+      const MALFORMED_KNOWN_ENGINE = {
+        $schema: SCHEMA,
+        name: 'Malformed Engine',
+        id: 'malformed.engine',
+        engines: {
+          camunda: 123
+        },
+        appliesTo: [ 'bpmn:Task' ],
+        properties: []
+      };
+
+      beforeEach(bootstrap([]));
+
+
+      it('should not be silently skipped', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          // host enforces the <camunda> engine key
+          elementTemplates.setEngines({ camunda: '8.6.0' });
+          elementTemplatesLoader.setTemplates([ MALFORMED_KNOWN_ENGINE ]);
+
+          // then
+          // it is handed to the validator (reported), not silently dropped
+          expect(errorListener).to.have.been.called;
+          expect(elementTemplates.getAll()).to.be.empty;
+        }
+      ));
+
+    });
+
+  });
+
+});

--- a/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
@@ -285,4 +285,181 @@ describe('provider/cloud-element-templates - ElementTemplatesLoader', function()
 
   });
 
+
+  describe('integration: loading + error handling', function() {
+
+    // a diagram with a task that already has VALID_INCOMPATIBLE applied
+    const APPLIED_DIAGRAM_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="AppliedTask" zeebe:modelerTemplate="valid.incompatible" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="AppliedTask_di" bpmnElement="AppliedTask">
+        <dc:Bounds x="100" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+    // templates whose <engines> have arbitrary, non-object shapes
+    const MALFORMED_SHAPES = [
+      {
+        $schema: SCHEMA,
+        name: 'Engines String',
+        id: 'engines.string',
+        engines: 'foo',
+        appliesTo: [ 'bpmn:Task' ],
+        properties: []
+      },
+      {
+        $schema: SCHEMA,
+        name: 'Engines Array',
+        id: 'engines.array',
+        engines: [ 1, 2 ],
+        appliesTo: [ 'bpmn:Task' ],
+        properties: []
+      },
+      {
+        $schema: SCHEMA,
+        name: 'Engines Null Value',
+        id: 'engines.null',
+        engines: { camunda: null },
+        appliesTo: [ 'bpmn:Task' ],
+        properties: []
+      }
+    ];
+
+
+    describe('engine-INCOMPATIBLE template applied to an element', function() {
+
+      // regression guard: a template that is incompatible with the host engines
+      // but already applied to an element must remain resolvable, so the
+      // element keeps working ("working regardless" of incompatibility). It is
+      // only excluded from *selection*, never dropped from the registry.
+      beforeEach(bootstrap([ VALID_INCOMPATIBLE ], ENGINES, APPLIED_DIAGRAM_XML));
+
+
+      it('should still resolve for the element it is applied to', inject(
+        function(elementRegistry, elementTemplates) {
+
+          // given
+          const task = elementRegistry.get('AppliedTask');
+
+          // when
+          const template = elementTemplates.get(task);
+
+          // then
+          expect(template).to.exist;
+          expect(template.id).to.eql('valid.incompatible');
+        }
+      ));
+
+    });
+
+
+    describe('mixed templates', function() {
+
+      beforeEach(bootstrap([
+        VALID_COMPATIBLE,
+        INVALID_COMPATIBLE,
+        INVALID_INCOMPATIBLE,
+        VALID_INCOMPATIBLE
+      ]));
+
+
+      it('should suppress incompatible errors but keep valid templates loaded', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // only the schema-invalid _compatible_ template reports an error;
+          // the schema-invalid _incompatible_ one is suppressed
+          expect(errorListener).to.have.been.calledOnce;
+
+          const { errors } = errorListener.getCall(0).args[0];
+
+          expect(errors).to.have.length(1);
+
+          // both schema-valid templates are loaded (compatible + incompatible),
+          // so elements they are applied to keep working
+          const loaded = elementTemplates.getAll().map(t => t.id).sort();
+
+          expect(loaded).to.eql([ 'valid.compatible', 'valid.incompatible' ]);
+
+          // but only the compatible one is offered for selection
+          expect(elementTemplates.getLatest('valid.compatible')).to.have.length(1);
+          expect(elementTemplates.getLatest('valid.incompatible')).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('broken / untrusted templates', function() {
+
+      describe('malformed <engines> shapes', function() {
+
+        beforeEach(bootstrap([ VALID_COMPATIBLE, ...MALFORMED_SHAPES ]));
+
+
+        it('should not break loading of valid templates', inject(
+          function(elementTemplatesLoader, elementTemplates) {
+
+            // when
+            const load = () => elementTemplatesLoader.reload();
+
+            // then
+            expect(load).not.to.throw();
+
+            // and the valid template still loads
+            const loaded = elementTemplates.getAll();
+
+            expect(loaded.map(t => t.id)).to.include('valid.compatible');
+          }
+        ));
+
+      });
+
+
+      describe('non-array templates', function() {
+
+        const loadTemplates = function(done) {
+          done(null, { not: 'an array' });
+        };
+
+        beforeEach(bootstrap(loadTemplates));
+
+
+        it('should report an error without throwing', inject(
+          function(elementTemplatesLoader, eventBus) {
+
+            // given
+            const errorListener = spy();
+
+            eventBus.on('elementTemplates.errors', errorListener);
+
+            // when
+            const load = () => elementTemplatesLoader.reload();
+
+            // then
+            expect(load).not.to.throw();
+            expect(errorListener).to.have.been.called;
+          }
+        ));
+
+      });
+
+    });
+
+  });
+
 });

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -673,6 +673,34 @@ describe('provider/cloud-element-templates - Validator', function() {
   });
 
 
+  describe('broken / untrusted templates', function() {
+
+    it('should reject non-object entries without throwing', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // templates are untrusted input and may have any shape
+      const nonObjects = [ null, undefined, 'foo', 123, true, [] ];
+
+      // when
+      const add = () => validator.addAll(nonObjects);
+
+      // then
+      expect(add).not.to.throw();
+
+      // each non-object entry is reported ...
+      expect(errors(validator)).to.eql(nonObjects.map(function() {
+        return 'template must be an object';
+      }));
+
+      // ... and none is treated as valid
+      expect(valid(validator)).to.be.empty;
+    });
+
+  });
+
+
   describe('error <template> reference', function() {
 
     const SCHEMA = 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json';

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -672,4 +672,64 @@ describe('provider/cloud-element-templates - Validator', function() {
 
   });
 
+
+  describe('error <template> reference', function() {
+
+    const SCHEMA = 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json';
+
+    it('should attach the source template to logged errors', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // a schema-invalid template (<optional> not supported for property binding)
+      const template = {
+        $schema: SCHEMA,
+        name: 'Invalid',
+        id: 'com.example.invalid',
+        appliesTo: [ 'bpmn:Task' ],
+        properties: [
+          {
+            type: 'String',
+            optional: true,
+            binding: {
+              type: 'property',
+              name: 'name'
+            }
+          }
+        ]
+      };
+
+      // when
+      validator.add(template);
+
+      // then
+      const loggedErrors = validator.getErrors();
+
+      expect(loggedErrors).to.have.length.above(0);
+
+      loggedErrors.forEach(function(error) {
+        expect(error.template).to.equal(template);
+      });
+    });
+
+
+    it('should not attach a template to template-less errors', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // when
+      // not an array => generic error without a source template
+      validator.addAll('not-an-array');
+
+      // then
+      const [ error ] = validator.getErrors();
+
+      expect(error).to.exist;
+      expect(error.template).not.to.exist;
+    });
+
+  });
+
 });

--- a/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
+++ b/test/spec/cloud-element-templates/linting/LinterPlugin.spec.js
@@ -360,6 +360,32 @@ describe('cloud-element-templates/linting', function() {
   });
 
 
+  it('should not blow up on malformed templates', function() {
+
+    // given
+    // templates are untrusted input and may have any shape
+    const malformed = [
+      null,
+      undefined,
+      'foo',
+      123,
+      true,
+      [],
+      {},
+      { id: 'broken-engines', engines: 'nope' },
+      { id: 'broken-engine-range', engines: { camunda: 123 } }
+    ];
+
+    // when
+    expect(function() {
+      ElementTemplateLinterPlugin(malformed);
+      validateRule({ templates: malformed });
+      compatibilityRule({ templates: malformed });
+      updateRule({ templates: malformed });
+    }).not.to.throw();
+  });
+
+
   it('should create the plugin within performance constraints', function() {
 
     // given

--- a/test/spec/element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/element-templates/ElementTemplatesLoader.spec.js
@@ -438,6 +438,218 @@ describe('provider/element-templates - ElementTemplatesLoader', function() {
 
   });
 
+
+  describe('integration: loading + error handling', function() {
+
+    // host provides an old desktop modeler; template <engines> are only
+    // enforced for engine keys present here (unknown keys stay compatible)
+    const engines = {
+      camundaDesktopModeler: '5.0.0'
+    };
+
+    // schema-valid, compatible
+    const validCompatible = {
+      name: 'Valid Compatible',
+      id: 'valid.compatible',
+      appliesTo: [ 'bpmn:Task' ],
+      properties: []
+    };
+
+    // schema-INVALID (missing properties), compatible
+    const invalidCompatible = {
+      name: 'Invalid Compatible',
+      id: 'invalid.compatible',
+      appliesTo: [ 'bpmn:Task' ]
+    };
+
+    // schema-INVALID (missing properties), incompatible with the host engines
+    const invalidIncompatible = {
+      name: 'Invalid Incompatible',
+      id: 'invalid.incompatible',
+      engines: {
+        camundaDesktopModeler: '>=999.0.0'
+      },
+      appliesTo: [ 'bpmn:Task' ]
+    };
+
+    // schema-VALID, incompatible with the host engines
+    const validIncompatible = {
+      name: 'Valid Incompatible',
+      id: 'valid.incompatible',
+      engines: {
+        camundaDesktopModeler: '>=999.0.0'
+      },
+      appliesTo: [ 'bpmn:Task' ],
+      properties: []
+    };
+
+    // a diagram with a task that already has validIncompatible applied
+    const APPLIED_DIAGRAM_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="AppliedTask" camunda:modelerTemplate="valid.incompatible" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="AppliedTask_di" bpmnElement="AppliedTask">
+        <dc:Bounds x="100" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+    // templates whose <engines> have arbitrary, non-object shapes
+    const MALFORMED_SHAPES = [
+      { name: 'Engines String', id: 'engines.string', engines: 'foo', appliesTo: [ 'bpmn:Task' ], properties: [] },
+      { name: 'Engines Array', id: 'engines.array', engines: [ 1, 2 ], appliesTo: [ 'bpmn:Task' ], properties: [] },
+      { name: 'Engines Null Value', id: 'engines.null', engines: { camunda: null }, appliesTo: [ 'bpmn:Task' ], properties: [] }
+    ];
+
+    function bootstrap(templates, xml = diagramXML) {
+      return bootstrapModeler(xml, {
+        container: container,
+        modules,
+        moddleExtensions: {
+          camunda: camundaModdlePackage
+        },
+        elementTemplates: {
+          engines,
+          loadTemplates: templates
+        }
+      });
+    }
+
+
+    describe('engine-INCOMPATIBLE template applied to an element', function() {
+
+      // regression guard: a template that is incompatible with the host engines
+      // but already applied to an element must remain resolvable, so the
+      // element keeps working ("working regardless" of incompatibility). It is
+      // only excluded from *selection*, never dropped from the registry.
+      beforeEach(bootstrap([ validIncompatible ], APPLIED_DIAGRAM_XML));
+
+
+      it('should still resolve for the element it is applied to', inject(
+        function(elementRegistry, elementTemplates) {
+
+          // given
+          const task = elementRegistry.get('AppliedTask');
+
+          // when
+          const template = elementTemplates.get(task);
+
+          // then
+          expect(template).to.exist;
+          expect(template.id).to.eql('valid.incompatible');
+        }
+      ));
+
+    });
+
+
+    describe('mixed templates', function() {
+
+      beforeEach(bootstrap([
+        validCompatible,
+        invalidCompatible,
+        invalidIncompatible,
+        validIncompatible
+      ]));
+
+
+      it('should suppress incompatible errors but keep valid templates loaded', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // only the schema-invalid _compatible_ template reports an error;
+          // the schema-invalid _incompatible_ one is suppressed
+          expect(errorListener).to.have.been.calledOnce;
+
+          const { errors } = errorListener.getCall(0).args[0];
+
+          expect(errors).to.have.length(1);
+
+          // both schema-valid templates are loaded (compatible + incompatible),
+          // so elements they are applied to keep working
+          const loaded = elementTemplates.getAll().map(t => t.id).sort();
+
+          expect(loaded).to.eql([ 'valid.compatible', 'valid.incompatible' ]);
+
+          // but only the compatible one is offered for selection
+          expect(elementTemplates.getLatest('valid.compatible')).to.have.length(1);
+          expect(elementTemplates.getLatest('valid.incompatible')).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('broken / untrusted templates', function() {
+
+      describe('malformed <engines> shapes', function() {
+
+        beforeEach(bootstrap([ validCompatible, ...MALFORMED_SHAPES ]));
+
+
+        it('should not break loading of valid templates', inject(
+          function(elementTemplatesLoader, elementTemplates) {
+
+            // when
+            const load = () => elementTemplatesLoader.reload();
+
+            // then
+            expect(load).not.to.throw();
+
+            // and the valid template still loads
+            const loaded = elementTemplates.getAll();
+
+            expect(loaded.map(t => t.id)).to.include('valid.compatible');
+          }
+        ));
+
+      });
+
+
+      describe('non-array templates', function() {
+
+        const loadTemplates = function(done) {
+          done(null, { not: 'an array' });
+        };
+
+        beforeEach(bootstrap(loadTemplates));
+
+
+        it('should report an error without throwing', inject(
+          function(elementTemplatesLoader, eventBus) {
+
+            // given
+            const errorListener = spy();
+
+            eventBus.on('elementTemplates.errors', errorListener);
+
+            // when
+            const load = () => elementTemplatesLoader.reload();
+
+            // then
+            expect(load).not.to.throw();
+            expect(errorListener).to.have.been.called;
+          }
+        ));
+
+      });
+
+    });
+
+  });
+
 });
 
 

--- a/test/spec/element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/element-templates/ElementTemplatesLoader.spec.js
@@ -259,6 +259,185 @@ describe('provider/element-templates - ElementTemplatesLoader', function() {
 
   });
 
+
+  describe('engine-profile filtering before schema validation', function() {
+
+    // host provides an old desktop modeler; template <engines> are only
+    // enforced for engine keys present here (unknown keys stay compatible)
+    const engines = {
+      camundaDesktopModeler: '5.0.0'
+    };
+
+    // schema-valid, compatible
+    const validCompatible = {
+      name: 'Valid Compatible',
+      id: 'valid.compatible',
+      appliesTo: [ 'bpmn:Task' ],
+      properties: []
+    };
+
+    // schema-INVALID (missing properties), compatible
+    const invalidCompatible = {
+      name: 'Invalid Compatible',
+      id: 'invalid.compatible',
+      appliesTo: [ 'bpmn:Task' ]
+    };
+
+    // schema-INVALID (missing properties), incompatible with the host engines
+    const invalidIncompatible = {
+      name: 'Invalid Incompatible',
+      id: 'invalid.incompatible',
+      engines: {
+        camundaDesktopModeler: '>=999.0.0'
+      },
+      appliesTo: [ 'bpmn:Task' ]
+    };
+
+    // schema-VALID, incompatible with the host engines
+    const validIncompatible = {
+      name: 'Valid Incompatible',
+      id: 'valid.incompatible',
+      engines: {
+        camundaDesktopModeler: '>=999.0.0'
+      },
+      appliesTo: [ 'bpmn:Task' ],
+      properties: []
+    };
+
+    function bootstrap(templates) {
+      return bootstrapModeler(diagramXML, {
+        container: container,
+        modules,
+        moddleExtensions: {
+          camunda: camundaModdlePackage
+        },
+        elementTemplates: {
+          engines,
+          loadTemplates: templates
+        }
+      });
+    }
+
+
+    describe('engine-INCOMPATIBLE + schema-INVALID template', function() {
+
+      beforeEach(bootstrap([ invalidIncompatible ]));
+
+
+      it('should be excluded without producing an error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // schema-invalid, but incompatible => its error is suppressed
+          expect(errorListener).not.to.have.been.called;
+
+          // and not loaded
+          expect(elementTemplates.getAll()).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('engine-COMPATIBLE + schema-INVALID template', function() {
+
+      beforeEach(bootstrap([ invalidCompatible ]));
+
+
+      it('should still report its validation error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          expect(errorListener).to.have.been.called;
+
+          const { errors } = errorListener.getCall(0).args[0];
+
+          expect(errors).to.have.length.above(0);
+          expect(elementTemplates.getAll()).to.be.empty;
+        }
+      ));
+
+    });
+
+
+    describe('engine-COMPATIBLE + schema-VALID template', function() {
+
+      beforeEach(bootstrap([ validCompatible ]));
+
+
+      it('should load without producing an error', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          expect(errorListener).not.to.have.been.called;
+
+          const loaded = elementTemplates.getAll();
+
+          expect(loaded).to.have.length(1);
+          expect(loaded[0].id).to.eql('valid.compatible');
+        }
+      ));
+
+    });
+
+
+    describe('engine-INCOMPATIBLE + schema-VALID template', function() {
+
+      beforeEach(bootstrap([ validIncompatible ]));
+
+
+      it('should load without error but be excluded from selection', inject(
+        function(elementTemplatesLoader, elementTemplates, eventBus) {
+
+          // given
+          const errorListener = spy();
+
+          eventBus.on('elementTemplates.errors', errorListener);
+
+          // when
+          elementTemplatesLoader.reload();
+
+          // then
+          // no intrusive error for a template built for another environment
+          expect(errorListener).not.to.have.been.called;
+
+          // but it is still loaded, so elements it is applied to keep working
+          expect(elementTemplates.get('valid.incompatible')).to.exist;
+          expect(elementTemplates.getAll()).to.have.length(1);
+
+          // and excluded from selection (not offered as a compatible template)
+          expect(elementTemplates.getLatest('valid.incompatible')).to.be.empty;
+        }
+      ));
+
+    });
+
+  });
+
 });
 
 

--- a/test/spec/element-templates/Validator.spec.js
+++ b/test/spec/element-templates/Validator.spec.js
@@ -781,6 +781,34 @@ describe('provider/element-templates - Validator', function() {
   });
 
 
+  describe('broken / untrusted templates', function() {
+
+    it('should reject non-object entries without throwing', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // templates are untrusted input and may have any shape
+      const nonObjects = [ null, undefined, 'foo', 123, true, [] ];
+
+      // when
+      const add = () => validator.addAll(nonObjects);
+
+      // then
+      expect(add).not.to.throw();
+
+      // each non-object entry is reported ...
+      expect(errors(validator)).to.eql(nonObjects.map(function() {
+        return 'template must be an object';
+      }));
+
+      // ... and none is treated as valid
+      expect(valid(validator)).to.be.empty;
+    });
+
+  });
+
+
   describe('error <template> reference', function() {
 
     it('should attach the source template to logged errors', function() {

--- a/test/spec/element-templates/Validator.spec.js
+++ b/test/spec/element-templates/Validator.spec.js
@@ -780,4 +780,51 @@ describe('provider/element-templates - Validator', function() {
 
   });
 
+
+  describe('error <template> reference', function() {
+
+    it('should attach the source template to logged errors', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // a schema-invalid template (missing <properties>)
+      const template = {
+        name: 'Invalid',
+        id: 'com.example.invalid',
+        appliesTo: [ 'bpmn:Task' ]
+      };
+
+      // when
+      validator.add(template);
+
+      // then
+      const loggedErrors = validator.getErrors();
+
+      expect(loggedErrors).to.have.length.above(0);
+
+      loggedErrors.forEach(function(error) {
+        expect(error.template).to.equal(template);
+      });
+    });
+
+
+    it('should not attach a template to template-less errors', function() {
+
+      // given
+      const validator = new Validator(moddle);
+
+      // when
+      // not an array => generic error without a source template
+      validator.addAll('not-an-array');
+
+      // then
+      const [ error ] = validator.getErrors();
+
+      expect(error).to.exist;
+      expect(error.template).not.to.exist;
+    });
+
+  });
+
 });


### PR DESCRIPTION
### Proposed Changes

Element templates declare the engine versions they target via `engines` (e.g. `{ "camundaDesktopModeler": ">=5.20" }`). A template built for a _newer_ environment may use schema features this installation cannot validate, and previously surfaced an intrusive, non-actionable `invalid template` error — even though it is already excluded from template _selection_ via the engine-aware `getLatest`/`getCompatible` lookups.

This PR keeps validation and loading exactly as before and only changes **which errors get reported**: errors of templates that are incompatible with the host engines are suppressed. Schema-valid incompatible templates stay **loaded** and resolvable via `get(id, version)` / `get(element)`, so elements they are already applied to keep working — they are only kept out of selection, as before.

Because element templates are untrusted input and may have any shape, the shared indexing paths are also hardened so malformed entries can no longer throw.

Split into focused commits:

1. `feat` — `Validator` attaches the source template to each logged error (`error.template`), so consumers can associate an error with its template without parsing messages.
2. `fix` — `Validator#add` tolerates non-object entries (reports them instead of throwing).
3. `fix` — `buildTemplatesById` skips non-object entries (keeps the linting rules, which index raw templates, robust).
4. `fix` — the loader suppresses reported errors for engine-incompatible templates (the actual https://github.com/camunda/camunda-modeler/issues/6071 fix); an incompatibility verdict is only trusted for well-formed `engines`.
5. `test` — integration coverage: applied incompatible templates still resolve, mixed batches report only compatible-invalid errors, untrusted input never breaks loading.

Applies to both the base (`element-templates`) and cloud (`cloud-element-templates`) loaders via a single inherited `setTemplates`; the cloud loader only overrides which validator to use.

Related to https://github.com/camunda/camunda-modeler/issues/6071

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)