### PR TITLE
feat(configuration): keyboard-accessible configuration chooser

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -155,10 +155,6 @@
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
-.bio-properties-panel-configuration-chooser-placeholder:focus-visible {
-  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
-}
-
 .bio-properties-panel-configuration-chooser-placeholder:disabled {
   cursor: default;
   opacity: 0.5;
@@ -264,10 +260,6 @@
   background-color: #fef3e0;
 }
 
-.bio-properties-panel-configuration-chooser-missing:focus-within {
-  box-shadow: 0 0 0 2px #f0ad4e;
-}
-
 .bio-properties-panel-configuration-chooser-error {
   cursor: default;
 }
@@ -277,10 +269,6 @@
   overflow-wrap: anywhere;
   text-overflow: clip;
   white-space: normal;
-}
-
-.bio-properties-panel-configuration-chooser-selected:focus-within {
-  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
 }
 
 /* logo */

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -190,8 +190,28 @@
   border: 1px solid var(--color-grey-225-10-75, #ccced0);
   border-radius: 4px;
   background-color: var(--color-white, #fff);
+  cursor: default;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-trigger {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-trigger:disabled {
+  cursor: default;
 }
 
 .bio-properties-panel-configuration-chooser-selected:hover {
@@ -235,7 +255,7 @@
   border: 1px solid #f0ad4e;
   border-radius: 4px;
   background-color: #fff8ed;
-  cursor: pointer;
+  cursor: default;
   outline: none;
 }
 
@@ -244,7 +264,7 @@
   background-color: #fef3e0;
 }
 
-.bio-properties-panel-configuration-chooser-missing:focus-visible {
+.bio-properties-panel-configuration-chooser-missing:focus-within {
   box-shadow: 0 0 0 2px #f0ad4e;
 }
 
@@ -259,7 +279,7 @@
   white-space: normal;
 }
 
-.bio-properties-panel-configuration-chooser-selected:focus-visible {
+.bio-properties-panel-configuration-chooser-selected:focus-within {
   box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
 }
 
@@ -355,6 +375,7 @@
   list-style: none;
   max-height: 280px;
   overflow-y: auto;
+  outline: none;
 }
 
 .bio-properties-panel-configuration-chooser-popover-row {
@@ -367,7 +388,7 @@
 }
 
 .bio-properties-panel-configuration-chooser-popover-row:hover,
-.bio-properties-panel-configuration-chooser-popover-row:focus-visible {
+.bio-properties-panel-configuration-chooser-popover-row--active {
   background-color: var(--color-blue-205-100-95, #eef4ff);
 }
 
@@ -393,6 +414,7 @@
 }
 
 .bio-properties-panel-configuration-chooser-create:hover,
+.bio-properties-panel-configuration-chooser-create--active,
 .bio-properties-panel-configuration-chooser-create:focus-visible {
   background-color: var(--color-blue-205-100-95, #eef4ff);
 }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -536,7 +536,8 @@ export function ConfigurationProperty(props) {
         'bio-properties-panel-configuration-chooser',
         validationError ? 'has-error' : ''
       ) }
-      data-entry-id={ id }>
+      data-entry-id={ id }
+      data-configuration-state={ variant }>
       <label class="bio-properties-panel-label">
         { configurationLabel }
       </label>
@@ -1286,14 +1287,19 @@ function ConfigurationLogo(props) {
 /**
  * Whether the configuration chooser has a non-empty selection.
  *
+ * Reads the chooser's rendered `data-configuration-state`, which reflects the
+ * current variant. Every variant except the placeholder represents a binding.
+ *
  * @param {HTMLElement} node
  * @returns {boolean}
  */
 export function isConfigurationChooserEdited(node) {
-  return !!domQuery(
-    '.bio-properties-panel-configuration-chooser-selected, .bio-properties-panel-configuration-chooser-missing, .bio-properties-panel-configuration-chooser-loading',
-    node
-  );
+  const stateNode = node && node.matches?.('[data-configuration-state]')
+    ? node
+    : domQuery('[data-configuration-state]', node);
+
+  return !!stateNode
+    && stateNode.getAttribute('data-configuration-state') !== VARIANT.PLACEHOLDER;
 }
 
 function isSameChooser(event, element, property) {

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -338,14 +338,20 @@ export function ConfigurationProperty(props) {
       return;
     }
 
-    const instance = instances.find(instance => instance.name === name);
+    const nextValue = name ? toReference(name) : '';
 
-    setValue(name ? toReference(name) : '', instance);
+    // re-choosing the current selection is a NOOP; the popover simply closes.
+    // Removing a configuration is done explicitly via the actions menu.
+    if (nextValue !== value) {
+      const instance = instances.find(instance => instance.name === name);
+
+      setValue(nextValue, instance);
+    }
 
     // return focus to the trigger once the (possibly freshly rendered) card mounts
     closePopover();
     dismissMenu();
-  }, [ disabled, instances, setValue, closePopover, dismissMenu ]);
+  }, [ disabled, value, instances, setValue, closePopover, dismissMenu ]);
 
   useEffect(() => {
     const onCreated = (event) => {
@@ -1109,7 +1115,7 @@ function ConfigurationPopover(props) {
     if (isCreateActive) {
       onCreate();
     } else if (activeInstance) {
-      onSelect(selected === activeInstance ? null : activeInstance.name);
+      onSelect(activeInstance.name);
     }
   };
 
@@ -1166,7 +1172,7 @@ function ConfigurationPopover(props) {
                 instance={ instance }
                 active={ index === activeIndex }
                 selected={ selected === instance }
-                onSelect={ () => onSelect(selected === instance ? null : instance.name) }
+                onSelect={ () => onSelect(instance.name) }
                 onHover={ () => setActiveIndex(index) }
                 translate={ translate } />
             ))

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -622,7 +622,7 @@ function SelectedConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected"
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-focus-ring"
       interactive
       disabled={ disabled }
       open={ open }
@@ -887,7 +887,7 @@ function PlaceholderConfiguration(props) {
       <button
         ref={ showEntryRef }
         type="button"
-        class="bio-properties-panel-configuration-chooser-placeholder"
+        class="bio-properties-panel-configuration-chooser-placeholder bio-properties-panel-focus-ring"
         disabled={ disabled || error || !available }
         aria-haspopup="listbox"
         aria-controls={ open ? listboxId : undefined }
@@ -959,7 +959,7 @@ function ErrorConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error"
+      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }
@@ -1007,7 +1007,7 @@ function MissingConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing"
+      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-focus-ring"
       interactive
       disabled={ disabled }
       open={ open }
@@ -1048,7 +1048,7 @@ function OfflineConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline"
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -105,6 +105,39 @@ function getBindingElement(extensionElements, binding) {
 }
 
 /**
+ * Subscribe to the `configurationInstances` service and expose its current
+ * state as a single object, re-reading whenever the service emits `changed`.
+ * The declared `configurationTemplateVersion` acts as the minimum required
+ * version when selecting compatible instances.
+ */
+function useConfigurationInstances(configurationInstances, eventBus, configurationTemplate, minimumVersion) {
+  const read = useCallback(() => ({
+    instances: configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumVersion),
+    loading: configurationInstances.isLoading(),
+    error: configurationInstances.hasError(),
+    available: configurationInstances.isAvailable(),
+    unavailableMessage: configurationInstances.getUnavailableMessage(),
+    canCreate: configurationInstances.canCreate(),
+    canUpdate: configurationInstances.canUpdate()
+  }), [ configurationInstances, configurationTemplate, minimumVersion ]);
+
+  const [ state, setState ] = useState(read);
+
+  useEffect(() => {
+    const onChanged = () => setState(read());
+
+    eventBus.on('configurationInstances.changed', onChanged);
+    onChanged();
+
+    return () => {
+      eventBus.off('configurationInstances.changed', onChanged);
+    };
+  }, [ eventBus, read ]);
+
+  return state;
+}
+
+/**
  * Configuration chooser.
  *
  * Renders a bespoke picker (NOT a plain select): a dashed placeholder that
@@ -148,36 +181,15 @@ export function ConfigurationProperty(props) {
   const chooserLabel = label ? toSentenceFragment(configurationLabel) : configurationLabel;
 
   // re-render when available instances change
-  const [ result, setResult ] = useState(
-    configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion)
-  );
-  const [ loading, setLoading ] = useState(configurationInstances.isLoading());
-  const [ error, setError ] = useState(configurationInstances.hasError());
-  const [ available, setAvailable ] = useState(configurationInstances.isAvailable());
-  const [ unavailableMessage, setUnavailableMessage ] = useState(configurationInstances.getUnavailableMessage());
-  const [ canCreate, setCanCreate ] = useState(configurationInstances.canCreate());
-  const [ canUpdate, setCanUpdate ] = useState(configurationInstances.canUpdate());
-
-  useEffect(() => {
-    const onChanged = () => {
-      setResult(configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion));
-      setLoading(configurationInstances.isLoading());
-      setError(configurationInstances.hasError());
-      setAvailable(configurationInstances.isAvailable());
-      setUnavailableMessage(configurationInstances.getUnavailableMessage());
-      setCanCreate(configurationInstances.canCreate());
-      setCanUpdate(configurationInstances.canUpdate());
-    };
-
-    eventBus.on('configurationInstances.changed', onChanged);
-    onChanged();
-
-    return () => {
-      eventBus.off('configurationInstances.changed', onChanged);
-    };
-  }, [ eventBus, configurationInstances, configurationTemplate, minimumConfigurationTemplateVersion ]);
-
-  const instances = result;
+  const {
+    instances,
+    loading,
+    error,
+    available,
+    unavailableMessage,
+    canCreate,
+    canUpdate
+  } = useConfigurationInstances(configurationInstances, eventBus, configurationTemplate, minimumConfigurationTemplateVersion);
 
   const getValue = useMemo(
     () => propertyGetter(element, property),

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -163,8 +163,6 @@ export function ConfigurationProperty(props) {
     configurationTemplateVersion
   } = property;
 
-  const minimumConfigurationTemplateVersion = configurationTemplateVersion;
-
   const disabled = editable === false;
 
   const bpmnFactory = useService('bpmnFactory'),
@@ -180,7 +178,6 @@ export function ConfigurationProperty(props) {
   const configurationLabel = translate(label || templateName || 'Configuration');
   const chooserLabel = label ? toSentenceFragment(configurationLabel) : configurationLabel;
 
-  // re-render when available instances change
   const {
     instances,
     loading,
@@ -189,7 +186,7 @@ export function ConfigurationProperty(props) {
     unavailableMessage,
     canCreate,
     canUpdate
-  } = useConfigurationInstances(configurationInstances, eventBus, configurationTemplate, minimumConfigurationTemplateVersion);
+  } = useConfigurationInstances(configurationInstances, eventBus, configurationTemplate, configurationTemplateVersion);
 
   const getValue = useMemo(
     () => propertyGetter(element, property),
@@ -218,11 +215,12 @@ export function ConfigurationProperty(props) {
   const typeIncompatible = !!boundInstance
     && boundMetadata.configurationTemplate !== configurationTemplate;
 
+  // the declared version is treated as the minimum required version
   const versionIncompatible = !!boundInstance
     && boundMetadata.configurationTemplate === configurationTemplate
-    && minimumConfigurationTemplateVersion != null
+    && configurationTemplateVersion != null
     && (boundMetadata.configurationTemplateVersion == null
-      || boundMetadata.configurationTemplateVersion < minimumConfigurationTemplateVersion);
+      || boundMetadata.configurationTemplateVersion < configurationTemplateVersion);
   const incompatible = typeIncompatible || versionIncompatible;
 
   // Read cached configuration metadata from the BPMN binding.
@@ -360,7 +358,7 @@ export function ConfigurationProperty(props) {
       if (!instance || !configurationInstances.isCompatible(
         instance,
         configurationTemplate,
-        minimumConfigurationTemplateVersion
+        configurationTemplateVersion
       )) {
         return;
       }
@@ -381,7 +379,7 @@ export function ConfigurationProperty(props) {
     property,
     configurationInstances,
     configurationTemplate,
-    minimumConfigurationTemplateVersion,
+    configurationTemplateVersion,
     setValue,
     dismissPopover,
     dismissMenu
@@ -486,7 +484,7 @@ export function ConfigurationProperty(props) {
           value={ value }
           cachedName={ cachedName }
           instance={ incompatible ? boundInstance : null }
-          minimumVersion={ minimumConfigurationTemplateVersion }
+          minimumVersion={ configurationTemplateVersion }
           typeIncompatible={ typeIncompatible }
           disabled={ disabled }
           menuId={ menuId }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -604,29 +604,22 @@ function SelectedConfiguration(props) {
   } = props;
 
   return (
-    <div class="bio-properties-panel-configuration-chooser-selected">
-      <ConfigurationTrigger
-        disabled={ disabled }
-        listboxId={ listboxId }
-        open={ open }
-        onClick={ onClick }>
-        <ConfigurationLogo instance={ instance } />
-        <span class="bio-properties-panel-configuration-chooser-text">
-          <span class="bio-properties-panel-configuration-chooser-title">
-            { getDisplayName(instance) }
-          </span>
-          <span class="bio-properties-panel-configuration-chooser-subtitle">
-            <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
-          </span>
-        </span>
-      </ConfigurationTrigger>
-      <ConfigurationMenuButton
-        menuId={ menuId }
-        menuOpen={ menuOpen }
-        disabled={ disabled }
-        onMenu={ onMenu }
-        translate={ translate } />
-    </div>
+    <ConfigurationCard
+      class="bio-properties-panel-configuration-chooser-selected"
+      interactive
+      disabled={ disabled }
+      open={ open }
+      listboxId={ listboxId }
+      onClick={ onClick }
+      menuId={ menuId }
+      menuOpen={ menuOpen }
+      onMenu={ onMenu }
+      translate={ translate }
+      logo={ <ConfigurationLogo instance={ instance } /> }
+      title={ getDisplayName(instance) }
+      subtitle={
+        <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
+      } />
   );
 }
 
@@ -651,6 +644,89 @@ function ConfigurationTrigger(props) {
       onClick={ disabled ? null : onClick }>
       { children }
     </button>
+  );
+}
+
+/**
+ * The shared identity of a configuration: its logo and the title/subtitle text.
+ * Presentational; used both by the cards and by the popover rows.
+ */
+function ConfigurationCardContent(props) {
+  const { logo, title, subtitle } = props;
+
+  return (
+    <>
+      { logo }
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { title }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          { subtitle }
+        </span>
+      </span>
+    </>
+  );
+}
+
+/**
+ * The shell shared by every configuration card variant (selected, missing,
+ * offline, error, loading): a container holding the identity content and,
+ * optionally, an interactive trigger and/or the actions ("…") menu button.
+ *
+ * - `interactive` wraps the content in the listbox trigger button.
+ * - passing `onMenu` renders the actions menu button.
+ */
+function ConfigurationCard(props) {
+  const {
+    class: className,
+    role,
+    logo,
+    title,
+    subtitle,
+    interactive = false,
+    disabled,
+    open,
+    listboxId,
+    onClick,
+    menuId,
+    menuOpen,
+    onMenu,
+    translate
+  } = props;
+
+  const content = (
+    <ConfigurationCardContent logo={ logo } title={ title } subtitle={ subtitle } />
+  );
+
+  return (
+    <div class={ className } role={ role }>
+      {
+        interactive
+          ? (
+            <ConfigurationTrigger
+              disabled={ disabled }
+              listboxId={ listboxId }
+              open={ open }
+              onClick={ onClick }>
+              { content }
+            </ConfigurationTrigger>
+          )
+          : content
+      }
+      {
+        onMenu
+          ? (
+            <ConfigurationMenuButton
+              menuId={ menuId }
+              menuOpen={ menuOpen }
+              disabled={ disabled }
+              onMenu={ onMenu }
+              translate={ translate } />
+          )
+          : null
+      }
+    </div>
   );
 }
 
@@ -842,19 +918,12 @@ function LoadingConfiguration(props) {
   };
 
   return (
-    <div
+    <ConfigurationCard
       class="bio-properties-panel-configuration-chooser-loading"
-      role="status">
-      <ConfigurationLogo instance={ instance } />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          { name }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
-          { translate('Loading configuration') }
-        </span>
-      </span>
-    </div>
+      role="status"
+      logo={ <ConfigurationLogo instance={ instance } /> }
+      title={ name }
+      subtitle={ translate('Loading configuration') } />
   );
 }
 
@@ -872,23 +941,16 @@ function ErrorConfiguration(props) {
   const refName = fromReference(value);
 
   return (
-    <div class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error">
-      <ConfigurationLogo warning />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          { cachedName || refName }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
-          { translate('Could not load configurations') }
-        </span>
-      </span>
-      <ConfigurationMenuButton
-        menuId={ menuId }
-        menuOpen={ menuOpen }
-        disabled={ disabled }
-        onMenu={ onMenu }
-        translate={ translate } />
-    </div>
+    <ConfigurationCard
+      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error"
+      disabled={ disabled }
+      menuId={ menuId }
+      menuOpen={ menuOpen }
+      onMenu={ onMenu }
+      translate={ translate }
+      logo={ <ConfigurationLogo warning /> }
+      title={ cachedName || refName }
+      subtitle={ translate('Could not load configurations') } />
   );
 }
 
@@ -927,29 +989,20 @@ function MissingConfiguration(props) {
     : cachedName ? translate('Not found on cluster') : refName;
 
   return (
-    <div class="bio-properties-panel-configuration-chooser-missing">
-      <ConfigurationTrigger
-        disabled={ disabled }
-        listboxId={ listboxId }
-        open={ open }
-        onClick={ onClick }>
-        <ConfigurationLogo warning />
-        <span class="bio-properties-panel-configuration-chooser-text">
-          <span class="bio-properties-panel-configuration-chooser-title">
-            { title }
-          </span>
-          <span class="bio-properties-panel-configuration-chooser-subtitle">
-            { subtitle }
-          </span>
-        </span>
-      </ConfigurationTrigger>
-      <ConfigurationMenuButton
-        menuId={ menuId }
-        menuOpen={ menuOpen }
-        disabled={ disabled }
-        onMenu={ onMenu }
-        translate={ translate } />
-    </div>
+    <ConfigurationCard
+      class="bio-properties-panel-configuration-chooser-missing"
+      interactive
+      disabled={ disabled }
+      open={ open }
+      listboxId={ listboxId }
+      onClick={ onClick }
+      menuId={ menuId }
+      menuOpen={ menuOpen }
+      onMenu={ onMenu }
+      translate={ translate }
+      logo={ <ConfigurationLogo warning /> }
+      title={ title }
+      subtitle={ subtitle } />
   );
 }
 
@@ -977,24 +1030,16 @@ function OfflineConfiguration(props) {
   };
 
   return (
-    <div
-      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline">
-      <ConfigurationLogo instance={ instance } />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          { cachedName || refName }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
-          { unavailableMessage || translate('Cluster unavailable') }
-        </span>
-      </span>
-      <ConfigurationMenuButton
-        menuId={ menuId }
-        menuOpen={ menuOpen }
-        disabled={ disabled }
-        onMenu={ onMenu }
-        translate={ translate } />
-    </div>
+    <ConfigurationCard
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline"
+      disabled={ disabled }
+      menuId={ menuId }
+      menuOpen={ menuOpen }
+      onMenu={ onMenu }
+      translate={ translate }
+      logo={ <ConfigurationLogo instance={ instance } /> }
+      title={ cachedName || refName }
+      subtitle={ unavailableMessage || translate('Cluster unavailable') } />
   );
 }
 
