### PR TITLE
test: cover undeclared custom group entry-id fallback

### DIFF
--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.getEntryId.json
@@ -132,5 +132,33 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Undeclared Group Template",
+    "id": "undeclared-group-template",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "groups": [
+      {
+        "id": "declared-group",
+        "label": "Declared Group"
+      }
+    ],
+    "properties": [
+      {
+        "id": "name-undeclared-group",
+        "type": "String",
+        "label": "Name",
+        "group": "missing-group",
+        "value": "templated-name",
+        "binding": {
+          "type": "property",
+          "name": "name"
+        }
+      }
+    ]
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -1192,6 +1192,31 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
     );
 
 
+    it('should resolve a property with undeclared group to its rendered default-group entry id', inject(
+      async function(elementRegistry, elementTemplates, elementTemplatesPropertiesProvider, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, getEntryIdTemplates[4]);
+        });
+        await act(() => selection.select(task));
+
+        const template = elementTemplates.get(task);
+        const property = template.properties.find(p => p.id === 'name-undeclared-group');
+
+        // when
+        const entryId = elementTemplatesPropertiesProvider.getEntryId(task, [ 'name' ]);
+
+        // then
+        expect(entryId).to.equal(getPropertyEntryId(template, property));
+        expect(entryId).to.equal('custom-entry-undeclared-group-template-0');
+        expect(domQuery(`[data-entry-id="${entryId}"]`, container)).to.exist;
+      })
+    );
+
+
     it('should return null when no template applies to the element', inject(
       function(elementRegistry, elementTemplatesPropertiesProvider) {
 


### PR DESCRIPTION
### Proposed Changes

Closes #271.

This change adds a regression around custom-entry id resolution for malformed templates that reference an undeclared `group`. Fix is already in code - just not properly tested.

- add a dedicated `Undeclared Group Template` fixture with one property bound to `name` and `group: "missing-group"`
- add a `getEntryId` spec asserting resolver and renderer produce the same entry id for that property
- assert the id uses default-group fallback (`custom-entry-undeclared-group-template-0`), matching rendered behavior

No UI/UX changes.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes (N/A)
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

Steps to try out:
1. Open `Task_1` from `ElementTemplatesPropertiesProvider.getEntryId.bpmn` in the spec harness.
2. Apply `Undeclared Group Template`.
3. Verify `getEntryId(task, [ 'name' ])` resolves to `custom-entry-undeclared-group-template-0` and that the entry exists in the panel.