### PR TITLE
fix: cap the configuration chooser popover height

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -344,6 +344,8 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  max-height: 280px;
+  overflow-y: auto;
 }
 
 .bio-properties-panel-configuration-chooser-popover-row {


### PR DESCRIPTION
An organization can hold hundreds of credentials for one configuration template, and the popover grew with the list, running past the viewport and leaving the create action unreachable. Scroll the options at the same height diagram-js caps its own popup results to, keeping the create action pinned below them.

Note that the vertical scroll is intentionally introduced to the dynamic list of credentials excluding the "+ Create" button, which would make the "+ Create" button look "sticky" at the bottom of the popover.

## Before, 200 items

<img width="400" alt="image" src="https://github.com/user-attachments/assets/497be6be-639c-4845-b20d-4ade48a9e475" />

## After, 200 items

<img width="400" alt="image" src="https://github.com/user-attachments/assets/cfac3679-9a4a-4f2c-8770-b9fbcb6d2d60" />

## After, no items

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b7f6caee-ca52-4d09-963d-f37f4027c800" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