@@ -1187,15 +1232,12 @@ function ConfigurationRow(props) {
       aria-selected={ selected }
       onClick={ onSelect }
       onMouseEnter={ onHover }>
-      <ConfigurationLogo instance={ instance } />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          { getDisplayName(instance) }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
+      <ConfigurationCardContent
+        logo={ <ConfigurationLogo instance={ instance } /> }
+        title={ getDisplayName(instance) }
+        subtitle={
           <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
-        </span>
-      </span>
+        } />
     </li>
   );
 }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -256,6 +256,7 @@ export function ConfigurationProperty(props) {
 
   const ref = useRef(null);
   const showEntryRef = useShowEntryEvent(id);
+  const controlId = `${ id }-control`;
   const listboxId = `${ id }-listbox`;
   const menuId = `${ id }-menu`;
   const availabilityRef = useRef({ error, available });
@@ -471,6 +472,7 @@ export function ConfigurationProperty(props) {
       return (
         <SelectedConfiguration
           instance={ selected }
+          controlId={ controlId }
           disabled={ disabled }
           menuId={ menuId }
           menuOpen={ menuOpen }
@@ -490,6 +492,7 @@ export function ConfigurationProperty(props) {
           value={ value }
           cachedName={ cachedName }
           instance={ incompatible ? boundInstance : null }
+          controlId={ controlId }
           minimumVersion={ configurationTemplateVersion }
           typeIncompatible={ typeIncompatible }
           disabled={ disabled }
@@ -518,6 +521,7 @@ export function ConfigurationProperty(props) {
       return (
         <PlaceholderConfiguration
           id={ id }
+          controlId={ controlId }
           disabled={ disabled }
           error={ error }
           available={ available }
@@ -542,7 +546,9 @@ export function ConfigurationProperty(props) {
       ) }
       data-entry-id={ id }
       data-configuration-state={ variant }>
-      <label class="bio-properties-panel-label">
+      <label
+        class="bio-properties-panel-label"
+        htmlFor={ controlId }>
         { configurationLabel }
       </label>
 
@@ -609,6 +615,7 @@ export function ConfigurationProperty(props) {
 
 function SelectedConfiguration(props) {
   const {
+    controlId,
     disabled,
     instance,
     listboxId,
@@ -624,6 +631,7 @@ function SelectedConfiguration(props) {
     <ConfigurationCard
       class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-focus-ring"
       interactive
+      controlId={ controlId }
       disabled={ disabled }
       open={ open }
       listboxId={ listboxId }
@@ -644,6 +652,7 @@ function ConfigurationTrigger(props) {
   const {
     children,
     disabled,
+    id,
     listboxId,
     open,
     onClick
@@ -651,6 +660,7 @@ function ConfigurationTrigger(props) {
 
   return (
     <button
+      id={ id }
       type="button"
       class="bio-properties-panel-configuration-chooser-trigger"
       disabled={ disabled }
@@ -702,6 +712,7 @@ function ConfigurationCard(props) {
     title,
     subtitle,
     interactive = false,
+    controlId,
     disabled,
     open,
     listboxId,
@@ -722,6 +733,7 @@ function ConfigurationCard(props) {
         interactive
           ? (
             <ConfigurationTrigger
+              id={ controlId }
               disabled={ disabled }
               listboxId={ listboxId }
               open={ open }
@@ -865,6 +877,7 @@ function PlaceholderConfiguration(props) {
   const {
     available,
     chooserLabel,
+    controlId,
     disabled,
     error,
     id,
@@ -885,6 +898,7 @@ function PlaceholderConfiguration(props) {
   return (
     <>
       <button
+        id={ controlId }
         ref={ showEntryRef }
         type="button"
         class="bio-properties-panel-configuration-chooser-placeholder bio-properties-panel-focus-ring"
@@ -974,6 +988,7 @@ function ErrorConfiguration(props) {
 function MissingConfiguration(props) {
   const {
     cachedName,
+    controlId,
     disabled,
     instance,
     listboxId,
@@ -1009,6 +1024,7 @@ function MissingConfiguration(props) {
     <ConfigurationCard
       class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-focus-ring"
       interactive
+      controlId={ controlId }
       disabled={ disabled }
       open={ open }
       listboxId={ listboxId }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -12,8 +12,57 @@ import classnames from 'classnames';
 import { PropertyDescription } from '../../../../components/PropertyDescription';
 import { PropertyTooltip } from '../../components/PropertyTooltip';
 import { propertyGetter, propertySetter, propertyValidator } from './util';
+import { useActiveIndex, useFocusOut, usePopup } from './hooks';
 
 import { findExtension, findInputParameter, findZeebeProperty } from '../../../Helper';
+
+// which end of the actions menu to focus when it opens; ArrowUp on the trigger
+// opens onto the last item, matching the WAI-ARIA menu button pattern
+const FOCUS_FIRST = 'first';
+const FOCUS_LAST = 'last';
+
+// the mutually exclusive states the chooser can render
+const VARIANT = {
+  ERROR: 'error',
+  SELECTED: 'selected',
+  LOADING: 'loading',
+  MISSING: 'missing',
+  OFFLINE: 'offline',
+  PLACEHOLDER: 'placeholder'
+};
+
+/**
+ * Pick which chooser variant to render from the current instance state. Kept
+ * pure (and order-sensitive) so the state machine is explicit and testable.
+ *
+ * @param {Object} state
+ * @returns {string} one of VARIANT
+ */
+function getConfigurationVariant(state) {
+  const { value, error, selected, loading, available } = state;
+
+  if (value && error) {
+    return VARIANT.ERROR;
+  }
+
+  if (selected) {
+    return VARIANT.SELECTED;
+  }
+
+  if (!value) {
+    return VARIANT.PLACEHOLDER;
+  }
+
+  if (loading) {
+    return VARIANT.LOADING;
+  }
+
+  if (available) {
+    return VARIANT.MISSING;
+  }
+
+  return VARIANT.OFFLINE;
+}
 
 /**
  * FEEL expression referencing a configuration instance as a cluster variable.
@@ -156,6 +205,7 @@ export function ConfigurationProperty(props) {
   const boundMetadata = boundInstance?.metadata || {};
   const typeIncompatible = !!boundInstance
     && boundMetadata.configurationTemplate !== configurationTemplate;
+
   const versionIncompatible = !!boundInstance
     && boundMetadata.configurationTemplate === configurationTemplate
     && minimumConfigurationTemplateVersion != null
@@ -194,11 +244,50 @@ export function ConfigurationProperty(props) {
 
   const validationError = globalValidationError || localValidationError;
 
-  const [ open, setOpen ] = useState(false);
-  const [ menuOpen, setMenuOpen ] = useState(false);
   const ref = useRef(null);
   const showEntryRef = useShowEntryEvent(id);
+  const listboxId = `${ id }-listbox`;
+  const menuId = `${ id }-menu`;
   const availabilityRef = useRef({ error, available });
+
+  // Resolve the current trigger. It changes with the selection (placeholder
+  // button vs. selected/missing card), so we resolve it from the DOM rather
+  // than holding a ref to a specific node.
+  const resolveTrigger = useCallback(() => {
+    const node = ref.current;
+
+    return node && domQuery(
+      '.bio-properties-panel-configuration-chooser-placeholder,'
+      + '.bio-properties-panel-configuration-chooser-trigger',
+      node
+    );
+  }, []);
+
+  // Resolve the actions ("…") menu button. Like the trigger, it lives inside
+  // whichever card variant is rendered, so we resolve it from the DOM.
+  const resolveMenuButton = useCallback(() => {
+    const node = ref.current;
+
+    return node && domQuery('.bio-properties-panel-configuration-chooser-menu', node);
+  }, []);
+
+  const popover = usePopup({ resolveReturnFocus: resolveTrigger });
+  const menu = usePopup({ resolveReturnFocus: resolveMenuButton });
+
+  const {
+    open: popoverOpen,
+    show: showPopover,
+    close: closePopover,
+    dismiss: dismissPopover
+  } = popover;
+
+  const {
+    open: menuOpen,
+    payload: menuInitialFocus,
+    toggle: toggleMenuState,
+    close: closeMenu,
+    dismiss: dismissMenu
+  } = menu;
 
   useEffect(() => {
     const previousAvailability = availabilityRef.current;
@@ -209,21 +298,21 @@ export function ConfigurationProperty(props) {
       (!previousAvailability.error && error)
       || (previousAvailability.available && !available)
     ) {
-      setOpen(false);
-      setMenuOpen(false);
+      dismissPopover();
+      dismissMenu();
     }
-  }, [ error, available ]);
+  }, [ error, available, dismissPopover, dismissMenu ]);
 
   // close popover/menu on outside click
   useEffect(() => {
-    if (!open && !menuOpen) {
+    if (!popoverOpen && !menuOpen) {
       return;
     }
 
     const onDocPointer = (event) => {
       if (ref.current && !ref.current.contains(event.target)) {
-        setOpen(false);
-        setMenuOpen(false);
+        dismissPopover();
+        dismissMenu();
       }
     };
 
@@ -232,7 +321,7 @@ export function ConfigurationProperty(props) {
     return () => {
       document.removeEventListener('mousedown', onDocPointer, true);
     };
-  }, [ open, menuOpen ]);
+  }, [ popoverOpen, menuOpen, dismissPopover, dismissMenu ]);
 
   const select = useCallback((name) => {
     if (disabled) {
@@ -242,9 +331,11 @@ export function ConfigurationProperty(props) {
     const instance = instances.find(instance => instance.name === name);
 
     setValue(name ? toReference(name) : '', instance);
-    setOpen(false);
-    setMenuOpen(false);
-  }, [ disabled, instances, setValue ]);
+
+    // return focus to the trigger once the (possibly freshly rendered) card mounts
+    closePopover();
+    dismissMenu();
+  }, [ disabled, instances, setValue, closePopover, dismissMenu ]);
 
   useEffect(() => {
     const onCreated = (event) => {
@@ -263,8 +354,8 @@ export function ConfigurationProperty(props) {
       }
 
       setValue(toReference(instance.name), instance);
-      setOpen(false);
-      setMenuOpen(false);
+      dismissPopover();
+      dismissMenu();
     };
 
     eventBus.on('configuration.created', onCreated);
@@ -279,11 +370,13 @@ export function ConfigurationProperty(props) {
     configurationInstances,
     configurationTemplate,
     minimumConfigurationTemplateVersion,
-    setValue
+    setValue,
+    dismissPopover,
+    dismissMenu
   ]);
 
   const createConfiguration = useCallback(() => {
-    setOpen(false);
+    dismissPopover();
 
     eventBus.fire('configuration.create', {
       element,
@@ -291,10 +384,10 @@ export function ConfigurationProperty(props) {
       configurationTemplate,
       configurationTemplateVersion
     });
-  }, [ eventBus, element, property, configurationTemplate, configurationTemplateVersion ]);
+  }, [ eventBus, element, property, configurationTemplate, configurationTemplateVersion, dismissPopover ]);
 
   const editConfiguration = useCallback(() => {
-    setMenuOpen(false);
+    dismissMenu();
 
     eventBus.fire('configuration.edit', {
       element,
@@ -303,10 +396,10 @@ export function ConfigurationProperty(props) {
       configurationTemplate,
       configurationTemplateVersion
     });
-  }, [ eventBus, element, property, selected, configurationTemplate, configurationTemplateVersion ]);
+  }, [ eventBus, element, property, selected, configurationTemplate, configurationTemplateVersion, dismissMenu ]);
 
   const upgradeConfiguration = useCallback(() => {
-    setMenuOpen(false);
+    dismissMenu();
 
     eventBus.fire('configuration.upgrade', {
       element,
@@ -315,26 +408,113 @@ export function ConfigurationProperty(props) {
       configurationTemplate,
       configurationTemplateVersion
     });
-  }, [ eventBus, element, property, boundInstance, configurationTemplate, configurationTemplateVersion ]);
+  }, [ eventBus, element, property, boundInstance, configurationTemplate, configurationTemplateVersion, dismissMenu ]);
 
   const toggleOpen = useCallback(() => {
     if (disabled || error || !available) {
       return;
     }
 
-    setMenuOpen(false);
-    setOpen(value => !value);
-  }, [ disabled, error, available ]);
+    dismissMenu();
 
-  const toggleMenu = useCallback((event) => {
+    // clicking the trigger while the dropdown is open closes it (canonical
+    // dropdown behavior), returning focus to the trigger
+    if (popoverOpen) {
+      closePopover();
+    } else {
+      showPopover();
+    }
+  }, [ disabled, error, available, popoverOpen, dismissMenu, closePopover, showPopover ]);
+
+  const toggleMenu = useCallback((event, initialFocus = FOCUS_FIRST) => {
     if (disabled) {
       return;
     }
 
     event.stopPropagation();
-    setOpen(false);
-    setMenuOpen(value => !value);
-  }, [ disabled ]);
+    dismissPopover();
+    toggleMenuState(initialFocus);
+  }, [ disabled, dismissPopover, toggleMenuState ]);
+
+  const variant = getConfigurationVariant({ value, error, selected, loading, available });
+
+  const renderConfiguration = () => {
+    switch (variant) {
+    case VARIANT.ERROR:
+      return (
+        <ErrorConfiguration
+          value={ value }
+          cachedName={ cachedName }
+          disabled={ disabled }
+          menuId={ menuId }
+          menuOpen={ menuOpen }
+          onMenu={ toggleMenu }
+          translate={ translate } />
+      );
+    case VARIANT.SELECTED:
+      return (
+        <SelectedConfiguration
+          instance={ selected }
+          disabled={ disabled }
+          menuId={ menuId }
+          menuOpen={ menuOpen }
+          open={ popoverOpen }
+          listboxId={ listboxId }
+          onClick={ toggleOpen }
+          onMenu={ toggleMenu }
+          translate={ translate } />
+      );
+    case VARIANT.LOADING:
+      return (
+        <LoadingConfiguration cachedName={ cachedName } translate={ translate } />
+      );
+    case VARIANT.MISSING:
+      return (
+        <MissingConfiguration
+          value={ value }
+          cachedName={ cachedName }
+          instance={ incompatible ? boundInstance : null }
+          minimumVersion={ minimumConfigurationTemplateVersion }
+          typeIncompatible={ typeIncompatible }
+          disabled={ disabled }
+          menuId={ menuId }
+          menuOpen={ menuOpen }
+          open={ popoverOpen }
+          listboxId={ listboxId }
+          onClick={ toggleOpen }
+          onMenu={ toggleMenu }
+          translate={ translate } />
+      );
+    case VARIANT.OFFLINE:
+      return (
+        <OfflineConfiguration
+          value={ value }
+          cachedName={ cachedName }
+          unavailableMessage={ unavailableMessage }
+          disabled={ disabled }
+          menuId={ menuId }
+          menuOpen={ menuOpen }
+          icon={ configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.icon?.contents }
+          onMenu={ toggleMenu }
+          translate={ translate } />
+      );
+    default:
+      return (
+        <PlaceholderConfiguration
+          id={ id }
+          disabled={ disabled }
+          error={ error }
+          available={ available }
+          unavailableMessage={ unavailableMessage }
+          open={ popoverOpen }
+          listboxId={ listboxId }
+          chooserLabel={ chooserLabel }
+          onClick={ toggleOpen }
+          showEntryRef={ showEntryRef }
+          translate={ translate } />
+      );
+    }
+  };
 
   return (
     <div
@@ -361,102 +541,7 @@ export function ConfigurationProperty(props) {
           : null
       }
 
-      {
-        value && error
-          ? (
-            <ErrorConfiguration
-              value={ value }
-              cachedName={ cachedName }
-              disabled={ disabled }
-              menuOpen={ menuOpen }
-              onMenu={ toggleMenu }
-              translate={ translate } />
-          )
-          : selected
-            ? (
-              <SelectedConfiguration
-                instance={ selected }
-                disabled={ disabled }
-                menuOpen={ menuOpen }
-                onClick={ toggleOpen }
-                onMenu={ toggleMenu }
-                translate={ translate } />
-            )
-            : value && !selected && loading
-              ? (
-                <LoadingConfiguration cachedName={ cachedName } translate={ translate } />
-              )
-              : value && !selected && available
-                ? (
-                  <MissingConfiguration
-                    value={ value }
-                    cachedName={ cachedName }
-                    instance={ incompatible ? boundInstance : null }
-                    minimumVersion={ minimumConfigurationTemplateVersion }
-                    typeIncompatible={ typeIncompatible }
-                    disabled={ disabled }
-                    menuOpen={ menuOpen }
-                    onClick={ toggleOpen }
-                    onMenu={ toggleMenu }
-                    translate={ translate } />
-                )
-                : value && !selected
-                  ? (
-                    <OfflineConfiguration
-                      value={ value }
-                      cachedName={ cachedName }
-                      unavailableMessage={ unavailableMessage }
-                      disabled={ disabled }
-                      menuOpen={ menuOpen }
-                      icon={ configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.icon?.contents }
-                      onMenu={ toggleMenu }
-                      translate={ translate } />
-                  )
-                  : (
-                    <>
-                      <button
-                        ref={ showEntryRef }
-                        type="button"
-                        class="bio-properties-panel-configuration-chooser-placeholder"
-                        disabled={ disabled || error || !available }
-                        aria-describedby={
-                          error
-                            ? `${ id }-error`
-                            : !available && unavailableMessage
-                              ? `${ id }-unavailable`
-                              : undefined
-                        }
-                        aria-expanded={ open }
-                        onClick={ toggleOpen }>
-                        <CreateIcon
-                          class="bio-properties-panel-configuration-chooser-create-icon"
-                          aria-hidden="true" />
-                        { translate('Choose {configuration}', { configuration: chooserLabel }) }
-                      </button>
-                      {
-                        error
-                          ? (
-                            <div
-                              id={ `${ id }-error` }
-                              class="bio-properties-panel-configuration-chooser-unavailable bio-properties-panel-configuration-chooser-unavailable--error"
-                              role="status">
-                              { translate('Could not load configurations') }
-                            </div>
-                          )
-                          : !available && unavailableMessage
-                            ? (
-                              <div
-                                id={ `${ id }-unavailable` }
-                                class="bio-properties-panel-configuration-chooser-unavailable"
-                                role="status">
-                                { unavailableMessage }
-                              </div>
-                            )
-                            : null
-                      }
-                    </>
-                  )
-      }
+      { renderConfiguration() }
 
       {
         validationError
@@ -469,14 +554,17 @@ export function ConfigurationProperty(props) {
       }
 
       {
-        open
+        popoverOpen
           ? (
             <ConfigurationPopover
+              listboxId={ listboxId }
               instances={ instances }
               selected={ selected }
               canCreate={ canCreate }
               onCreate={ createConfiguration }
               onSelect={ select }
+              onClose={ closePopover }
+              onDismiss={ dismissPopover }
               loading={ loading }
               translate={ translate } />
           )
@@ -487,9 +575,13 @@ export function ConfigurationProperty(props) {
         menuOpen
           ? (
             <ConfigurationContextMenu
+              menuId={ menuId }
+              initialFocus={ menuInitialFocus }
               onEdit={ selected && canUpdate ? editConfiguration : null }
               onUpgrade={ versionIncompatible && canUpdate ? upgradeConfiguration : null }
               onRemove={ () => select(null) }
+              onClose={ closeMenu }
+              onDismiss={ dismissMenu }
               translate={ translate } />
           )
           : null
@@ -502,78 +594,240 @@ function SelectedConfiguration(props) {
   const {
     disabled,
     instance,
+    listboxId,
+    menuId,
     menuOpen,
+    open,
     onClick,
     onMenu,
     translate
   } = props;
 
   return (
-    <div
-      class="bio-properties-panel-configuration-chooser-selected"
-      role="button"
-      tabIndex={ disabled ? -1 : 0 }
-      onClick={ disabled ? null : onClick }
-      onKeyDown={ disabled ? null : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } }>
-      <ConfigurationLogo instance={ instance } />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          { getDisplayName(instance) }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
-          <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
-        </span>
-      </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
+    <div class="bio-properties-panel-configuration-chooser-selected">
+      <ConfigurationTrigger
         disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+        listboxId={ listboxId }
+        open={ open }
+        onClick={ onClick }>
+        <ConfigurationLogo instance={ instance } />
+        <span class="bio-properties-panel-configuration-chooser-text">
+          <span class="bio-properties-panel-configuration-chooser-title">
+            { getDisplayName(instance) }
+          </span>
+          <span class="bio-properties-panel-configuration-chooser-subtitle">
+            <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
+          </span>
+        </span>
+      </ConfigurationTrigger>
+      <ConfigurationMenuButton
+        menuId={ menuId }
+        menuOpen={ menuOpen }
+        disabled={ disabled }
+        onMenu={ onMenu }
+        translate={ translate } />
     </div>
   );
 }
 
-function ConfigurationContextMenu(props) {
-  const { onEdit, onRemove, onUpgrade, translate } = props;
+function ConfigurationTrigger(props) {
+  const {
+    children,
+    disabled,
+    listboxId,
+    open,
+    onClick
+  } = props;
 
   return (
-    <div class="bio-properties-panel-configuration-chooser-context-menu">
+    <button
+      type="button"
+      class="bio-properties-panel-configuration-chooser-trigger"
+      disabled={ disabled }
+      aria-haspopup="listbox"
+      aria-expanded={ open }
+      aria-controls={ open ? listboxId : undefined }
+      onMouseDown={ open ? (event) => event.preventDefault() : undefined }
+      onClick={ disabled ? null : onClick }>
+      { children }
+    </button>
+  );
+}
+
+function ConfigurationMenuButton(props) {
+  const { disabled, menuId, menuOpen, onMenu, translate } = props;
+
+  const onKeyDown = (event) => {
+
+    if (menuOpen) {
+      return;
+    }
+
+    // open the menu with the arrow keys, matching native menu-button behaviour:
+    // ArrowDown focuses the first item, ArrowUp the last
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      onMenu(event, FOCUS_FIRST);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      onMenu(event, FOCUS_LAST);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      class="bio-properties-panel-configuration-chooser-menu"
+      title={ translate('More actions') }
+      aria-label={ translate('More actions') }
+      aria-haspopup="menu"
+      aria-expanded={ menuOpen }
+      aria-controls={ menuOpen ? menuId : undefined }
+      disabled={ disabled }
+      onClick={ onMenu }
+      onKeyDown={ onKeyDown }>
+      …
+    </button>
+  );
+}
+
+function ConfigurationContextMenu(props) {
+  const { initialFocus, menuId, onClose, onDismiss, onEdit, onRemove, onUpgrade, translate } = props;
+
+  const menuRef = useRef(null);
+  const itemRefs = useRef([]);
+
+  const items = [];
+
+  if (onEdit) {
+    items.push({ key: 'edit', label: translate('Edit'), onClick: onEdit });
+  }
+
+  if (onUpgrade) {
+    items.push({ key: 'upgrade', label: translate('Upgrade'), onClick: onUpgrade });
+  }
+
+  items.push({ key: 'remove', label: translate('Unset'), onClick: onRemove });
+
+  const itemCount = items.length;
+
+  // the menu is re-mounted on each open, so useActiveIndex re-seeds from the
+  // current initialFocus intent ('first' vs 'last') each time
+  const [ activeIndex, setActiveIndex, onNavigationKeyDown ] = useActiveIndex(itemCount, {
+    initialIndex: initialFocus === FOCUS_LAST ? itemCount - 1 : 0,
+    wrap: true
+  });
+
+  // move real focus to the active item (menus use roving focus rather than
+  // aria-activedescendant); this also moves focus into the menu on open
+  useEffect(() => {
+    const node = itemRefs.current[ activeIndex ];
+
+    if (node) {
+      node.focus();
+    }
+  }, [ activeIndex ]);
+
+  const onKeyDown = (event) => {
+    onNavigationKeyDown(event);
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  // close the menu once focus leaves it entirely (e.g. tabbing away), letting
+  // focus continue to its natural destination
+  useFocusOut(menuRef, onDismiss);
+
+  return (
+    <div
+      ref={ menuRef }
+      id={ menuId }
+      role="menu"
+      aria-label={ translate('More actions') }
+      class="bio-properties-panel-configuration-chooser-context-menu"
+      onKeyDown={ onKeyDown }>
       {
-        onEdit
-          ? (
-            <button
-              type="button"
-              class="bio-properties-panel-configuration-chooser-context-menu-item"
-              onClick={ onEdit }>
-              { translate('Edit') }
-            </button>
-          )
-          : null
+        items.map((item, index) => (
+          <button
+            key={ item.key }
+            ref={ node => itemRefs.current[ index ] = node }
+            type="button"
+            role="menuitem"
+            tabIndex={ index === activeIndex ? 0 : -1 }
+            class="bio-properties-panel-configuration-chooser-context-menu-item"
+            onClick={ item.onClick }
+            onMouseEnter={ () => setActiveIndex(index) }>
+            { item.label }
+          </button>
+        ))
       }
-      {
-        onUpgrade
-          ? (
-            <button
-              type="button"
-              class="bio-properties-panel-configuration-chooser-context-menu-item"
-              onClick={ onUpgrade }>
-              { translate('Upgrade') }
-            </button>
-          )
-          : null
-      }
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-context-menu-item"
-        onClick={ onRemove }>
-        { translate('Unset') }
-      </button>
     </div>
+  );
+}
+
+function PlaceholderConfiguration(props) {
+  const {
+    available,
+    chooserLabel,
+    disabled,
+    error,
+    id,
+    listboxId,
+    onClick,
+    open,
+    showEntryRef,
+    translate,
+    unavailableMessage
+  } = props;
+
+  const describedBy = error
+    ? `${ id }-error`
+    : !available && unavailableMessage
+      ? `${ id }-unavailable`
+      : undefined;
+
+  return (
+    <>
+      <button
+        ref={ showEntryRef }
+        type="button"
+        class="bio-properties-panel-configuration-chooser-placeholder"
+        disabled={ disabled || error || !available }
+        aria-haspopup="listbox"
+        aria-controls={ open ? listboxId : undefined }
+        aria-describedby={ describedBy }
+        aria-expanded={ open }
+        onClick={ onClick }>
+        <CreateIcon
+          class="bio-properties-panel-configuration-chooser-create-icon"
+          aria-hidden="true" />
+        { translate('Choose {configuration}', { configuration: chooserLabel }) }
+      </button>
+      {
+        error
+          ? (
+            <div
+              id={ `${ id }-error` }
+              class="bio-properties-panel-configuration-chooser-unavailable bio-properties-panel-configuration-chooser-unavailable--error"
+              role="status">
+              { translate('Could not load configurations') }
+            </div>
+          )
+          : !available && unavailableMessage
+            ? (
+              <div
+                id={ `${ id }-unavailable` }
+                class="bio-properties-panel-configuration-chooser-unavailable"
+                role="status">
+                { unavailableMessage }
+              </div>
+            )
+            : null
+      }
+    </>
   );
 }
 
@@ -608,6 +862,7 @@ function ErrorConfiguration(props) {
   const {
     cachedName,
     disabled,
+    menuId,
     menuOpen,
     onMenu,
     translate,
@@ -627,16 +882,12 @@ function ErrorConfiguration(props) {
           { translate('Could not load configurations') }
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
+      <ConfigurationMenuButton
+        menuId={ menuId }
+        menuOpen={ menuOpen }
         disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+        onMenu={ onMenu }
+        translate={ translate } />
     </div>
   );
 }
@@ -646,8 +897,11 @@ function MissingConfiguration(props) {
     cachedName,
     disabled,
     instance,
+    listboxId,
+    menuId,
     menuOpen,
     minimumVersion,
+    open,
     onClick,
     onMenu,
     translate,
@@ -659,45 +913,42 @@ function MissingConfiguration(props) {
   const refName = fromReference(value);
   const instanceVersion = instance?.metadata?.configurationTemplateVersion;
 
+  const title = instance
+    ? getDisplayName(instance)
+    : cachedName || translate('Configuration not found');
+
+  const subtitle = instance
+    ? typeIncompatible
+      ? translate('Incompatible configuration type')
+      : translate('Version {version} · Requires version {minimumVersion}+', {
+        version: instanceVersion == null ? '?' : instanceVersion,
+        minimumVersion
+      })
+    : cachedName ? translate('Not found on cluster') : refName;
+
   return (
-    <div
-      class="bio-properties-panel-configuration-chooser-missing"
-      role="button"
-      tabIndex={ disabled ? -1 : 0 }
-      onClick={ disabled ? null : onClick }
-      onKeyDown={ disabled ? null : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } }>
-      <ConfigurationLogo warning />
-      <span class="bio-properties-panel-configuration-chooser-text">
-        <span class="bio-properties-panel-configuration-chooser-title">
-          {
-            instance
-              ? getDisplayName(instance)
-              : cachedName || translate('Configuration not found')
-          }
-        </span>
-        <span class="bio-properties-panel-configuration-chooser-subtitle">
-          {
-            instance
-              ? typeIncompatible
-                ? translate('Incompatible configuration type')
-                : translate('Version {version} · Requires version {minimumVersion}+', {
-                  version: instanceVersion == null ? '?' : instanceVersion,
-                  minimumVersion
-                })
-              : cachedName ? translate('Not found on cluster') : refName
-          }
-        </span>
-      </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
+    <div class="bio-properties-panel-configuration-chooser-missing">
+      <ConfigurationTrigger
         disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+        listboxId={ listboxId }
+        open={ open }
+        onClick={ onClick }>
+        <ConfigurationLogo warning />
+        <span class="bio-properties-panel-configuration-chooser-text">
+          <span class="bio-properties-panel-configuration-chooser-title">
+            { title }
+          </span>
+          <span class="bio-properties-panel-configuration-chooser-subtitle">
+            { subtitle }
+          </span>
+        </span>
+      </ConfigurationTrigger>
+      <ConfigurationMenuButton
+        menuId={ menuId }
+        menuOpen={ menuOpen }
+        disabled={ disabled }
+        onMenu={ onMenu }
+        translate={ translate } />
     </div>
   );
 }
@@ -707,6 +958,7 @@ function OfflineConfiguration(props) {
     cachedName,
     disabled,
     icon,
+    menuId,
     menuOpen,
     onMenu,
     translate,
@@ -736,16 +988,12 @@ function OfflineConfiguration(props) {
           { unavailableMessage || translate('Cluster unavailable') }
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
+      <ConfigurationMenuButton
+        menuId={ menuId }
+        menuOpen={ menuOpen }
         disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+        onMenu={ onMenu }
+        translate={ translate } />
     </div>
   );
 }
@@ -754,15 +1002,84 @@ function ConfigurationPopover(props) {
   const {
     canCreate,
     instances,
+    listboxId,
     loading,
+    onClose,
     onCreate,
+    onDismiss,
     onSelect,
     selected,
     translate
   } = props;
 
+  const listRef = useRef(null);
+  const createRef = useRef(null);
+  const popoverRef = useRef(null);
+
+  const createId = `${ listboxId }-create`;
+
+  // the create action participates in keyboard navigation as a trailing option
+  const createIndex = canCreate ? instances.length : -1;
+  const optionCount = instances.length + (canCreate ? 1 : 0);
+
+  const selectedIndex = instances.findIndex(instance => instance === selected);
+
+  const [ activeIndex, setActiveIndex, onNavigationKeyDown ] = useActiveIndex(optionCount, {
+    initialIndex: selectedIndex >= 0 ? selectedIndex : 0
+  });
+
+  // move focus into the popover so it can be operated by keyboard; the parent
+  // restores focus to the trigger when the popover is closed via keyboard
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.focus();
+    } else if (createRef.current) {
+      createRef.current.focus();
+    }
+  }, []);
+
+  const isCreateActive = canCreate && activeIndex === createIndex;
+  const activeInstance = isCreateActive ? null : instances[ activeIndex ];
+
+  const optionId = (instance) => `${ listboxId }-option-${ instance.name }`;
+
+  const activeDescendant = isCreateActive
+    ? createId
+    : activeInstance
+      ? optionId(activeInstance)
+      : undefined;
+
+  const activateSelection = () => {
+    if (isCreateActive) {
+      onCreate();
+    } else if (activeInstance) {
+      onSelect(selected === activeInstance ? null : activeInstance.name);
+    }
+  };
+
+  const onKeyDown = (event) => {
+    onNavigationKeyDown(event);
+
+    const { key } = event;
+
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      activateSelection();
+    } else if (key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  // close the popover once focus leaves it entirely (e.g. tabbing to the next
+  // field), letting focus continue to its natural destination
+  useFocusOut(popoverRef, onDismiss);
+
   return (
-    <div class="bio-properties-panel-configuration-chooser-popover">
+    <div
+      ref={ popoverRef }
+      class="bio-properties-panel-configuration-chooser-popover"
+      onKeyDown={ onKeyDown }>
       {
         loading
           ? (
@@ -775,40 +1092,61 @@ function ConfigurationPopover(props) {
           : null
       }
 
-      {
-        instances.length
-          ? (
-            <ul class="bio-properties-panel-configuration-chooser-popover-list">
-              {
-                instances.map((instance) => (
-                  <ConfigurationRow
-                    key={ instance.name }
-                    instance={ instance }
-                    selected={ selected === instance }
-                    onSelect={ () => onSelect(selected === instance ? null : instance.name) }
-                    translate={ translate } />
-                ))
-              }
-            </ul>
-          )
-          : (
-            <div class="bio-properties-panel-configuration-chooser-empty">
-              {
-                loading
-                  ? translate('Loading...')
-                  : translate('No compatible configurations are available in the connected cluster')
-              }
-            </div>
-          )
-      }
+      <ul
+        ref={ listRef }
+        id={ listboxId }
+        role="listbox"
+        tabIndex={ -1 }
+        aria-label={ translate('Configurations') }
+        aria-activedescendant={ activeDescendant }
+        aria-owns={ canCreate ? createId : undefined }
+        class="bio-properties-panel-configuration-chooser-popover-list">
+        {
+          instances.length
+            ? instances.map((instance, index) => (
+              <ConfigurationRow
+                key={ instance.name }
+                id={ optionId(instance) }
+                instance={ instance }
+                active={ index === activeIndex }
+                selected={ selected === instance }
+                onSelect={ () => onSelect(selected === instance ? null : instance.name) }
+                onHover={ () => setActiveIndex(index) }
+                translate={ translate } />
+            ))
+            : (
+              <li
+                class="bio-properties-panel-configuration-chooser-empty"
+                role="presentation">
+                <span role="status">
+                  {
+                    loading
+                      ? translate('Loading...')
+                      : translate('No compatible configurations are available in the connected cluster')
+                  }
+                </span>
+              </li>
+            )
+        }
+      </ul>
 
       {
         canCreate
           ? (
             <button
+              ref={ createRef }
               type="button"
-              class="bio-properties-panel-configuration-chooser-create"
-              onClick={ onCreate }>
+              id={ createId }
+              role="option"
+              tabIndex={ -1 }
+              aria-selected={ false }
+              class={
+                isCreateActive
+                  ? 'bio-properties-panel-configuration-chooser-create bio-properties-panel-configuration-chooser-create--active'
+                  : 'bio-properties-panel-configuration-chooser-create'
+              }
+              onClick={ onCreate }
+              onMouseEnter={ () => setActiveIndex(createIndex) }>
               <CreateIcon
                 class="bio-properties-panel-configuration-chooser-create-icon"
                 aria-hidden="true" />
@@ -823,17 +1161,13 @@ function ConfigurationPopover(props) {
 
 function ConfigurationRow(props) {
   const {
+    active,
+    id,
     instance,
+    onHover,
     onSelect,
     selected
   } = props;
-
-  const onKeyDown = (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      onSelect();
-    }
-  };
 
   const classes = [ 'bio-properties-panel-configuration-chooser-popover-row' ];
 
@@ -841,14 +1175,18 @@ function ConfigurationRow(props) {
     classes.push('bio-properties-panel-configuration-chooser-popover-row--selected');
   }
 
+  if (active) {
+    classes.push('bio-properties-panel-configuration-chooser-popover-row--active');
+  }
+
   return (
     <li
+      id={ id }
       class={ classes.join(' ') }
-      role="button"
-      tabIndex={ 0 }
-      aria-pressed={ selected }
+      role="option"
+      aria-selected={ selected }
       onClick={ onSelect }
-      onKeyDown={ onKeyDown }>
+      onMouseEnter={ onHover }>
       <ConfigurationLogo instance={ instance } />
       <span class="bio-properties-panel-configuration-chooser-text">
         <span class="bio-properties-panel-configuration-chooser-title">

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/hooks.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/hooks.js
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
+
+/**
+ * Manage an open/closed popup (e.g. a popover or menu) together with the focus
+ * choreography that keyboard accessibility requires. Unlike a plain ARIA
+ * disclosure, a popup moves focus into the layer on open and must return it to
+ * the trigger on close.
+ *
+ * Distinguishes two ways of closing:
+ *
+ * - `close()` closes and returns focus to the trigger (keyboard-driven close,
+ *   e.g. Escape or activating an item). The refocus is deferred until the
+ *   trigger is available again, since the trigger may be a freshly rendered
+ *   element (e.g. a card that replaces a placeholder once the model change has
+ *   propagated).
+ * - `dismiss()` closes without moving focus, letting focus continue to its
+ *   natural destination (e.g. focus leaving the popup, or an outside click).
+ *
+ * `show(payload)`/`toggle(payload)` carry an opaque payload describing the
+ * open intent (e.g. which end of a menu to focus); it is exposed as `payload`
+ * while open and reset on close.
+ *
+ * @param {Object} [options]
+ * @param {() => (HTMLElement|null)} [options.resolveReturnFocus] resolve the
+ * element that focus should return to after a `close()`
+ *
+ * @returns {{
+ *   open: boolean,
+ *   payload: any,
+ *   show: (payload?: any) => void,
+ *   toggle: (payload?: any) => void,
+ *   close: () => void,
+ *   dismiss: () => void
+ * }}
+ */
+export function usePopup(options = {}) {
+  const { resolveReturnFocus } = options;
+
+  const [ state, setState ] = useState({ open: false, payload: undefined });
+
+  const pendingFocusRef = useRef(false);
+
+  const show = useCallback((payload) => {
+    setState({ open: true, payload });
+  }, []);
+
+  const toggle = useCallback((payload) => {
+    setState(state => state.open
+      ? { open: false, payload: undefined }
+      : { open: true, payload });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setState({ open: false, payload: undefined });
+  }, []);
+
+  const close = useCallback(() => {
+    pendingFocusRef.current = true;
+    setState({ open: false, payload: undefined });
+  }, []);
+
+  // return focus to the trigger once closed; retried across renders until the
+  // trigger is available, hence the unconditional (dependency-free) effect
+  useEffect(() => {
+    if (state.open || !pendingFocusRef.current) {
+      return;
+    }
+
+    const target = resolveReturnFocus && resolveReturnFocus();
+
+    if (target) {
+      target.focus();
+      pendingFocusRef.current = false;
+    }
+  });
+
+  return {
+    open: state.open,
+    payload: state.payload,
+    show,
+    toggle,
+    close,
+    dismiss
+  };
+}
+
+/**
+ * Manage the active index of a keyboard-navigable list of options (e.g. a
+ * listbox or menu). Owns the index, keeps it within bounds as the list size
+ * changes, and returns a key handler for the arrow/Home/End navigation keys.
+ *
+ * The caller decides how the active index is reflected (aria-activedescendant
+ * vs. roving focus) and how activation keys (Enter/Space/Escape) are handled.
+ *
+ * @param {number} count number of options
+ * @param {Object} [options]
+ * @param {number} [options.initialIndex=0]
+ * @param {boolean} [options.wrap=false] wrap around at the list boundaries
+ *
+ * @returns {[ number, (index: number) => void, (event: KeyboardEvent) => void ]}
+ */
+export function useActiveIndex(count, options = {}) {
+  const { initialIndex = 0, wrap = false } = options;
+
+  const [ activeIndex, setActiveIndex ] = useState(initialIndex);
+
+  // keep the active index within bounds as the list changes
+  useEffect(() => {
+    setActiveIndex(index => clamp(index, count));
+  }, [ count ]);
+
+  const onKeyDown = useCallback((event) => {
+    const { key } = event;
+
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex(index => step(index, 1, count, wrap));
+    } else if (key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex(index => step(index, -1, count, wrap));
+    } else if (key === 'Home') {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (key === 'End') {
+      event.preventDefault();
+      setActiveIndex(count - 1);
+    }
+  }, [ count, wrap ]);
+
+  return [ activeIndex, setActiveIndex, onKeyDown ];
+}
+
+/**
+ * Invoke a handler once focus leaves the referenced element entirely (e.g.
+ * tabbing to the next field), letting focus continue to its natural
+ * destination.
+ *
+ * We attach a native `focusout` listener (which bubbles) rather than relying on
+ * preact's synthetic onFocusOut, which does not reliably fire for bubbled focus
+ * events.
+ *
+ * @param {{ current: HTMLElement }} ref
+ * @param {() => void} handler stable callback (e.g. via useCallback)
+ */
+export function useFocusOut(ref, handler) {
+  useEffect(() => {
+    const node = ref.current;
+
+    if (!node) {
+      return;
+    }
+
+    const onFocusOut = (event) => {
+      const next = event.relatedTarget || document.activeElement;
+
+      if (!node.contains(next)) {
+        handler();
+      }
+    };
+
+    node.addEventListener('focusout', onFocusOut);
+
+    return () => node.removeEventListener('focusout', onFocusOut);
+  }, [ ref, handler ]);
+}
+
+function clamp(index, count) {
+  return Math.max(0, Math.min(index, count - 1));
+}
+
+function step(index, delta, count, wrap) {
+  const next = index + delta;
+
+  if (wrap) {
+    return (next + count) % count;
+  }
+
+  return clamp(next, count);
+}

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1830,6 +1830,89 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     }));
 
 
+    it('should NOT unset when re-choosing the current selection', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(getConfigurationPlaceholder(entry));
+      });
+      clickConfigurationOption(entry, 'Slack Production');
+
+      // re-open the dropdown on the now selected configuration
+      const trigger = await waitFor(() => {
+        const node = getConfigurationTrigger(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      await act(() => {
+        fireEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationRow(entry)).to.exist;
+      });
+
+      // when re-choosing the already selected instance
+      clickConfigurationOption(entry, 'Slack Production');
+
+      // then the selection is preserved (NOOP, not toggled off)
+      const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
+            zeebeProperty = findZeebeProperty(zeebeProperties, { name: 'configuration' });
+
+      expect(zeebeProperty).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'configuration',
+        value: '=camunda.vars.env.slackProduction',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+
+      // and the popover is closed
+      expect(getConfigurationPopover(entry)).not.to.exist;
+    }));
+
+
     it('should close the popover when clicking the open trigger', inject(async function(elementTemplates, configurationInstances) {
 
       // given

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1482,7 +1482,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const select = async (entry, name) => {
         await act(() => {
           fireEvent.click(domQuery(
-            '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-selected',
+            '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-trigger',
             entry
           ));
         });
@@ -1817,13 +1817,798 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // when
-      fireEvent.keyDown(getConfigurationSelected(entry), {
-        key: 'Enter'
-      });
+      // when
+      fireEvent.click(getConfigurationTrigger(entry));
 
       // then
       expect(getConfigurationPopover(entry)).to.exist;
 
+    }));
+
+
+    it('should close the popover when clicking the open trigger', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(getConfigurationPlaceholder(entry));
+      });
+      clickConfigurationOption(entry, 'Slack Production');
+
+      const trigger = await waitFor(() => {
+        const node = getConfigurationTrigger(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      // when opening the dropdown
+      await act(() => {
+        fireEvent.click(trigger);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationPopover(entry)).to.exist;
+      });
+
+      // then clicking the open trigger closes it (canonical dropdown behavior).
+      // Its mousedown is prevented so the popover does not dismiss-then-reopen
+      // when focus would otherwise shift to the trigger.
+      const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+
+      trigger.dispatchEvent(mousedown);
+
+      expect(mousedown.defaultPrevented).to.be.true;
+
+      await act(() => {
+        fireEvent.click(trigger);
+      });
+
+      expect(getConfigurationPopover(entry)).not.to.exist;
+    }));
+
+
+    it('should move focus to the trigger after selecting', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationRow(container)).to.exist;
+      });
+
+      // spy on focus to observe which trigger receives focus (headless
+      // browsers do not reliably move document.activeElement)
+      const focusSpy = spy(HTMLElement.prototype, 'focus');
+
+      try {
+
+        // when
+        await act(() => {
+          fireEvent.keyDown(getConfigurationRow(container), {
+            key: ' '
+          });
+        });
+
+        // then
+        // focus moves to the freshly rendered trigger, not the removed placeholder
+        await waitFor(() => {
+          const trigger = getConfigurationTrigger(entry);
+
+          expect(trigger).to.exist;
+          expect(focusSpy.getCalls().some((call) => call.thisValue === trigger)).to.be.true;
+        });
+      } finally {
+        focusSpy.restore();
+      }
+    }));
+
+
+    it('should restore focus to the trigger when closing via keyboard', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      const listbox = await waitFor(() => {
+        const node = domQuery('[role="listbox"]', container);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      const focusSpy = spy(placeholder, 'focus');
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(listbox, { key: 'Escape' });
+      });
+
+      // then
+      await waitFor(() => {
+        expect(getConfigurationPopover(entry)).not.to.exist;
+        expect(focusSpy).to.have.been.called;
+      });
+
+      focusSpy.restore();
+    }));
+
+
+    it('should reach the create action via keyboard navigation', inject(async function(elementTemplates, eventBus, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const property = {
+        id: 'configuration',
+        label: 'Configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2,
+        binding: {
+          type: 'zeebe:property',
+          name: 'configuration'
+        }
+      };
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ property ]
+      };
+      const createSpy = spy();
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      configurationInstances.setState({
+        permissions: {
+          create: true
+        }
+      });
+      eventBus.on('configuration.create', createSpy);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      const listbox = await waitFor(() => {
+        const node = domQuery('[role="listbox"]', container);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      const createOption = getConfigurationCreate(entry);
+
+      expect(createOption).to.exist;
+
+      // when
+      // arrow down from the single instance to the create action, then activate
+      await act(() => {
+        fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      });
+
+      // then
+      await waitFor(() => {
+        expect(listbox.getAttribute('aria-activedescendant')).to.equal(createOption.id);
+      });
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(listbox, { key: 'Enter' });
+      });
+
+      // then
+      expect(createSpy).to.have.been.calledOnce;
+    }));
+
+
+    it('should dismiss the popover when focus leaves it', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      const popover = await waitFor(() => {
+        const node = getConfigurationPopover(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      const focusSpy = spy(placeholder, 'focus');
+
+      const listbox = domQuery('[role="listbox"]', popover);
+
+      // when
+      // focus moves from the inner listbox to an element outside of the popover;
+      // real browsers fire a bubbling `focusout` in this case
+      await act(() => {
+        listbox.dispatchEvent(new FocusEvent('focusout', {
+          bubbles: true,
+          relatedTarget: document.body
+        }));
+      });
+
+      // then
+      await waitFor(() => {
+        expect(getConfigurationPopover(entry)).not.to.exist;
+      });
+
+      // focus is not forced back onto the trigger
+      expect(focusSpy).not.to.have.been.called;
+
+      focusSpy.restore();
+    }));
+
+
+    it('should keep the empty popover keyboard-operable', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      // no compatible instances and no create permission
+      configurationInstances.setState({
+        selectableInstances: [],
+        available: true,
+        loading: false
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      // when
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      const popover = await waitFor(() => {
+        const node = getConfigurationPopover(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      // then
+      // the popover exposes a listbox the trigger points to, even without options
+      const listbox = domQuery('[role="listbox"]', popover);
+
+      expect(listbox).to.exist;
+      expect(listbox.id).to.equal(placeholder.getAttribute('aria-controls'));
+
+      // and the empty message is still announced
+      expect(domQuery('.bio-properties-panel-configuration-chooser-empty', popover).textContent)
+        .to.equal('No compatible configurations are available in the connected cluster');
+
+      // and the popover can be closed via keyboard, returning focus to the trigger
+      const focusSpy = spy(placeholder, 'focus');
+
+      await act(() => {
+        fireEvent.keyDown(listbox, { key: 'Escape' });
+      });
+
+      // then
+      await waitFor(() => {
+        expect(getConfigurationPopover(entry)).not.to.exist;
+        expect(focusSpy).to.have.been.called;
+      });
+
+      focusSpy.restore();
+    }));
+
+
+    it('should open the actions menu (not the chooser) when activating it via keyboard', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      // select an instance so the selected card (with its actions menu) renders
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationRow(container)).to.exist;
+      });
+
+      await act(() => {
+        fireEvent.keyDown(getConfigurationRow(container), {
+          key: ' '
+        });
+      });
+
+      const card = await waitFor(() => {
+        const node = getConfigurationSelected(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      const menuButton = getConfigurationMenuButton(card);
+
+      // when
+      // the actions menu button (nested inside the card) is activated via keyboard
+      await act(() => {
+        fireEvent.keyDown(menuButton, { key: 'Enter' });
+      });
+
+      // then
+      // the chooser popover is not opened by the nested activation
+      expect(getConfigurationPopover(entry)).not.to.exist;
+
+      // and the actions menu opens (native button activation)
+      await act(() => {
+        fireEvent.click(menuButton);
+      });
+
+      expect(getConfigurationContextMenu(entry)).to.exist;
+      expect(getConfigurationPopover(entry)).not.to.exist;
+    }));
+
+
+    it('should expose the actions menu as a keyboard-operable menu', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      // select an instance so the selected card (with its actions menu) renders
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationRow(container)).to.exist;
+      });
+
+      await act(() => {
+        fireEvent.keyDown(getConfigurationRow(container), {
+          key: ' '
+        });
+      });
+
+      const menuButton = await waitFor(() => {
+        const node = getConfigurationMenuButton(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      // grant update permission so the menu has more than one item (Edit + Remove)
+      await act(() => {
+        configurationInstances.setState({
+          permissions: {
+            update: true
+          }
+        });
+      });
+
+      // the trigger advertises a menu popup
+      expect(menuButton.getAttribute('aria-haspopup')).to.equal('menu');
+
+      // when
+      // the menu is opened via the arrow keys
+      await act(() => {
+        fireEvent.keyDown(menuButton, { key: 'ArrowDown' });
+      });
+
+      const menu = await waitFor(() => {
+        const node = getConfigurationContextMenu(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      // then
+      // it has menu semantics
+      expect(menu.getAttribute('role')).to.equal('menu');
+
+      const menuItems = getConfigurationContextMenuItems(entry);
+
+      menuItems.forEach(item => {
+        expect(item.getAttribute('role')).to.equal('menuitem');
+      });
+
+      // and the first item is the active (tabbable) item
+      expect(menuItems[0].getAttribute('tabindex')).to.equal('0');
+      expect(menuItems[1].getAttribute('tabindex')).to.equal('-1');
+
+      // when
+      // navigating down with the keyboard
+      await act(() => {
+        fireEvent.keyDown(menu, { key: 'ArrowDown' });
+      });
+
+      // then
+      // the active (tabbable) item moves to the next one (roving focus)
+      await waitFor(() => {
+        expect(menuItems[1].getAttribute('tabindex')).to.equal('0');
+      });
+      expect(menuItems[0].getAttribute('tabindex')).to.equal('-1');
+
+      // when
+      // pressing Escape (spy on focus, since headless browsers do not reliably
+      // move document.activeElement)
+      const focusSpy = spy(menuButton, 'focus');
+
+      await act(() => {
+        fireEvent.keyDown(menu, { key: 'Escape' });
+      });
+
+      // then
+      // the menu closes and focus returns to the trigger button
+      await waitFor(() => {
+        expect(getConfigurationContextMenu(entry)).not.to.exist;
+      });
+
+      expect(focusSpy).to.have.been.called;
+
+      focusSpy.restore();
+    }));
+
+
+    it('should open the actions menu with the last item active on ArrowUp', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      // select an instance so the selected card (with its actions menu) renders
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationRow(container)).to.exist;
+      });
+
+      await act(() => {
+        fireEvent.keyDown(getConfigurationRow(container), {
+          key: ' '
+        });
+      });
+
+      const menuButton = await waitFor(() => {
+        const node = getConfigurationMenuButton(entry);
+
+        expect(node).to.exist;
+
+        return node;
+      });
+
+      // grant update permission so the menu has more than one item (Edit + Remove)
+      await act(() => {
+        configurationInstances.setState({
+          permissions: {
+            update: true
+          }
+        });
+      });
+
+      // when
+      // the menu is opened via ArrowUp
+      await act(() => {
+        fireEvent.keyDown(menuButton, { key: 'ArrowUp' });
+      });
+
+      await waitFor(() => {
+        expect(getConfigurationContextMenu(entry)).to.exist;
+      });
+
+      // then
+      // the last item is the active (tabbable) one
+      const menuItems = getConfigurationContextMenuItems(entry);
+
+      expect(menuItems.length).to.be.above(1);
+      expect(menuItems[menuItems.length - 1].getAttribute('tabindex')).to.equal('0');
+      expect(menuItems[0].getAttribute('tabindex')).to.equal('-1');
     }));
 
 
@@ -2612,9 +3397,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(missing).to.exist;
       expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
 
-      fireEvent.keyDown(missing, {
-        key: 'Enter'
-      });
+      fireEvent.click(getConfigurationTrigger(missing));
 
       const rows = getConfigurationRows(entry);
 
@@ -5304,8 +6087,8 @@ function clickConfigurationOption(entry, name) {
 
 function getConfigurationOption(entry, name) {
   return within(entry).getAllByText(name).find(option => {
-    return option.closest('li[role="button"]');
-  }).closest('li[role="button"]');
+    return option.closest('li[role="option"]');
+  }).closest('li[role="option"]');
 }
 
 function getConfigurationMenuItem(entry, label) {
@@ -5351,6 +6134,27 @@ function getConfigurationMissing(entry) {
 
 function getConfigurationContextMenu(entry) {
   return domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry);
+}
+
+
+function getConfigurationTrigger(entry) {
+  const trigger = domQuery('.bio-properties-panel-configuration-chooser-trigger', entry);
+
+  expect(trigger, 'configuration chooser trigger').to.exist;
+
+  return trigger;
+}
+
+function getConfigurationMenuButton(entry) {
+  const button = domQuery('.bio-properties-panel-configuration-chooser-menu', entry);
+
+  expect(button, 'configuration chooser actions menu button').to.exist;
+
+  return button;
+}
+
+function getConfigurationContextMenuItems(entry) {
+  return domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
 }
 
 function expectSelected(id) {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -103,26 +103,6 @@ import timerElementTemplates from './CustomProperties.timer.json';
 
 describe('provider/cloud-element-templates - CustomProperties', function() {
 
-  describe('configuration edited state', function() {
-
-    it('should treat every bound configuration state as edited', function() {
-
-      const selected = document.createElement('div');
-      selected.innerHTML = '<div class="bio-properties-panel-configuration-chooser-selected"></div>';
-      const missing = document.createElement('div');
-      missing.innerHTML = '<div class="bio-properties-panel-configuration-chooser-missing"></div>';
-      const loading = document.createElement('div');
-      loading.innerHTML = '<div class="bio-properties-panel-configuration-chooser-loading"></div>';
-      const empty = document.createElement('div');
-
-      expect(isConfigurationChooserEdited(selected)).to.be.true;
-      expect(isConfigurationChooserEdited(missing)).to.be.true;
-      expect(isConfigurationChooserEdited(loading)).to.be.true;
-      expect(isConfigurationChooserEdited(empty)).to.be.false;
-    });
-
-  });
-
   let container;
 
   beforeEach(function() {
@@ -1139,6 +1119,30 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
       expect(zeebeProperty.$attrs).to.eql({});
     }));
+
+  });
+
+
+  describe('configuration edited state', function() {
+
+    it('should treat every bound configuration state as edited', function() {
+
+      const selected = document.createElement('div');
+      selected.innerHTML = '<div data-configuration-state="selected"></div>';
+      const missing = document.createElement('div');
+      missing.innerHTML = '<div data-configuration-state="missing"></div>';
+      const loading = document.createElement('div');
+      loading.innerHTML = '<div data-configuration-state="loading"></div>';
+      const placeholder = document.createElement('div');
+      placeholder.innerHTML = '<div data-configuration-state="placeholder"></div>';
+      const empty = document.createElement('div');
+
+      expect(isConfigurationChooserEdited(selected)).to.be.true;
+      expect(isConfigurationChooserEdited(missing)).to.be.true;
+      expect(isConfigurationChooserEdited(loading)).to.be.true;
+      expect(isConfigurationChooserEdited(placeholder)).to.be.false;
+      expect(isConfigurationChooserEdited(empty)).to.be.false;
+    });
 
   });
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1199,13 +1199,13 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(domQuery('.bio-properties-panel-label', labeledEntry).textContent).to.equal('Destination AWS credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', labeledEntry).textContent).to.equal('Choose destination AWS credential');
+      expect(getConfigurationPlaceholder(labeledEntry).textContent).to.equal('Choose destination AWS credential');
       expect(domQuery('.bio-properties-panel-label', fallbackEntry).textContent).to.equal('AWS Credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry).textContent).to.equal('Choose AWS Credential');
+      expect(getConfigurationPlaceholder(fallbackEntry).textContent).to.equal('Choose AWS Credential');
 
       // when
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry));
+        fireEvent.click(getConfigurationPlaceholder(fallbackEntry));
       });
 
       // then
@@ -1250,7 +1250,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      expect(domQuery('.bio-properties-panel-configuration-chooser-missing', fallbackEntry).textContent).to.contain('AWS Production');
+      expect(getConfigurationMissing(fallbackEntry).textContent).to.contain('AWS Production');
 
       // when
       await act(() => {
@@ -1272,7 +1272,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      const typeMismatch = domQuery('.bio-properties-panel-configuration-chooser-missing', fallbackEntry);
+      const typeMismatch = getConfigurationMissing(fallbackEntry);
 
       expect(typeMismatch.textContent).to.contain('AWS Production');
       expect(typeMismatch.textContent).to.contain('Incompatible configuration type');
@@ -1328,7 +1328,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(domQuery('.bio-properties-panel-label', entry).textContent).to.equal('AWS Credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry).textContent).to.equal('Choose AWS Credential');
+      expect(getConfigurationPlaceholder(entry).textContent).to.equal('Choose AWS Credential');
     }));
 
 
@@ -1359,12 +1359,12 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
             inputEntry = findEntry('custom-entry-configuration-metadata-cleanup-1', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', propertyEntry));
+        fireEvent.click(getConfigurationPlaceholder(propertyEntry));
       });
       clickConfigurationOption(propertyEntry, 'Slack Production');
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', inputEntry));
+        fireEvent.click(getConfigurationPlaceholder(inputEntry));
       });
       clickConfigurationOption(inputEntry, 'Slack Production');
 
