### PR TITLE
chore(loader): emit template warnings from the base loader

### DIFF
--- a/src/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/cloud-element-templates/ElementTemplatesLoader.js
@@ -19,28 +19,6 @@ export default class ElementTemplatesLoader extends TemplatesLoader {
   _createValidator() {
     return new Validator(this._moddle);
   }
-
-  setTemplates(templates) {
-    const elementTemplates = this._elementTemplates;
-
-    const validator = this._createValidator().addAll(templates);
-
-    elementTemplates.set(validator.getValidTemplates());
-
-    const errors = validator.getErrors().filter(
-      (error) => !this._isIncompatibleTemplateError(error)
-    );
-
-    if (errors.length) {
-      this._templateErrors(errors);
-    }
-
-    const warnings = validator.getWarnings();
-
-    if (warnings.length) {
-      elementTemplates._fire('warnings', { warnings });
-    }
-  }
 }
 
 ElementTemplatesLoader.$inject = [

--- a/src/cloud-element-templates/Validator.js
+++ b/src/cloud-element-templates/Validator.js
@@ -20,15 +20,10 @@ const SUPPORTED_SCHEMA_PACKAGE = getTemplateSchemaPackage();
  * A Camunda Cloud element template validator.
  */
 export class Validator extends BaseValidator {
-  constructor(moddle) {
-    super(moddle);
-
-    this._warnings = [];
-  }
 
   /**
-  * Collect warnings for conflicting configuration template definitions before
-  * validating individual element templates.
+   * Collect warnings for conflicting configuration template definitions before
+   * validating individual element templates.
    *
    * @param {TemplateDescriptor[]} templates
    * @returns {Validator}
@@ -183,15 +178,6 @@ export class Validator extends BaseValidator {
 
   isSchemaValid(schema) {
     return schema && schema.includes(SUPPORTED_SCHEMA_PACKAGE);
-  }
-
-  /**
-   * Get non-blocking validation warnings.
-   *
-   * @returns {Error[]}
-   */
-  getWarnings() {
-    return this._warnings;
   }
 }
 

--- a/src/element-templates/ElementTemplatesLoader.js
+++ b/src/element-templates/ElementTemplatesLoader.js
@@ -95,6 +95,12 @@ export default class ElementTemplatesLoader {
     if (errors.length) {
       this._templateErrors(errors);
     }
+
+    const warnings = validator.getWarnings();
+
+    if (warnings.length) {
+      this._templateWarnings(warnings);
+    }
   }
 
   /**
@@ -123,6 +129,12 @@ export default class ElementTemplatesLoader {
   _templateErrors(errors) {
     this._elementTemplates._fire('errors', {
       errors: errors
+    });
+  }
+
+  _templateWarnings(warnings) {
+    this._elementTemplates._fire('warnings', {
+      warnings: warnings
     });
   }
 }

--- a/src/element-templates/Validator.js
+++ b/src/element-templates/Validator.js
@@ -29,6 +29,7 @@ export class Validator {
 
     this._validTemplates = [];
     this._errors = [];
+    this._warnings = [];
     this._moddle = moddle;
   }
 
@@ -271,6 +272,15 @@ export class Validator {
 
   getValidTemplates() {
     return this._validTemplates;
+  }
+
+  /**
+   * Get non-blocking validation warnings.
+   *
+   * @return {Error[]}
+   */
+  getWarnings() {
+    return this._warnings;
   }
 }
 


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> Stacked on top of #263.

Follow-up to the review of #263: the cloud `ElementTemplatesLoader` re-implemented the whole `setTemplates` method just to add the `warnings` event, duplicating the base loader's valid-template registration, error reporting, and incompatible-template filtering. 

This PR removes the near-verbatim `setTemplates` duplication between the two loaders so error handling and incompatible-template filtering can no longer diverge, while keeping warnings a cloud-only concern via the validator (base validators simply report no warnings).

### Tests

Pure refactoring, changes covered via existing (cloud) tests.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)