@@ -1711,12 +1711,12 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry(CONFIGURATION_ENTRY_ID, container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+        fireEvent.click(getConfigurationPlaceholder(entry));
       });
 
       // when
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+        fireEvent.click(getConfigurationRow(entry));
       });
 
       // then
@@ -1787,7 +1787,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+            placeholder = getConfigurationPlaceholder(entry);
 
       expect(placeholder.textContent).to.equal('Choose configuration');
 
@@ -1797,7 +1797,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       await waitFor(() => {
-        expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
+        expect(getConfigurationRow(container)).to.exist;
       });
 
       fireEvent.keyDown(getConfigurationOption(container, 'Slack Production'), {
@@ -1817,12 +1817,12 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // when
-      fireEvent.keyDown(domQuery('.bio-properties-panel-configuration-chooser-selected', entry), {
+      fireEvent.keyDown(getConfigurationSelected(entry), {
         key: 'Enter'
       });
 
       // then
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.exist;
+      expect(getConfigurationPopover(entry)).to.exist;
 
     }));
 
@@ -1867,14 +1867,14 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-input-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+            placeholder = getConfigurationPlaceholder(entry);
 
       await act(() => {
         fireEvent.click(placeholder);
       });
 
       await waitFor(() => {
-        expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
+        expect(getConfigurationRow(container)).to.exist;
       });
 
       clickConfigurationOption(container, 'Slack Production');
@@ -1944,7 +1944,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+            placeholder = getConfigurationPlaceholder(entry);
 
       await act(() => {
         fireEvent.click(placeholder);
@@ -1960,17 +1960,17 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       await waitFor(() => {
-        expect(domQuery('.bio-properties-panel-configuration-chooser-selected', entry)).to.exist;
+        expect(getConfigurationSelected(entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-selected--offline', entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-logo', entry).getAttribute('src')).to.equal('data:image/svg+xml;base64,offline-icon');
         expect(domQuery('.bio-properties-panel-configuration-chooser-subtitle', entry).textContent).to.equal('No cluster selected');
-        expect(domQuery('.bio-properties-panel-configuration-chooser-missing', entry)).not.to.exist;
+        expect(getConfigurationMissing(entry)).not.to.exist;
       });
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-selected', entry));
+      fireEvent.click(getConfigurationSelected(entry));
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
-      expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).not.to.exist;
+      expect(getConfigurationPopover(entry)).not.to.exist;
+      expect(getConfigurationCreate(entry)).not.to.exist;
 
       // when
       openConfigurationMenu(entry);
@@ -2024,7 +2024,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry('custom-entry-configuration-property-0', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+        fireEvent.click(getConfigurationPlaceholder(entry));
       });
       clickConfigurationOption(entry, 'Slack Production');
 
@@ -2090,13 +2090,13 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+            placeholder = getConfigurationPlaceholder(entry);
 
       await act(() => {
         fireEvent.click(placeholder);
       });
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.exist;
+      expect(getConfigurationPopover(entry)).to.exist;
 
       // when
       await act(() => {
@@ -2113,7 +2113,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-unavailable');
       expect(unavailable.getAttribute('role')).to.equal('status');
       expect(unavailable.textContent).to.equal('No cluster selected');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
+      expect(getConfigurationPopover(entry)).not.to.exist;
     }));
 
 
@@ -2151,7 +2151,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry),
+            placeholder = getConfigurationPlaceholder(entry),
             error = domQuery('.bio-properties-panel-configuration-chooser-unavailable--error', entry);
 
       // then
@@ -2217,7 +2217,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry('custom-entry-configuration-property-0', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+        fireEvent.click(getConfigurationPlaceholder(entry));
       });
       clickConfigurationOption(entry, 'Slack Production');
 
@@ -2235,7 +2235,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       openConfigurationMenu(entry);
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).to.exist;
+      expect(getConfigurationContextMenu(entry)).to.exist;
 
       // when - failed response
       await act(() => {
@@ -2255,11 +2255,11 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(error.textContent).to.contain('Slack Production');
       expect(error.textContent).to.contain('Could not load configurations');
       expect(entry.textContent).not.to.contain('Not found on cluster');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).not.to.exist;
+      expect(getConfigurationContextMenu(entry)).not.to.exist;
 
       fireEvent.click(error);
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
+      expect(getConfigurationPopover(entry)).not.to.exist;
 
       openConfigurationMenu(entry);
 
@@ -2303,14 +2303,14 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
-            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+            placeholder = getConfigurationPlaceholder(entry);
 
       // when
       await act(() => {
         fireEvent.click(placeholder);
       });
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).not.to.exist;
+      expect(getConfigurationCreate(entry)).not.to.exist;
 
       await act(() => {
         configurationInstances.setState({
@@ -2321,10 +2321,10 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       await waitFor(() => {
-        expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).to.exist;
+        expect(getConfigurationCreate(entry)).to.exist;
       });
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-create', entry));
+      fireEvent.click(getConfigurationCreate(entry));
 
       // then
       expect(createSpy).to.have.been.calledOnce;
@@ -2334,7 +2334,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(event.property).to.equal(property);
       expect(event.configurationTemplate).to.equal('io.camunda:slack-connection:1');
       expect(event.configurationTemplateVersion).to.equal(2);
-      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.not.exist;
+      expect(getConfigurationPopover(entry)).to.not.exist;
     }));
 
 
@@ -2491,7 +2491,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry('custom-entry-configuration-property-0', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+        fireEvent.click(getConfigurationPlaceholder(entry));
       });
       clickConfigurationOption(entry, 'Slack Production');
       openConfigurationMenu(entry);
@@ -2592,7 +2592,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry('custom-entry-configuration-property-0', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+        fireEvent.click(getConfigurationPlaceholder(entry));
       });
       clickConfigurationOption(entry, 'Slack Production');
 
@@ -2607,7 +2607,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         });
       });
 
-      const missing = domQuery('.bio-properties-panel-configuration-chooser-missing', entry);
+      const missing = getConfigurationMissing(entry);
 
       expect(missing).to.exist;
       expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
@@ -2616,7 +2616,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         key: 'Enter'
       });
 
-      const rows = domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry);
+      const rows = getConfigurationRows(entry);
 
       expect(rows).to.have.length(1);
       expect(rows[0].textContent).to.contain('Slack Development');
@@ -5314,6 +5314,43 @@ function getConfigurationMenuItem(entry, label) {
 
 function openConfigurationMenu(entry) {
   fireEvent.click(within(entry).getByTitle('More actions'));
+}
+
+
+function getConfigurationPlaceholder(entry) {
+  const placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+  expect(placeholder, 'configuration chooser placeholder').to.exist;
+
+  return placeholder;
+}
+
+function getConfigurationPopover(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-popover', entry);
+}
+
+function getConfigurationRow(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry);
+}
+
+function getConfigurationRows(entry) {
+  return domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry);
+}
+
+function getConfigurationCreate(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-create', entry);
+}
+
+function getConfigurationSelected(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-selected', entry);
+}
+
+function getConfigurationMissing(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-missing', entry);
+}
+
+function getConfigurationContextMenu(entry) {
+  return domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry);
 }
 
 function expectSelected(id) {


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> Stacked on top of #263 as a follow-up.

Makes the configuration chooser fully keyboard accessible and cleans up the internal structure:

<img width="909" height="556" alt="capture GfxsnU_optimized" src="https://github.com/user-attachments/assets/49292a19-79a7-407c-a976-e286c1b49868" />

### What's inside

- **Popover accessibility:** the options popover now follows the [collapsible listbox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-collapsible/) — `role="listbox"`/`role="option"` with `aria-activedescendant` roving, ArrowUp/Down, Home/End, Enter/Space and Escape, and focus returning to the trigger on close.
- **Actions menu accessibility:** the `…` menu follows the [menu button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/) — `role="menu"` with roving `tabindex`, `ArrowUp` opening onto the last item, and dismissal on Escape / focus-out.
- **Composability:** the shared popup, list-navigation and focus-out behaviour is extracted into reusable hooks, the repeated card markup into a `ConfigurationCard` shell, and the mirrored instance state into a single hook.
- **A fix for #263** — re-selecting the currently wired configuration instance is a *noop*, it does not *unset* the current instance.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)