### PR TITLE
chore: replace select Remove action with a placeholder item

### DIFF
--- a/CONNECTIONS_DESIGN_README.md
+++ b/CONNECTIONS_DESIGN_README.md
@@ -1,0 +1,330 @@
+# Configuration Chooser Prototype
+
+Properties-panel picker for reusable configuration instances. Stores selection as a FEEL expression and cached metadata on `zeebe:input` or `zeebe:property`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  API["Cluster API"] -->|instances| Host["Host application"]
+  Host -->|updates| Registry["ConfigurationInstances"]
+  Registry -->|compatible instances| Chooser["Configuration chooser"]
+  Template["Element template<br/>template ID + minimum version"] --> Chooser
+  Chooser -->|writes selection + cached metadata| BPMN["BPMN XML<br/>zeebe:input / zeebe:property"]
+```
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ConfigurationProperty
+    participant ConfigurationInstances
+    participant CommandStack
+
+    User->>ConfigurationProperty: clicks placeholder
+    ConfigurationProperty->>ConfigurationInstances: getSelectableByConfigurationTemplate(id, minVersion)
+    ConfigurationInstances-->>ConfigurationProperty: compatible instances[]
+    ConfigurationProperty->>User: shows popover with rows
+    User->>ConfigurationProperty: selects instance
+    ConfigurationProperty->>CommandStack: set source/value = "=camunda.vars.env.<name>"
+    ConfigurationProperty->>CommandStack: stamp modelerConfigurationTemplate, modelerConfigurationName
+```
+
+## Bootstrap & Extraction Flow
+
+```mermaid
+sequenceDiagram
+    participant Host as Host App (Web Modeler)
+    participant ETL as ElementTemplatesLoader
+    participant ET as ElementTemplates
+    participant CT as ConfigurationTemplates
+
+    Host->>ETL: provide templates JSON
+    ETL->>ET: elementTemplates.set(valid templates)
+    ET->>ET: index by id/version
+    ET-->>CT: fires elementTemplates.changed
+    CT->>CT: _extract() — collects configurationTemplates from all ETs
+    CT-->>CT: fires configurationTemplates.changed
+```
+
+`ElementTemplates.set()` is the trigger. It fires `elementTemplates.changed`, which `ConfigurationTemplates` listens to. No manual wiring needed — the core module registers `ConfigurationTemplates` in `__init__` so it subscribes on bootstrap.
+
+## Configuration Instances Update Flow
+
+```mermaid
+sequenceDiagram
+    participant Host as Host App (Web Modeler)
+    participant ClusterAPI as Cluster API
+    participant CI as ConfigurationInstances
+    participant CP as ConfigurationProperty
+
+    Host->>CI: setState({ available: true, loading: true, permissions: none })
+    CI-->>CP: fires configurationInstances.changed
+    Host->>ClusterAPI: fetch selectable instances and permissions
+    ClusterAPI-->>Host: selectableInstances[], permissions
+    Host->>CI: setState({ selectableInstances, permissions, loading: false, available: true })
+    CI-->>CP: fires configurationInstances.changed
+    CP->>CP: re-render with host-provided data
+```
+
+### Host App Setup
+
+```js
+const configurationInstances = modeler.get('configurationInstances');
+
+async function refreshConfigurations() {
+  configurationInstances.setState({
+    available: true,
+    loading: true,
+    error: false,
+    permissions: {
+      create: false,
+      update: false
+    }
+  });
+
+  try {
+    const [ response, permissions ] = await Promise.all([
+      fetch(`/clusters/${clusterId}/variables?kind=CREDENTIAL`),
+      getConfigurationPermissions(clusterId)
+    ]);
+    const { items } = await response.json();
+
+    configurationInstances.setState({
+      selectableInstances: items,
+      loading: false,
+      error: false,
+      available: true,
+      permissions
+    });
+  } catch (error) {
+    configurationInstances.setState({
+      selectableInstances: [],
+      loading: false,
+      error: true,
+      available: true,
+      permissions: {
+        create: false,
+        update: false
+      }
+    });
+    throw error;
+  }
+}
+
+function clearUnavailableConfigurations() {
+  configurationInstances.setState({
+    selectableInstances: [],
+    loading: false,
+    error: false,
+    available: false,
+    unavailableMessage: 'No cluster selected'
+  });
+}
+```
+
+The host owns fetching, caching, refresh timing, errors, availability, access-token handling, unavailable-state copy, and mapping the cluster authorization response to `{ create, update }`. It passes the compatible cluster-variable search result `items` as `selectableInstances` without flattening their `metadata`. `ConfigurationInstances` stores the latest host-provided selectable configurations plus loading, error, availability, and permission state, filters template-derived configurations using the presence of `metadata.kind`, `metadata.configurationTemplate`, and `metadata.configurationTemplateVersion`, and emits `configurationInstances.changed` after every state update. Permissions default to `false`; an open `c8run` host explicitly supplies `{ create: true, update: true }`. When configurations are unavailable, the host clears the list, sets `available: false`, and provides `unavailableMessage`; the registry clears errors and permissions and the chooser shows a cached selection without claiming it is missing. A failed fetch sets `error: true`, clears selectable configurations and permissions, and shows "Could not load configurations": on an unbound property, as inline status beneath the disabled chooser; on a bound property, as its configuration card. Selection and cluster-backed management actions remain unavailable until a successful refresh clears the error; removing the local BPMN binding remains available.
+
+### Chooser States
+
+Registry-level states are shown beneath an unbound chooser; binding-level states are shown in its configuration card.
+
+| State | Condition | Representation |
+| --- | --- | --- |
+| Ready | No binding; configurations are available | Enabled "Choose configuration" placeholder |
+| Available choices | Chooser is open with compatible instances | Popover listing compatible configurations |
+| No compatible choices | Chooser is open; loaded list is empty | "No compatible configurations are available in the connected cluster" |
+| Loading | Refresh in progress | Loading indicator in the popover; an unresolved binding shows "Loading configuration" |
+| Unavailable | No cluster or integration is unavailable | Disabled placeholder plus host-provided unavailable message; a bound configuration remains visible offline |
+| Fetch error | Configuration fetch failed | Disabled placeholder plus "Could not load configurations"; a bound configuration shows the same error in its card |
+| Selected | Binding resolves to a compatible instance | Configuration card with display and variable names |
+| Missing | Bound instance is absent after a successful fetch | Warning card with "Not found on cluster" |
+| Incompatible type | Bound instance has a different template ID | Warning card with "Incompatible configuration type" |
+| Version too old | Bound instance is below the required version | Warning card with actual and required versions; **Upgrade** is available with update permission |
+
+The chooser exposes **Create** when the host grants create permission, **Edit** for a compatible selected instance when it grants update permission, and always allows removing the local BPMN binding.
+
+For configurations already referenced by BPMN, the host fetches records directly by cluster-variable name and provides them via `setReferencedInstances()` (or `setState({ referencedInstances })`). These records are used by `getReferencedInstanceByName()` only and are intentionally separate from the selectable list.
+
+### Host Integration Pattern: Selectable + Referenced Configurations
+
+Use two data channels:
+
+1. `selectableInstances` from the compatible search query
+2. `referencedInstances` from direct by-name fetches for currently bound BPMN references
+
+```js
+async function refreshConfigurationRegistry(clusterId, boundNames) {
+  configurationInstances.setState({
+    loading: true,
+    error: false,
+    available: true,
+    permissions: {
+      create: false,
+      update: false
+    }
+  });
+
+  try {
+    const [ listResponse, permissions, referencedInstances ] = await Promise.all([
+      // Compatible chooser rows only (kind/template/floor filtered)
+      fetch(`/clusters/${clusterId}/variables/search?kind=CREDENTIAL`),
+      getConfigurationPermissions(clusterId),
+      // Already-bound records by name (may be incompatible)
+      Promise.all(boundNames.map((name) => getClusterVariableByName(clusterId, name)))
+    ]);
+
+    const { items } = await listResponse.json();
+
+    configurationInstances.setState({
+      selectableInstances: items,
+      referencedInstances: referencedInstances.filter(Boolean),
+      loading: false,
+      error: false,
+      available: true,
+      permissions
+    });
+  } catch (error) {
+    configurationInstances.setState({
+      selectableInstances: [],
+      referencedInstances: [],
+      loading: false,
+      error: true,
+      available: true,
+      permissions: {
+        create: false,
+        update: false
+      }
+    });
+
+    throw error;
+  }
+}
+```
+
+This keeps the chooser list strictly compatible while still allowing `getReferencedInstanceByName()` to explain and act on a BPMN-referenced incompatible configuration (type mismatch or below-floor version).
+
+The chooser label resolves from the element-template property `label`, falling back to the referenced configuration template's required `name`. The resolved label provides context in the unselected state, for example "Choose AWS Credential". The empty state is generic: "No compatible configurations are available in the connected cluster". An incompatible bound instance retains its own display name as the title; a generic subtitle explains whether its configuration type or version is incompatible.
+
+Cached `modelerConfigurationTemplate` and `modelerConfigurationName` attributes exist only while the binding contains a configuration reference. Removing a selection clears both attributes; optional bindings are removed entirely, while non-optional bindings retain only their empty runtime value.
+
+### Create Configuration Event
+
+When the user clicks **Create configuration**, the chooser fires `configuration.create` on the modeler's event bus. The host application handles the event and opens its configuration editor.
+
+```js
+eventBus.on('configuration.create', ({
+  element,
+  property,
+  configurationTemplate,
+  configurationTemplateVersion
+}) => {
+  // Open a creation modal for the requested template.
+});
+```
+
+After a successful write, the host fires `configuration.created` with the original `element` and `property` plus the created API-shaped `instance`:
+
+```js
+eventBus.fire('configuration.created', {
+  element,
+  property,
+  instance
+});
+```
+
+The originating chooser verifies the instance kind, template ID, and version floor, then writes its FEEL reference and cached metadata into BPMN. Unrelated or incompatible completion events are ignored. The host still refreshes `ConfigurationInstances` so the created instance is available in the selectable list; selection itself does not wait for that refresh.
+
+The chooser exposes instance selection when a cluster is selected and creation when the host additionally grants `permissions.create`. Offline, a cached selection can only be removed.
+
+### Edit and Upgrade Configuration Events
+
+With `permissions.update`, the context menu exposes **Edit** for a compatible selected instance and fires `configuration.edit`. For a resolved bound instance below the chooser's version floor, it exposes **Upgrade** and fires `configuration.upgrade`. Both events carry `{ element, property, instance, configurationTemplate, configurationTemplateVersion }`; the host opens the appropriate editor, fetches the full value, writes the update, and refreshes the registry.
+
+The compatible search response does not include a BPMN-referenced configuration with the wrong configuration template or a version below the floor. The host therefore fetches it directly by cluster-variable name and passes that record through `setReferencedInstances()` (or `setState({ referencedInstances })`). `getSelectableByConfigurationTemplate()` continues to exclude it from the selectable list, while `getReferencedInstanceByName()` lets the chooser identify and explain the incompatible binding. A wrong-template instance shows "Incompatible configuration type" and cannot be upgraded; a matching instance below the floor shows its version mismatch and offers Upgrade when permitted. If the host has not fetched the referenced configuration, the chooser retains the generic missing state and does not offer Upgrade.
+
+## Element Template Schema
+
+```json
+{
+  "configurationTemplates": [{
+    "id": "io.camunda:slack-connection:1",
+    "name": "Slack Connection",
+    "version": 2,
+    "kind": "CREDENTIAL",
+    "properties": [{ "label": "Slack API Token", "type": "String", "binding": { "type": "property", "name": "slackOauthToken" } }]
+  }],
+  "properties": [{
+    "type": "Configuration",
+    "label": "Slack connection",
+    "configurationTemplate": "io.camunda:slack-connection:1",
+    "configurationTemplateVersion": 2,
+    "binding": { "name": "configuration", "type": "zeebe:input" }
+  }]
+}
+```
+
+- `configurationTemplate` — filters instances by this ID
+- `configurationTemplateVersion` — minimum version floor; instances below are excluded
+- `configurationTemplates` — embedded schema defining the JSON object stored server-side (Hub renders it; Modeler only uses `id`/`version` for filtering)
+
+`Configuration` properties require a non-empty `configurationTemplate` and a `zeebe:input` or `zeebe:property` binding with a name. Embedded configuration templates require non-empty `id`, `name`, and `kind` fields plus a `properties` array. Invalid element templates are reported and not registered.
+
+## BPMN XML Output
+
+For an outbound connector, the chooser writes a `zeebe:input`:
+
+```xml
+<zeebe:input source="=camunda.vars.env.slackProduction" target="configuration"
+             modelerConfigurationTemplate="io.camunda:slack-connection:1"
+             modelerConfigurationName="Slack Production" />
+```
+
+For an inbound connector, it writes a `zeebe:property`:
+
+```xml
+<zeebe:property name="configuration" value="=camunda.vars.env.slackProduction"
+                modelerConfigurationTemplate="io.camunda:slack-connection:1"
+                modelerConfigurationName="Slack Production" />
+```
+
+Both binding types carry the same modeler metadata:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `source` / `value` | Runtime FEEL reference to cluster variable (`source` on `zeebe:input`, `value` on `zeebe:property`) |
+| `modelerConfigurationTemplate` | Design-time: chooser filter + validation |
+| `modelerConfigurationName` | Design-time: offline display (cached) |
+
+Engine ignores `modeler*` attributes.
+
+## Key Implementation Details
+
+**Dispatcher** routes to `ConfigurationProperty` when `type === 'Configuration'` or `configurationTemplate` is present.
+
+**ConfigurationTemplates service** — automatically extracts `configurationTemplates` from all element templates on `elementTemplates.changed`. Provides `get(id, version?)`, `getAll()`, `getLatest()`. Fires `configurationTemplates.changed`.
+
+**ConfigurationInstances service** — host-fed instance registry. The host calls `setLoading()`, `setSelectableInstances()`, `setReferencedInstances()`, or atomic `setState({ selectableInstances, referencedInstances, loading, error, available, unavailableMessage, permissions })`; the service fires `configurationInstances.changed` and exposes `getSelectableInstances()`, `getSelectableByConfigurationTemplate(id, minVersion)`, `getReferencedInstanceByName(name)`, `isLoading()`, `hasError()`, `isAvailable()`, `getUnavailableMessage()`, `canCreate()`, and `canUpdate()` for consumers. `referencedInstances` are used only for direct by-name lookups and never become selectable rows. When unavailable, the registry clears errors, permissions, and referenced instances.
+
+**Moddle extension** — `modelerConfigurationTemplate` and `modelerConfigurationName` attributes on `zeebe:Input` and `zeebe:Property`. Lives upstream in [`zeebe-bpmn-moddle#configuration-template-support`](https://github.com/camunda/zeebe-bpmn-moddle/tree/configuration-template-support).
+
+**Cached name fallback** — while the host reports loading, reads `modelerConfigurationName` from the binding element to show the cached name with "Loading...". Once loading is false and the instance is absent, it shows "Not found on cluster".
+
+**ConfigurationProperty** — stamps `modelerConfigurationTemplate` and `modelerConfigurationName` after creating or updating either a `zeebe:Input` or `zeebe:Property` binding.
+
+## Files
+
+| Area | Path |
+|------|------|
+| Moddle | `zeebe-bpmn-moddle` (branch: `configuration-template-support`) |
+| Configuration Templates | `src/cloud-element-templates/core/ConfigurationTemplates.js` |
+| Configuration Instances | `src/cloud-element-templates/core/ConfigurationInstances.js` |
+| Core module | `src/cloud-element-templates/core/index.js` |
+| Component | `src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js` |
+| Dispatcher | `src/cloud-element-templates/properties-panel/properties/custom-properties/index.js` |
+| Setter | `src/cloud-element-templates/CreateHelper.js` |
+| Styles | `assets/element-templates.css` |
+| Fixture | `test/spec/cloud-element-templates/fixtures/connections-design.json` |
+| Tests | `test/spec/cloud-element-templates/ConfigurationTemplates.spec.js` |
+| Demo | `test/spec/Example.spec.js` |

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -155,10 +155,20 @@
   opacity: 0.5;
 }
 
-.bio-properties-panel-configuration-chooser-placeholder-plus {
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1;
+.bio-properties-panel-configuration-chooser-unavailable {
+  margin-top: 4px;
+  color: var(--color-grey-225-10-55, #7d8186);
+  font-size: 12px;
+}
+
+.bio-properties-panel-configuration-chooser-unavailable--error {
+  color: #a66b00;
+}
+
+.bio-properties-panel-configuration-chooser-create-icon {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
 }
 
 /* selected configuration card */
@@ -199,19 +209,11 @@
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
-.bio-properties-panel-configuration-chooser-loading-shimmer {
-  flex: 0 0 auto;
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: linear-gradient(90deg, #e6e8ea 25%, #f0f1f2 50%, #e6e8ea 75%);
-  background-size: 200% 100%;
-  animation: configuration-shimmer 1.5s infinite;
-}
-
-@keyframes configuration-shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+.bio-properties-panel-configuration-chooser-refreshing {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-grey-225-10-85, #e5e6e7);
 }
 
 /* missing configuration state */
@@ -241,12 +243,6 @@
   cursor: default;
 }
 
-.bio-properties-panel-configuration-chooser-missing-icon {
-  flex: 0 0 auto;
-  font-size: 18px;
-  line-height: 1;
-}
-
 .bio-properties-panel-configuration-chooser-missing .bio-properties-panel-configuration-chooser-subtitle {
   overflow: visible;
   overflow-wrap: anywhere;
@@ -274,6 +270,11 @@
   background-color: var(--color-grey-225-10-90, #e6e8ea);
   color: var(--color-grey-225-10-35, #4d5258);
   font-weight: 600;
+}
+
+.bio-properties-panel-configuration-chooser-logo--warning {
+  background-color: #fce4bc;
+  color: #a66b00;
 }
 
 /* text block */
@@ -339,20 +340,6 @@
   overflow: hidden;
 }
 
-.bio-properties-panel-configuration-chooser-refreshing {
-  display: block;
-  padding: 8px 12px;
-  font-weight: 400;
-  font-size: 10px;
-  color: var(--color-grey-225-10-55, #7d8186);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
 .bio-properties-panel-configuration-chooser-popover-list {
   margin: 0;
   padding: 0;
@@ -401,8 +388,12 @@
 
 .bio-properties-panel-configuration-chooser-empty {
   padding: 10px 12px;
-  color: var(--color-grey-225-10-55, #7d8186);
-  font-style: italic;
+}
+
+.bio-properties-panel-configuration-chooser-refreshing,
+.bio-properties-panel-configuration-chooser-empty {
+  color: var(--color-grey-225-10-45, #70757a);
+  font-size: 13px;
 }
 
 /* context menu (... actions) */

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -344,6 +344,8 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  max-height: 280px;
+  overflow-y: auto;
 }
 
 .bio-properties-panel-configuration-chooser-popover-row {

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -115,3 +115,333 @@
 .bio-properties-panel-template-incompatible-text {
   width: 216px;
 }
+
+/* configuration chooser */
+.bio-properties-panel-configuration-chooser {
+  position: relative;
+  margin: 2px 32px 6px 12px;
+  padding-bottom: 10px;
+}
+
+/* placeholder trigger (no selection) */
+.bio-properties-panel-configuration-chooser-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px dashed var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-white, #fff);
+  color: var(--color-grey-225-10-35, #4d5258);
+  font-size: 13px;
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-placeholder:hover:not(:disabled) {
+  border-color: var(--color-grey-225-10-55, #7d8186);
+  background-color: var(--color-grey-225-10-97, #f7f8f8);
+}
+
+.bio-properties-panel-configuration-chooser-placeholder:focus-visible {
+  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
+}
+
+.bio-properties-panel-configuration-chooser-placeholder:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.bio-properties-panel-configuration-chooser-placeholder-plus {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+/* selected configuration card */
+.bio-properties-panel-configuration-chooser-selected {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-white, #fff);
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-selected:hover {
+  border-color: var(--color-blue-205-100-50, #1a75ff);
+  background-color: var(--color-blue-205-100-95, #eef4ff);
+}
+
+.bio-properties-panel-configuration-chooser-selected--offline,
+.bio-properties-panel-configuration-chooser-selected--offline:hover {
+  cursor: default;
+  border-color: var(--color-grey-225-10-75, #ccced0);
+  background-color: var(--color-white, #fff);
+}
+
+/* loading state */
+.bio-properties-panel-configuration-chooser-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-grey-225-10-97, #f7f8f8);
+}
+
+.bio-properties-panel-configuration-chooser-loading-shimmer {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #e6e8ea 25%, #f0f1f2 50%, #e6e8ea 75%);
+  background-size: 200% 100%;
+  animation: configuration-shimmer 1.5s infinite;
+}
+
+@keyframes configuration-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* missing configuration state */
+.bio-properties-panel-configuration-chooser-missing {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid #f0ad4e;
+  border-radius: 4px;
+  background-color: #fff8ed;
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-missing:hover {
+  border-color: #e09730;
+  background-color: #fef3e0;
+}
+
+.bio-properties-panel-configuration-chooser-missing:focus-visible {
+  box-shadow: 0 0 0 2px #f0ad4e;
+}
+
+.bio-properties-panel-configuration-chooser-error {
+  cursor: default;
+}
+
+.bio-properties-panel-configuration-chooser-missing-icon {
+  flex: 0 0 auto;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.bio-properties-panel-configuration-chooser-missing .bio-properties-panel-configuration-chooser-subtitle {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.bio-properties-panel-configuration-chooser-selected:focus-visible {
+  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
+}
+
+/* logo */
+.bio-properties-panel-configuration-chooser-logo {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  object-fit: contain;
+}
+
+.bio-properties-panel-configuration-chooser-logo--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-grey-225-10-90, #e6e8ea);
+  color: var(--color-grey-225-10-35, #4d5258);
+  font-weight: 600;
+}
+
+/* text block */
+.bio-properties-panel-configuration-chooser-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.bio-properties-panel-configuration-chooser-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bio-properties-panel-configuration-chooser-subtitle {
+  font-size: 12px;
+  color: var(--color-grey-225-10-55, #7d8186);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bio-properties-panel-configuration-chooser-varname {
+  font-family: monospace;
+}
+
+/* menu (...) button */
+.bio-properties-panel-configuration-chooser-menu {
+  flex: 0 0 auto;
+  padding: 0 6px;
+  border: none;
+  background: none;
+  color: var(--color-grey-225-10-35, #4d5258);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.bio-properties-panel-configuration-chooser-menu:hover:not(:disabled) {
+  background-color: var(--color-grey-225-10-90, #e6e8ea);
+}
+
+.bio-properties-panel-configuration-chooser-menu:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* popover */
+.bio-properties-panel-configuration-chooser-popover {
+  position: absolute;
+  z-index: 100;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-white, #fff);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.bio-properties-panel-configuration-chooser-refreshing {
+  display: block;
+  padding: 8px 12px;
+  font-weight: 400;
+  font-size: 10px;
+  color: var(--color-grey-225-10-55, #7d8186);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.bio-properties-panel-configuration-chooser-popover-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bio-properties-panel-configuration-chooser-popover-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-popover-row:hover,
+.bio-properties-panel-configuration-chooser-popover-row:focus-visible {
+  background-color: var(--color-blue-205-100-95, #eef4ff);
+}
+
+.bio-properties-panel-configuration-chooser-popover-row--selected {
+  background-color: var(--color-blue-205-100-95, #eef4ff);
+}
+
+/* create configuration footer */
+.bio-properties-panel-configuration-chooser-create {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-top: 1px solid var(--color-grey-225-10-90, #e6e8ea);
+  background: none;
+  color: var(--color-blue-205-100-50, #1a75ff);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-create:hover,
+.bio-properties-panel-configuration-chooser-create:focus-visible {
+  background-color: var(--color-blue-205-100-95, #eef4ff);
+}
+
+.bio-properties-panel-configuration-chooser-empty {
+  padding: 10px 12px;
+  color: var(--color-grey-225-10-55, #7d8186);
+  font-style: italic;
+}
+
+/* context menu (... actions) */
+.bio-properties-panel-configuration-chooser-context-menu {
+  position: absolute;
+  z-index: 11;
+  right: 0;
+  margin-top: 4px;
+  min-width: 150px;
+  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-white, #fff);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.bio-properties-panel-configuration-chooser-context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: var(--color-grey-225-10-15, #1a1d20);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+}
+
+.bio-properties-panel-configuration-chooser-context-menu-item:hover,
+.bio-properties-panel-configuration-chooser-context-menu-item:focus-visible {
+  background-color: var(--color-grey-225-10-97, #f7f8f8);
+}
+
+.bio-properties-panel-configuration-chooser-context-menu-item--danger {
+  color: var(--color-red-360-100-45, #e60000);
+}
+
+.bio-properties-panel-configuration-chooser-context-menu-item--danger:hover,
+.bio-properties-panel-configuration-chooser-context-menu-item--danger:focus-visible {
+  background-color: #fff0f0;
+}

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -366,6 +366,15 @@
   background-color: var(--color-blue-205-100-95, #eef4ff);
 }
 
+.bio-properties-panel-configuration-chooser-popover-row--empty {
+  border-bottom: 1px solid var(--color-grey-225-10-90, #e6e8ea);
+}
+
+.bio-properties-panel-configuration-chooser-logo--empty {
+  border: 1px dashed var(--color-grey-225-10-75, #ccced0);
+  border-radius: 6px;
+}
+
 /* create configuration footer */
 .bio-properties-panel-configuration-chooser-create {
   display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@bpmn-io/element-template-chooser": "^3.0.0",
         "@bpmn-io/element-template-icon-renderer": "^1.0.0",
         "@bpmn-io/properties-panel": "^3.48.0",
+        "@camunda/connectors-element-templates": "1.0.22",
         "@camunda/linting": "^3.54.0",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-babel": "^7.1.0",
@@ -729,6 +730,13 @@
       "integrity": "sha512-G3jH5MRvF/3L9/h6fY1zn+kwgYgH7APa84p34jajSG9IVWPCIGpttVGyRTrnbsCI76C2QdPbR2AvOm3RaLzUJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@camunda/connectors-element-templates": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@camunda/connectors-element-templates/-/connectors-element-templates-1.0.22.tgz",
+      "integrity": "sha512-nZg4TSrF8eyfxYeIPX9CJOQZlJqs5Ya3jVSihOyQcvcaXyq2BfHw1I0i4sfoufAmFTFfB40qEagbuVKCgoNoXQ==",
+      "dev": true,
+      "license": "Camunda License 1.0"
     },
     "node_modules/@camunda/linting": {
       "version": "3.54.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@bpmn-io/element-template-chooser": "^3.0.0",
     "@bpmn-io/element-template-icon-renderer": "^1.0.0",
     "@bpmn-io/properties-panel": "^3.48.0",
+    "@camunda/connectors-element-templates": "1.0.22",
     "@camunda/linting": "^3.54.0",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-babel": "^7.1.0",

--- a/src/cloud-element-templates/CreateHelper.js
+++ b/src/cloud-element-templates/CreateHelper.js
@@ -12,17 +12,19 @@ import { createElement } from '../utils/ElementUtil';
  * @param {String} value
  * @param {BpmnFactory} bpmnFactory
  * @param {ModdleElement} ioMapping
+ * @param {Object} additionalProperties
  *
  * @return {ModdleElement}
  */
-export function createInputParameter(binding, value, bpmnFactory, ioMapping) {
+export function createInputParameter(binding, value, bpmnFactory, ioMapping, additionalProperties = {}) {
   const {
     name
   } = binding;
 
   return createElement('zeebe:Input', {
     source: value,
-    target: name
+    target: name,
+    ...additionalProperties
   }, ioMapping, bpmnFactory);
 }
 
@@ -33,6 +35,7 @@ export function createInputParameter(binding, value, bpmnFactory, ioMapping) {
  * @param {PropertyBinding} binding
  * @param {String} value
  * @param {BpmnFactory} bpmnFactory
+ * @param {Object} additionalProperties
  * @param {ModdleElement} ioMapping
  *
  * @return {ModdleElement}
@@ -90,12 +93,13 @@ export function createTaskDefinition(attrs = {}, bpmnFactory) {
  *
  * @return {ModdleElement}
  */
-export function createZeebeProperty(binding, value = '', bpmnFactory) {
+export function createZeebeProperty(binding, value = '', bpmnFactory, additionalProperties = {}) {
   const { name } = binding;
 
   return bpmnFactory.create('zeebe:Property', {
     name,
-    value
+    value,
+    ...additionalProperties
   });
 }
 

--- a/src/cloud-element-templates/ElementTemplatesLoader.js
+++ b/src/cloud-element-templates/ElementTemplatesLoader.js
@@ -19,6 +19,28 @@ export default class ElementTemplatesLoader extends TemplatesLoader {
   _createValidator() {
     return new Validator(this._moddle);
   }
+
+  setTemplates(templates) {
+    const elementTemplates = this._elementTemplates;
+
+    const validator = this._createValidator().addAll(templates);
+
+    elementTemplates.set(validator.getValidTemplates());
+
+    const errors = validator.getErrors().filter(
+      (error) => !this._isIncompatibleTemplateError(error)
+    );
+
+    if (errors.length) {
+      this._templateErrors(errors);
+    }
+
+    const warnings = validator.getWarnings();
+
+    if (warnings.length) {
+      elementTemplates._fire('warnings', { warnings });
+    }
+  }
 }
 
 ElementTemplatesLoader.$inject = [

--- a/src/cloud-element-templates/Validator.js
+++ b/src/cloud-element-templates/Validator.js
@@ -22,6 +22,23 @@ const SUPPORTED_SCHEMA_PACKAGE = getTemplateSchemaPackage();
 export class Validator extends BaseValidator {
   constructor(moddle) {
     super(moddle);
+
+    this._warnings = [];
+  }
+
+  /**
+  * Collect warnings for conflicting configuration template definitions before
+  * validating individual element templates.
+   *
+   * @param {TemplateDescriptor[]} templates
+   * @returns {Validator}
+   */
+  addAll(templates) {
+    const result = super.addAll(templates);
+
+    this._warnings = getConfigurationTemplateConflictWarnings(this.getValidTemplates());
+
+    return result;
   }
 
   /**
@@ -76,7 +93,14 @@ export class Validator extends BaseValidator {
       return elementTypeError;
     }
 
-    // (5) JSON schema compliance
+    // (5) configuration validation
+    const configurationError = this._validateConfiguration(template);
+
+    if (configurationError) {
+      return configurationError;
+    }
+
+    // (6) JSON schema compliance
     const schemaValidationResult = validateAgainstSchema(template);
 
     const {
@@ -92,7 +116,7 @@ export class Validator extends BaseValidator {
       return new Error('invalid template');
     }
 
-    // (6) engines validation
+    // (7) engines validation
     const enginesError = this._validateEngines(template);
 
     if (enginesError) {
@@ -102,7 +126,144 @@ export class Validator extends BaseValidator {
     return null;
   }
 
+  _validateConfiguration(template) {
+    const {
+      configurationTemplates,
+      properties = []
+    } = template;
+
+    if (configurationTemplates !== undefined) {
+      if (!Array.isArray(configurationTemplates)) {
+        return this._logError('configurationTemplates must be an array', template);
+      }
+
+      for (const configurationTemplate of configurationTemplates) {
+        if (!configurationTemplate || typeof configurationTemplate !== 'object') {
+          return this._logError('configurationTemplates entries must be objects', template);
+        }
+
+        if (!isNonEmptyString(configurationTemplate.id)) {
+          return this._logError('configuration template id must be a non-empty string', template);
+        }
+
+        if (!isNonEmptyString(configurationTemplate.name)) {
+          return this._logError('configuration template name must be a non-empty string', template);
+        }
+
+        if (!isNonEmptyString(configurationTemplate.kind)) {
+          return this._logError('configuration template kind must be a non-empty string', template);
+        }
+
+        if (!Array.isArray(configurationTemplate.properties)) {
+          return this._logError('configuration template properties must be an array', template);
+        }
+      }
+    }
+
+    for (const property of properties) {
+      if (property?.type !== 'Configuration') {
+        continue;
+      }
+
+      if (!isNonEmptyString(property.configurationTemplate)) {
+        return this._logError('configuration property requires a configurationTemplate', template);
+      }
+
+      const { binding } = property;
+
+      if (!binding || ![ 'zeebe:input', 'zeebe:property' ].includes(binding.type)) {
+        return this._logError('configuration property binding must be zeebe:input or zeebe:property', template);
+      }
+
+      if (!isNonEmptyString(binding.name)) {
+        return this._logError('configuration property binding requires a name', template);
+      }
+    }
+  }
+
   isSchemaValid(schema) {
     return schema && schema.includes(SUPPORTED_SCHEMA_PACKAGE);
   }
+
+  /**
+   * Get non-blocking validation warnings.
+   *
+   * @returns {Error[]}
+   */
+  getWarnings() {
+    return this._warnings;
+  }
+}
+
+function getConfigurationTemplateConflictWarnings(templates) {
+  const definitionsByKey = new Map();
+  const warnings = [];
+
+  if (!Array.isArray(templates)) {
+    return warnings;
+  }
+
+  for (const template of templates) {
+    if (!Array.isArray(template?.configurationTemplates)) {
+      continue;
+    }
+
+    for (const configurationTemplate of template.configurationTemplates) {
+      const key = getConfigurationTemplateKey(configurationTemplate);
+
+      if (!key) {
+        continue;
+      }
+
+      const definition = JSON.stringify(canonicalize(configurationTemplate));
+      const existingDefinition = definitionsByKey.get(key);
+
+      if (existingDefinition && existingDefinition !== definition) {
+        const { id, version = 1 } = configurationTemplate;
+
+        warnings.push(createWarning(
+          `configuration template id <${ id }> and version <${ version }> conflicts with the first embedded definition and will be ignored`,
+          template
+        ));
+      } else {
+        definitionsByKey.set(key, definition);
+      }
+    }
+  }
+
+  return warnings;
+}
+
+function getConfigurationTemplateKey(configurationTemplate) {
+  if (!configurationTemplate || !configurationTemplate.id) {
+    return null;
+  }
+
+  return `${ configurationTemplate.id }@${ configurationTemplate.version ?? 1 }`;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map(key => [ key, canonicalize(value[key]) ])
+    );
+  }
+
+  return value;
+}
+
+function createWarning(message, template) {
+  return new Error(
+    `template(id: <${ template.id }>, name: <${ template.name }>): ${ message }`
+  );
 }

--- a/src/cloud-element-templates/core/ConfigurationInstances.js
+++ b/src/cloud-element-templates/core/ConfigurationInstances.js
@@ -1,0 +1,228 @@
+/**
+ * @typedef { {
+ *   name: string,
+ *   metadata: {
+ *     kind: string,
+ *     displayName?: string,
+ *     configurationTemplate: string,
+ *     configurationTemplateVersion?: number
+ *   },
+ *   icon?: string
+ * } } ConfigurationInstance
+ */
+
+/**
+ * @typedef { {
+ *   create?: boolean,
+ *   update?: boolean
+ * } } ConfigurationPermissions
+ */
+
+/**
+ * Registry of available configuration instances (cluster variables with
+ * `kind = CREDENTIAL`).
+ */
+export default class ConfigurationInstances {
+  constructor(eventBus) {
+    this._eventBus = eventBus;
+
+    /** @type {ConfigurationInstance[]} */
+    this._instances = [];
+
+    /** @type {boolean} */
+    this._loading = false;
+
+    /** @type {boolean} */
+    this._error = false;
+
+    /** @type {boolean} */
+    this._clusterSelected = false;
+
+    /** @type {{ create: boolean, update: boolean }} */
+    this._permissions = {
+      create: false,
+      update: false
+    };
+  }
+
+  /**
+   * Replace the set of available instances and notify listeners.
+   *
+   * @param {ConfigurationInstance[]} instances
+   */
+  setInstances(instances) {
+    this.setState({
+      instances,
+      error: false,
+      clusterSelected: true
+    });
+  }
+
+  /**
+   * Set whether the host is loading configuration instances.
+   *
+   * @param {boolean} loading
+   */
+  setLoading(loading) {
+    this.setState({
+      loading,
+      ...(loading ? { error: false } : {})
+    });
+  }
+
+  /**
+   * Update host-provided configuration instance state and notify listeners.
+   *
+  * @param {{ instances?: ConfigurationInstance[], loading?: boolean, error?: boolean, clusterSelected?: boolean, permissions?: ConfigurationPermissions }} state
+   */
+  setState(state) {
+    if ('instances' in state) {
+      this._instances = state.instances || [];
+    }
+
+    if ('loading' in state) {
+      this._loading = !!state.loading;
+    }
+
+    if ('error' in state) {
+      this._error = !!state.error;
+    }
+
+    if ('clusterSelected' in state) {
+      this._clusterSelected = !!state.clusterSelected;
+    }
+
+    if ('permissions' in state) {
+      const permissions = state.permissions || {};
+
+      this._permissions = {
+        create: !!permissions.create,
+        update: !!permissions.update
+      };
+    }
+
+    if (!this._clusterSelected) {
+      this._error = false;
+      this._permissions = {
+        create: false,
+        update: false
+      };
+    }
+
+    this._eventBus.fire('configurationInstances.changed', {
+      instances: this._instances,
+      loading: this._loading,
+      error: this._error,
+      clusterSelected: this._clusterSelected,
+      permissions: this._permissions
+    });
+  }
+
+  /**
+   * Whether the host is loading configuration instances.
+   *
+   * @returns {boolean}
+   */
+  isLoading() {
+    return this._loading;
+  }
+
+  /**
+   * Whether loading configuration instances failed.
+   *
+   * @returns {boolean}
+   */
+  hasError() {
+    return this._error;
+  }
+
+  /**
+   * Whether the host has selected a cluster whose configuration instances can
+   * be queried.
+   *
+   * @returns {boolean}
+   */
+  isClusterSelected() {
+    return this._clusterSelected;
+  }
+
+  /**
+   * Whether the current user may create configuration instances.
+   *
+   * @returns {boolean}
+   */
+  canCreate() {
+    return this._permissions.create;
+  }
+
+  /**
+   * Whether the current user may update configuration instances.
+   *
+   * @returns {boolean}
+   */
+  canUpdate() {
+    return this._permissions.update;
+  }
+
+  /**
+   * Get all available instances.
+   *
+   * @returns {ConfigurationInstance[]}
+   */
+  getAll() {
+    return this._instances;
+  }
+
+  /**
+   * Get an instance by its cluster-variable name.
+   *
+   * @param {string} name
+   * @returns {ConfigurationInstance|undefined}
+   */
+  getByName(name) {
+    return this._instances.find(instance => instance.name === name);
+  }
+
+  /**
+   * Whether an instance is compatible with the given template reference and version.
+   *
+   * @param {ConfigurationInstance} instance
+   * @param {string} configurationTemplate - configuration template ID
+   * @param {number} [minVersion] - minimum version floor (inclusive)
+   * @returns {boolean}
+   */
+  isCompatible(instance, configurationTemplate, minVersion) {
+    const {
+      kind,
+      configurationTemplate: instanceTemplate,
+      configurationTemplateVersion: instanceVersion
+    } = instance.metadata || {};
+
+    return kind === 'CREDENTIAL'
+      && instanceTemplate === configurationTemplate
+      && (minVersion == null || (instanceVersion != null && instanceVersion >= minVersion));
+  }
+
+  /**
+    * Get instances compatible with the given template reference and version.
+   *
+   * @param {string} configurationTemplate - configuration template ID
+   * @param {number} [minVersion] - minimum version floor (inclusive)
+   * @returns {ConfigurationInstance[]}
+   */
+  getByConfigurationTemplate(configurationTemplate, minVersion) {
+    const compatible = [];
+
+    for (const instance of this._instances) {
+      if (!this.isCompatible(instance, configurationTemplate, minVersion)) {
+        continue;
+      }
+
+      compatible.push(instance);
+    }
+
+    return compatible;
+  }
+}
+
+ConfigurationInstances.$inject = [ 'eventBus' ];

--- a/src/cloud-element-templates/core/ConfigurationInstances.js
+++ b/src/cloud-element-templates/core/ConfigurationInstances.js
@@ -19,15 +19,18 @@
  */
 
 /**
- * Registry of available configuration instances (cluster variables with
- * `kind = CREDENTIAL`).
+ * Registry of available template-derived configuration instances (cluster
+ * variables with a metadata `kind`).
  */
 export default class ConfigurationInstances {
   constructor(eventBus) {
     this._eventBus = eventBus;
 
     /** @type {ConfigurationInstance[]} */
-    this._instances = [];
+    this._selectableInstances = [];
+
+    /** @type {Record<string, ConfigurationInstance>} */
+    this._referencedInstancesByName = {};
 
     /** @type {boolean} */
     this._loading = false;
@@ -46,15 +49,28 @@ export default class ConfigurationInstances {
   }
 
   /**
-   * Replace the set of available instances and notify listeners.
+   * Replace the configurations that may appear as chooser options and notify
+   * listeners.
    *
-   * @param {ConfigurationInstance[]} instances
+   * @param {ConfigurationInstance[]} selectableInstances
    */
-  setInstances(instances) {
+  setSelectableInstances(selectableInstances) {
     this.setState({
-      instances,
+      selectableInstances,
       error: false,
       clusterSelected: true
+    });
+  }
+
+  /**
+   * Replace configurations referenced in BPMN and fetched by cluster-variable
+   * name, then notify listeners.
+   *
+   * @param {ConfigurationInstance[]} referencedInstances
+   */
+  setReferencedInstances(referencedInstances) {
+    this.setState({
+      referencedInstances
     });
   }
 
@@ -73,11 +89,25 @@ export default class ConfigurationInstances {
   /**
    * Update host-provided configuration instance state and notify listeners.
    *
-  * @param {{ instances?: ConfigurationInstance[], loading?: boolean, error?: boolean, clusterSelected?: boolean, permissions?: ConfigurationPermissions }} state
+  * @param {{ selectableInstances?: ConfigurationInstance[], referencedInstances?: ConfigurationInstance[], loading?: boolean, error?: boolean, clusterSelected?: boolean, permissions?: ConfigurationPermissions }} state
    */
   setState(state) {
-    if ('instances' in state) {
-      this._instances = state.instances || [];
+    if ('selectableInstances' in state) {
+      this._selectableInstances = state.selectableInstances || [];
+    }
+
+    if ('referencedInstances' in state) {
+      const referencedInstances = state.referencedInstances || [];
+
+      this._referencedInstancesByName = referencedInstances.reduce((byName, instance) => {
+        if (!instance || !instance.name) {
+          return byName;
+        }
+
+        byName[ instance.name ] = instance;
+
+        return byName;
+      }, {});
     }
 
     if ('loading' in state) {
@@ -107,10 +137,11 @@ export default class ConfigurationInstances {
         create: false,
         update: false
       };
+      this._referencedInstancesByName = {};
     }
 
     this._eventBus.fire('configurationInstances.changed', {
-      instances: this._instances,
+      selectableInstances: this._selectableInstances,
       loading: this._loading,
       error: this._error,
       clusterSelected: this._clusterSelected,
@@ -165,22 +196,22 @@ export default class ConfigurationInstances {
   }
 
   /**
-   * Get all available instances.
+   * Get all configurations that may appear as chooser options.
    *
    * @returns {ConfigurationInstance[]}
    */
-  getAll() {
-    return this._instances;
+  getSelectableInstances() {
+    return this._selectableInstances;
   }
 
   /**
-   * Get an instance by its cluster-variable name.
+   * Get a BPMN-referenced configuration by its cluster-variable name.
    *
    * @param {string} name
    * @returns {ConfigurationInstance|undefined}
    */
-  getByName(name) {
-    return this._instances.find(instance => instance.name === name);
+  getReferencedInstanceByName(name) {
+    return this._referencedInstancesByName[ name ];
   }
 
   /**
@@ -198,22 +229,23 @@ export default class ConfigurationInstances {
       configurationTemplateVersion: instanceVersion
     } = instance.metadata || {};
 
-    return kind === 'CREDENTIAL'
+    return !!kind
       && instanceTemplate === configurationTemplate
       && (minVersion == null || (instanceVersion != null && instanceVersion >= minVersion));
   }
 
   /**
-    * Get instances compatible with the given template reference and version.
+    * Get selectable configurations compatible with the given template reference
+    * and version.
    *
    * @param {string} configurationTemplate - configuration template ID
    * @param {number} [minVersion] - minimum version floor (inclusive)
    * @returns {ConfigurationInstance[]}
    */
-  getByConfigurationTemplate(configurationTemplate, minVersion) {
+  getSelectableByConfigurationTemplate(configurationTemplate, minVersion) {
     const compatible = [];
 
-    for (const instance of this._instances) {
+    for (const instance of this._selectableInstances) {
       if (!this.isCompatible(instance, configurationTemplate, minVersion)) {
         continue;
       }

--- a/src/cloud-element-templates/core/ConfigurationInstances.js
+++ b/src/cloud-element-templates/core/ConfigurationInstances.js
@@ -39,7 +39,10 @@ export default class ConfigurationInstances {
     this._error = false;
 
     /** @type {boolean} */
-    this._clusterSelected = false;
+    this._available = false;
+
+    /** @type {string|null} */
+    this._unavailableMessage = null;
 
     /** @type {{ create: boolean, update: boolean }} */
     this._permissions = {
@@ -58,7 +61,7 @@ export default class ConfigurationInstances {
     this.setState({
       selectableInstances,
       error: false,
-      clusterSelected: true
+      available: true
     });
   }
 
@@ -89,7 +92,7 @@ export default class ConfigurationInstances {
   /**
    * Update host-provided configuration instance state and notify listeners.
    *
-  * @param {{ selectableInstances?: ConfigurationInstance[], referencedInstances?: ConfigurationInstance[], loading?: boolean, error?: boolean, clusterSelected?: boolean, permissions?: ConfigurationPermissions }} state
+  * @param {{ selectableInstances?: ConfigurationInstance[], referencedInstances?: ConfigurationInstance[], loading?: boolean, error?: boolean, available?: boolean, unavailableMessage?: string, permissions?: ConfigurationPermissions }} state
    */
   setState(state) {
     if ('selectableInstances' in state) {
@@ -118,8 +121,12 @@ export default class ConfigurationInstances {
       this._error = !!state.error;
     }
 
-    if ('clusterSelected' in state) {
-      this._clusterSelected = !!state.clusterSelected;
+    if ('available' in state) {
+      this._available = !!state.available;
+    }
+
+    if ('unavailableMessage' in state) {
+      this._unavailableMessage = state.unavailableMessage || null;
     }
 
     if ('permissions' in state) {
@@ -131,20 +138,23 @@ export default class ConfigurationInstances {
       };
     }
 
-    if (!this._clusterSelected) {
+    if (!this._available) {
       this._error = false;
       this._permissions = {
         create: false,
         update: false
       };
       this._referencedInstancesByName = {};
+    } else {
+      this._unavailableMessage = null;
     }
 
     this._eventBus.fire('configurationInstances.changed', {
       selectableInstances: this._selectableInstances,
       loading: this._loading,
       error: this._error,
-      clusterSelected: this._clusterSelected,
+      available: this._available,
+      unavailableMessage: this._unavailableMessage,
       permissions: this._permissions
     });
   }
@@ -168,13 +178,21 @@ export default class ConfigurationInstances {
   }
 
   /**
-   * Whether the host has selected a cluster whose configuration instances can
-   * be queried.
+  * Whether configuration instances can be queried and managed.
    *
    * @returns {boolean}
    */
-  isClusterSelected() {
-    return this._clusterSelected;
+  isAvailable() {
+    return this._available;
+  }
+
+  /**
+   * Get the host-provided reason configuration instances are unavailable.
+   *
+   * @returns {string|null}
+   */
+  getUnavailableMessage() {
+    return this._unavailableMessage;
   }
 
   /**

--- a/src/cloud-element-templates/core/ConfigurationTemplates.js
+++ b/src/cloud-element-templates/core/ConfigurationTemplates.js
@@ -1,0 +1,125 @@
+/**
+ * @typedef { {
+ *   id: string,
+ *   name: string,
+ *   version: number,
+ *   icon?: { contents: string },
+ *   properties?: Array<Object>
+ * } } ConfigurationTemplate
+ */
+
+/**
+ * Registry for configuration templates extracted from element templates.
+ *
+ * Listens to `elementTemplates.changed` and automatically indexes all
+ * `configurationTemplates` entries found in the loaded element templates.
+ */
+export default class ConfigurationTemplates {
+  constructor(elementTemplates, eventBus) {
+    this._eventBus = eventBus;
+    this._elementTemplates = elementTemplates;
+
+    /** @type {Object<string, Object<number, ConfigurationTemplate>>} */
+    this._byId = {};
+
+    eventBus.on('elementTemplates.changed', () => {
+      this._extract();
+      this._eventBus.fire('configurationTemplates.changed');
+    });
+  }
+
+  /**
+   * Get a configuration template by ID and optional version.
+   * Without version, returns the latest.
+   *
+   * @param {string} id
+   * @param {number} [version]
+   * @returns {ConfigurationTemplate|null}
+   */
+  get(id, version) {
+    const versions = this._byId[id];
+
+    if (!versions) {
+      return null;
+    }
+
+    if (version != null) {
+      return versions[version] || null;
+    }
+
+    // return latest
+    const latest = Object.keys(versions)
+      .map(Number)
+      .sort((a, b) => b - a)[0];
+
+    return versions[latest] || null;
+  }
+
+  /**
+   * Get all configuration templates (all versions).
+   *
+   * @returns {ConfigurationTemplate[]}
+   */
+  getAll() {
+    const result = [];
+
+    for (const versions of Object.values(this._byId)) {
+      for (const template of Object.values(versions)) {
+        result.push(template);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the latest version of each configuration template.
+   *
+   * @returns {ConfigurationTemplate[]}
+   */
+  getLatest() {
+    const result = [];
+
+    for (const versions of Object.values(this._byId)) {
+      const latest = Object.keys(versions)
+        .map(Number)
+        .sort((a, b) => b - a)[0];
+
+      result.push(versions[latest]);
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract configuration templates from all loaded element templates.
+   */
+  _extract() {
+    const map = {};
+
+    for (const elementTemplate of this._elementTemplates.getAll()) {
+      const configurationTemplates = elementTemplate.configurationTemplates;
+
+      if (!configurationTemplates) {
+        continue;
+      }
+
+      for (const ct of configurationTemplates) {
+        const { id, version = 1 } = ct;
+
+        if (!map[id]) {
+          map[id] = {};
+        }
+
+        // highest version wins on collision within same id+version
+        if (!map[id][version]) {
+          map[id][version] = ct;
+        }
+      }
+    }
+
+    this._byId = map;
+  }
+}
+
+ConfigurationTemplates.$inject = [ 'elementTemplates', 'eventBus' ];

--- a/src/cloud-element-templates/core/ConfigurationTemplates.js
+++ b/src/cloud-element-templates/core/ConfigurationTemplates.js
@@ -111,7 +111,7 @@ export default class ConfigurationTemplates {
           map[id] = {};
         }
 
-        // highest version wins on collision within same id+version
+        // Keep the first definition for an identical id and version.
         if (!map[id][version]) {
           map[id][version] = ct;
         }

--- a/src/cloud-element-templates/core/index.js
+++ b/src/cloud-element-templates/core/index.js
@@ -1,5 +1,7 @@
 import ElementTemplates from '../ElementTemplates';
 import ElementTemplatesLoader from '../ElementTemplatesLoader';
+import ConfigurationInstances from './ConfigurationInstances';
+import ConfigurationTemplates from './ConfigurationTemplates';
 
 import commandsModule from '../cmd';
 import createModule from '../create';
@@ -12,8 +14,11 @@ export default {
     createModule
   ],
   __init__: [
-    'elementTemplatesLoader'
+    'elementTemplatesLoader',
+    'configurationTemplates'
   ],
   elementTemplates: [ 'type', ElementTemplates ],
-  elementTemplatesLoader: [ 'type', ElementTemplatesLoader ]
+  elementTemplatesLoader: [ 'type', ElementTemplatesLoader ],
+  configurationInstances: [ 'type', ConfigurationInstances ],
+  configurationTemplates: [ 'type', ConfigurationTemplates ]
 };

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1,6 +1,7 @@
 import { useService } from 'bpmn-js-properties-panel';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
+import { CreateIcon } from '@bpmn-io/properties-panel';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -101,7 +102,8 @@ export function ConfigurationProperty(props) {
   );
   const [ loading, setLoading ] = useState(configurationInstances.isLoading());
   const [ error, setError ] = useState(configurationInstances.hasError());
-  const [ clusterSelected, setClusterSelected ] = useState(configurationInstances.isClusterSelected());
+  const [ available, setAvailable ] = useState(configurationInstances.isAvailable());
+  const [ unavailableMessage, setUnavailableMessage ] = useState(configurationInstances.getUnavailableMessage());
   const [ canCreate, setCanCreate ] = useState(configurationInstances.canCreate());
   const [ canUpdate, setCanUpdate ] = useState(configurationInstances.canUpdate());
 
@@ -110,7 +112,8 @@ export function ConfigurationProperty(props) {
       setResult(configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion));
       setLoading(configurationInstances.isLoading());
       setError(configurationInstances.hasError());
-      setClusterSelected(configurationInstances.isClusterSelected());
+      setAvailable(configurationInstances.isAvailable());
+      setUnavailableMessage(configurationInstances.getUnavailableMessage());
       setCanCreate(configurationInstances.canCreate());
       setCanUpdate(configurationInstances.canUpdate());
     };
@@ -177,6 +180,21 @@ export function ConfigurationProperty(props) {
   const [ open, setOpen ] = useState(false);
   const [ menuOpen, setMenuOpen ] = useState(false);
   const ref = useRef(null);
+  const availabilityRef = useRef({ error, available });
+
+  useEffect(() => {
+    const previousAvailability = availabilityRef.current;
+
+    availabilityRef.current = { error, available };
+
+    if (
+      (!previousAvailability.error && error)
+      || (previousAvailability.available && !available)
+    ) {
+      setOpen(false);
+      setMenuOpen(false);
+    }
+  }, [ error, available ]);
 
   // close popover/menu on outside click
   useEffect(() => {
@@ -282,13 +300,13 @@ export function ConfigurationProperty(props) {
   }, [ eventBus, element, property, boundInstance, configurationTemplate, configurationTemplateVersion ]);
 
   const toggleOpen = useCallback(() => {
-    if (disabled || error || !clusterSelected) {
+    if (disabled || error || !available) {
       return;
     }
 
     setMenuOpen(false);
     setOpen(value => !value);
-  }, [ disabled, error, clusterSelected ]);
+  }, [ disabled, error, available ]);
 
   const toggleMenu = useCallback((event) => {
     if (disabled) {
@@ -346,7 +364,7 @@ export function ConfigurationProperty(props) {
               ? (
                 <LoadingConfiguration cachedName={ cachedName } translate={ translate } />
               )
-              : value && !selected && clusterSelected
+              : value && !selected && available
                 ? (
                   <MissingConfiguration
                     value={ value }
@@ -423,7 +441,6 @@ export function ConfigurationProperty(props) {
               instances={ instances }
               selected={ selected }
               canCreate={ canCreate }
-              configurationLabel={ configurationLabel }
               onCreate={ createConfiguration }
               onSelect={ select }
               loading={ loading }
@@ -528,13 +545,25 @@ function ConfigurationContextMenu(props) {
 
 function LoadingConfiguration(props) {
   const { cachedName, translate } = props;
+  const name = cachedName || translate('Configuration');
+  const instance = {
+    name,
+    metadata: {
+      displayName: name
+    }
+  };
 
   return (
-    <div class="bio-properties-panel-configuration-chooser-loading">
-      <span class="bio-properties-panel-configuration-chooser-loading-shimmer" />
+    <div
+      class="bio-properties-panel-configuration-chooser-loading"
+      role="status">
+      <ConfigurationLogo instance={ instance } />
       <span class="bio-properties-panel-configuration-chooser-text">
         <span class="bio-properties-panel-configuration-chooser-title">
-          { cachedName || translate('Loading...') }
+          { name }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          { translate('Loading configuration') }
         </span>
       </span>
     </div>
@@ -555,7 +584,7 @@ function ErrorConfiguration(props) {
 
   return (
     <div class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error">
-      <span class="bio-properties-panel-configuration-chooser-missing-icon">⚠</span>
+      <ConfigurationLogo warning />
       <span class="bio-properties-panel-configuration-chooser-text">
         <span class="bio-properties-panel-configuration-chooser-title">
           { cachedName || refName }
@@ -603,7 +632,7 @@ function MissingConfiguration(props) {
       tabIndex={ disabled ? -1 : 0 }
       onClick={ disabled ? null : onClick }
       onKeyDown={ disabled ? null : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } }>
-      <span class="bio-properties-panel-configuration-chooser-missing-icon">⚠</span>
+      <ConfigurationLogo warning />
       <span class="bio-properties-panel-configuration-chooser-text">
         <span class="bio-properties-panel-configuration-chooser-title">
           {
@@ -689,7 +718,6 @@ function OfflineConfiguration(props) {
 function ConfigurationPopover(props) {
   const {
     canCreate,
-    configurationLabel,
     instances,
     loading,
     onCreate,
@@ -702,7 +730,13 @@ function ConfigurationPopover(props) {
     <div class="bio-properties-panel-configuration-chooser-popover">
       {
         loading
-          ? <span class="bio-properties-panel-configuration-chooser-refreshing">{ translate('Loading...') }</span>
+          ? (
+            <span
+              class="bio-properties-panel-configuration-chooser-refreshing"
+              role="status">
+              { translate('Refreshing configurations...') }
+            </span>
+          )
           : null
       }
 
@@ -727,8 +761,7 @@ function ConfigurationPopover(props) {
               {
                 loading
                   ? translate('Loading...')
-                  : translate('{configuration} not present in connected cluster')
-                    .replace('{configuration}', configurationLabel)
+                  : translate('No compatible configurations are available in the connected cluster')
               }
             </div>
           )
@@ -741,7 +774,9 @@ function ConfigurationPopover(props) {
               type="button"
               class="bio-properties-panel-configuration-chooser-create"
               onClick={ onCreate }>
-              <span class="bio-properties-panel-configuration-chooser-placeholder-plus">+</span>
+              <CreateIcon
+                class="bio-properties-panel-configuration-chooser-create-icon"
+                aria-hidden="true" />
               { translate('Create') }
             </button>
           )
@@ -793,7 +828,15 @@ function ConfigurationRow(props) {
 }
 
 function ConfigurationLogo(props) {
-  const { instance } = props;
+  const { instance, warning } = props;
+
+  if (warning) {
+    return (
+      <span class="bio-properties-panel-configuration-chooser-logo bio-properties-panel-configuration-chooser-logo--placeholder bio-properties-panel-configuration-chooser-logo--warning">
+        !
+      </span>
+    );
+  }
 
   if (instance.icon) {
     return (

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -347,6 +347,7 @@ export function ConfigurationProperty(props) {
               cachedName={ cachedName }
               disabled={ disabled }
               menuOpen={ menuOpen }
+              showMenu
               onMenu={ toggleMenu }
               translate={ translate } />
           )
@@ -356,6 +357,7 @@ export function ConfigurationProperty(props) {
                 instance={ selected }
                 disabled={ disabled }
                 menuOpen={ menuOpen }
+                showMenu={ canUpdate }
                 onClick={ toggleOpen }
                 onMenu={ toggleMenu }
                 translate={ translate } />
@@ -374,6 +376,7 @@ export function ConfigurationProperty(props) {
                     typeIncompatible={ typeIncompatible }
                     disabled={ disabled }
                     menuOpen={ menuOpen }
+                    showMenu={ versionIncompatible && canUpdate }
                     onClick={ toggleOpen }
                     onMenu={ toggleMenu }
                     translate={ translate } />
@@ -386,6 +389,7 @@ export function ConfigurationProperty(props) {
                       unavailableMessage={ unavailableMessage }
                       disabled={ disabled }
                       menuOpen={ menuOpen }
+                      showMenu
                       icon={ configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.icon?.contents }
                       onMenu={ toggleMenu }
                       translate={ translate } />
@@ -441,6 +445,7 @@ export function ConfigurationProperty(props) {
             <ConfigurationPopover
               instances={ instances }
               selected={ selected }
+              hasSelection={ !!value }
               canCreate={ canCreate }
               onCreate={ createConfiguration }
               onSelect={ select }
@@ -456,7 +461,7 @@ export function ConfigurationProperty(props) {
             <ConfigurationContextMenu
               onEdit={ selected && canUpdate ? editConfiguration : null }
               onUpgrade={ versionIncompatible && canUpdate ? upgradeConfiguration : null }
-              onRemove={ () => select(null) }
+              onClear={ error || !available ? () => select(null) : null }
               translate={ translate } />
           )
           : null
@@ -472,6 +477,7 @@ function SelectedConfiguration(props) {
     menuOpen,
     onClick,
     onMenu,
+    showMenu,
     translate
   } = props;
 
@@ -491,22 +497,28 @@ function SelectedConfiguration(props) {
           <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
-        disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+      {
+        showMenu
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-menu"
+              title={ translate('More actions') }
+              aria-label={ translate('More actions') }
+              aria-expanded={ menuOpen }
+              disabled={ disabled }
+              onClick={ onMenu }>
+              …
+            </button>
+          )
+          : null
+      }
     </div>
   );
 }
 
 function ConfigurationContextMenu(props) {
-  const { onEdit, onRemove, onUpgrade, translate } = props;
+  const { onClear, onEdit, onUpgrade, translate } = props;
 
   return (
     <div class="bio-properties-panel-configuration-chooser-context-menu">
@@ -534,12 +546,18 @@ function ConfigurationContextMenu(props) {
           )
           : null
       }
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-context-menu-item bio-properties-panel-configuration-chooser-context-menu-item--danger"
-        onClick={ onRemove }>
-        { translate('Remove') }
-      </button>
+      {
+        onClear
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-context-menu-item"
+              onClick={ onClear }>
+              { translate('Clear selection') }
+            </button>
+          )
+          : null
+      }
     </div>
   );
 }
@@ -577,6 +595,7 @@ function ErrorConfiguration(props) {
     disabled,
     menuOpen,
     onMenu,
+    showMenu,
     translate,
     value
   } = props;
@@ -594,16 +613,22 @@ function ErrorConfiguration(props) {
           { translate('Could not load configurations') }
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
-        disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+      {
+        showMenu
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-menu"
+              title={ translate('More actions') }
+              aria-label={ translate('More actions') }
+              aria-expanded={ menuOpen }
+              disabled={ disabled }
+              onClick={ onMenu }>
+              …
+            </button>
+          )
+          : null
+      }
     </div>
   );
 }
@@ -617,6 +642,7 @@ function MissingConfiguration(props) {
     minimumVersion,
     onClick,
     onMenu,
+    showMenu,
     translate,
     typeIncompatible,
     value
@@ -655,16 +681,22 @@ function MissingConfiguration(props) {
           }
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
-        disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+      {
+        showMenu
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-menu"
+              title={ translate('More actions') }
+              aria-label={ translate('More actions') }
+              aria-expanded={ menuOpen }
+              disabled={ disabled }
+              onClick={ onMenu }>
+              …
+            </button>
+          )
+          : null
+      }
     </div>
   );
 }
@@ -676,6 +708,7 @@ function OfflineConfiguration(props) {
     icon,
     menuOpen,
     onMenu,
+    showMenu,
     translate,
     unavailableMessage,
     value
@@ -703,16 +736,22 @@ function OfflineConfiguration(props) {
           { unavailableMessage || translate('Cluster unavailable') }
         </span>
       </span>
-      <button
-        type="button"
-        class="bio-properties-panel-configuration-chooser-menu"
-        title={ translate('More actions') }
-        aria-label={ translate('More actions') }
-        aria-expanded={ menuOpen }
-        disabled={ disabled }
-        onClick={ onMenu }>
-        …
-      </button>
+      {
+        showMenu
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-menu"
+              title={ translate('More actions') }
+              aria-label={ translate('More actions') }
+              aria-expanded={ menuOpen }
+              disabled={ disabled }
+              onClick={ onMenu }>
+              …
+            </button>
+          )
+          : null
+      }
     </div>
   );
 }
@@ -720,6 +759,7 @@ function OfflineConfiguration(props) {
 function ConfigurationPopover(props) {
   const {
     canCreate,
+    hasSelection,
     instances,
     loading,
     onCreate,
@@ -743,9 +783,18 @@ function ConfigurationPopover(props) {
       }
 
       {
-        instances.length
+        instances.length || hasSelection
           ? (
             <ul class="bio-properties-panel-configuration-chooser-popover-list">
+              {
+                hasSelection
+                  ? (
+                    <EmptyConfigurationRow
+                      onSelect={ () => onSelect(null) }
+                      translate={ translate } />
+                  )
+                  : null
+              }
               {
                 instances.map((instance) => (
                   <ConfigurationRow
@@ -755,6 +804,19 @@ function ConfigurationPopover(props) {
                     onSelect={ () => onSelect(selected === instance ? null : instance.name) }
                     translate={ translate } />
                 ))
+              }
+              {
+                !instances.length
+                  ? (
+                    <li class="bio-properties-panel-configuration-chooser-empty">
+                      {
+                        loading
+                          ? translate('Loading...')
+                          : translate('No compatible configurations are available in the connected cluster')
+                      }
+                    </li>
+                  )
+                  : null
               }
             </ul>
           )
@@ -785,6 +847,37 @@ function ConfigurationPopover(props) {
           : null
       }
     </div>
+  );
+}
+
+function EmptyConfigurationRow(props) {
+  const { onSelect, translate } = props;
+
+  const onKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  };
+
+  return (
+    <li
+      class={ [
+        'bio-properties-panel-configuration-chooser-popover-row',
+        'bio-properties-panel-configuration-chooser-popover-row--empty'
+      ].join(' ') }
+      role="button"
+      tabIndex={ 0 }
+      aria-pressed={ false }
+      onClick={ onSelect }
+      onKeyDown={ onKeyDown }>
+      <span
+        class="bio-properties-panel-configuration-chooser-logo bio-properties-panel-configuration-chooser-logo--empty"
+        aria-hidden="true" />
+      <span class="bio-properties-panel-configuration-chooser-subtitle">
+        { translate('No selection') }
+      </span>
+    </li>
   );
 }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -89,13 +89,15 @@ export function ConfigurationProperty(props) {
         configurationTemplates = useService('configurationTemplates'),
         configurationInstances = useService('configurationInstances');
 
-  const templateName = configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.name;
+  const configurationTemplateDefinition = configurationTemplates.get(configurationTemplate, configurationTemplateVersion)
+    || configurationTemplates.get(configurationTemplate);
+  const templateName = configurationTemplateDefinition?.name;
   const configurationLabel = translate(label || templateName || 'Configuration');
   const chooserLabel = label ? toSentenceFragment(configurationLabel) : configurationLabel;
 
   // re-render when available instances change
   const [ result, setResult ] = useState(
-    configurationInstances.getByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion)
+    configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion)
   );
   const [ loading, setLoading ] = useState(configurationInstances.isLoading());
   const [ error, setError ] = useState(configurationInstances.hasError());
@@ -105,7 +107,7 @@ export function ConfigurationProperty(props) {
 
   useEffect(() => {
     const onChanged = () => {
-      setResult(configurationInstances.getByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion));
+      setResult(configurationInstances.getSelectableByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion));
       setLoading(configurationInstances.isLoading());
       setError(configurationInstances.hasError());
       setClusterSelected(configurationInstances.isClusterSelected());
@@ -145,7 +147,7 @@ export function ConfigurationProperty(props) {
 
   const value = getValue();
   const selected = instances.find(({ name }) => toReference(name) === value);
-  const boundInstance = value ? configurationInstances.getByName(fromReference(value)) : null;
+  const boundInstance = value ? configurationInstances.getReferencedInstanceByName(fromReference(value)) : null;
   const boundMetadata = boundInstance?.metadata || {};
   const typeIncompatible = !!boundInstance
     && boundMetadata.configurationTemplate !== configurationTemplate;
@@ -210,7 +212,7 @@ export function ConfigurationProperty(props) {
 
   useEffect(() => {
     const onCreated = (event) => {
-      if (event.element !== element || event.property !== property) {
+      if (!isSameChooser(event, element, property)) {
         return;
       }
 
@@ -818,5 +820,17 @@ function ConfigurationLogo(props) {
  * @returns {boolean}
  */
 export function isConfigurationChooserEdited(node) {
-  return !!domQuery('.bio-properties-panel-configuration-chooser-selected', node);
+  return !!domQuery(
+    '.bio-properties-panel-configuration-chooser-selected, .bio-properties-panel-configuration-chooser-missing, .bio-properties-panel-configuration-chooser-loading',
+    node
+  );
+}
+
+function isSameChooser(event, element, property) {
+  if (event.element === element && event.property === property) {
+    return true;
+  }
+
+  return event.element?.id === element.id
+    && event.property?.id === property.id;
 }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1,0 +1,822 @@
+import { useService } from 'bpmn-js-properties-panel';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
+
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import { query as domQuery } from 'min-dom';
+
+import { PropertyDescription } from '../../../../components/PropertyDescription';
+import { PropertyTooltip } from '../../components/PropertyTooltip';
+import { propertyGetter, propertySetter } from './util';
+
+import { findExtension, findInputParameter, findZeebeProperty } from '../../../Helper';
+
+/**
+ * FEEL expression referencing a configuration instance as a cluster variable.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function toReference(name) {
+  return `=camunda.vars.env.${ name }`;
+}
+
+function fromReference(value) {
+  const prefix = '=camunda.vars.env.';
+
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function getDisplayName(instance) {
+  return instance.metadata?.displayName || instance.name;
+}
+
+function toSentenceFragment(value) {
+  return /^[A-Z][a-z]/.test(value)
+    ? value.charAt(0).toLowerCase() + value.slice(1)
+    : value;
+}
+
+function getBindingElement(extensionElements, binding) {
+  if (binding.type === 'zeebe:input') {
+    const ioMapping = findExtension(extensionElements, 'zeebe:IoMapping');
+
+    return ioMapping && findInputParameter(ioMapping, binding);
+  }
+
+  if (binding.type === 'zeebe:property') {
+    const zeebeProperties = findExtension(extensionElements, 'zeebe:Properties');
+
+    return zeebeProperties && findZeebeProperty(zeebeProperties, binding);
+  }
+}
+
+/**
+ * Configuration chooser.
+ *
+ * Renders a bespoke picker (NOT a plain select): a dashed placeholder that
+ * opens a popover listing the configuration instances compatible with the
+ * property's `configurationTemplate`. Once chosen, the configuration is shown as a card.
+ * The stored value is a FEEL expression referencing the chosen configuration as a
+ * cluster variable (`=camunda.vars.env.<name>`); clearing the selection
+ * removes the binding.
+ */
+export function ConfigurationProperty(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const {
+    description,
+    editable,
+    label,
+    tooltip,
+    configurationTemplate,
+    configurationTemplateVersion
+  } = property;
+
+  const minimumConfigurationTemplateVersion = configurationTemplateVersion;
+
+  const disabled = editable === false;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        translate = useService('translate'),
+        eventBus = useService('eventBus'),
+        configurationTemplates = useService('configurationTemplates'),
+        configurationInstances = useService('configurationInstances');
+
+  const templateName = configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.name;
+  const configurationLabel = translate(label || templateName || 'Configuration');
+  const chooserLabel = label ? toSentenceFragment(configurationLabel) : configurationLabel;
+
+  // re-render when available instances change
+  const [ result, setResult ] = useState(
+    configurationInstances.getByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion)
+  );
+  const [ loading, setLoading ] = useState(configurationInstances.isLoading());
+  const [ error, setError ] = useState(configurationInstances.hasError());
+  const [ clusterSelected, setClusterSelected ] = useState(configurationInstances.isClusterSelected());
+  const [ canCreate, setCanCreate ] = useState(configurationInstances.canCreate());
+  const [ canUpdate, setCanUpdate ] = useState(configurationInstances.canUpdate());
+
+  useEffect(() => {
+    const onChanged = () => {
+      setResult(configurationInstances.getByConfigurationTemplate(configurationTemplate, minimumConfigurationTemplateVersion));
+      setLoading(configurationInstances.isLoading());
+      setError(configurationInstances.hasError());
+      setClusterSelected(configurationInstances.isClusterSelected());
+      setCanCreate(configurationInstances.canCreate());
+      setCanUpdate(configurationInstances.canUpdate());
+    };
+
+    eventBus.on('configurationInstances.changed', onChanged);
+    onChanged();
+
+    return () => {
+      eventBus.off('configurationInstances.changed', onChanged);
+    };
+  }, [ eventBus, configurationInstances, configurationTemplate, minimumConfigurationTemplateVersion ]);
+
+  const instances = result;
+
+  const getValue = useMemo(
+    () => propertyGetter(element, property),
+    [ element, property ]
+  );
+
+  const baseSetValue = useMemo(
+    () => propertySetter(bpmnFactory, commandStack, element, property),
+    [ bpmnFactory, commandStack, element, property ]
+  );
+
+  // Wrap setter to stamp configuration metadata on the BPMN binding.
+  const setValue = useCallback((value, instance) => {
+    const selectedInstance = instance || instances.find(({ name }) => toReference(name) === value);
+
+    baseSetValue(value, {
+      modelerConfigurationTemplate: value && configurationTemplate || undefined,
+      modelerConfigurationName: selectedInstance ? getDisplayName(selectedInstance) : undefined
+    });
+  }, [ baseSetValue, configurationTemplate, instances ]);
+
+  const value = getValue();
+  const selected = instances.find(({ name }) => toReference(name) === value);
+  const boundInstance = value ? configurationInstances.getByName(fromReference(value)) : null;
+  const boundMetadata = boundInstance?.metadata || {};
+  const typeIncompatible = !!boundInstance
+    && boundMetadata.configurationTemplate !== configurationTemplate;
+  const versionIncompatible = !!boundInstance
+    && boundMetadata.configurationTemplate === configurationTemplate
+    && minimumConfigurationTemplateVersion != null
+    && (boundMetadata.configurationTemplateVersion == null
+      || boundMetadata.configurationTemplateVersion < minimumConfigurationTemplateVersion);
+  const incompatible = typeIncompatible || versionIncompatible;
+
+  // Read cached configuration metadata from the BPMN binding.
+  const cachedName = useMemo(() => {
+    if (!value || !property.binding) {
+      return null;
+    }
+
+    const businessObject = getBusinessObject(element);
+    const extensionElements = businessObject.get('extensionElements');
+
+    if (!extensionElements) return null;
+
+    const bindingElement = getBindingElement(extensionElements, property.binding);
+
+    return bindingElement && bindingElement.modelerConfigurationName;
+  }, [ element, property, value ]);
+
+  const [ open, setOpen ] = useState(false);
+  const [ menuOpen, setMenuOpen ] = useState(false);
+  const ref = useRef(null);
+
+  // close popover/menu on outside click
+  useEffect(() => {
+    if (!open && !menuOpen) {
+      return;
+    }
+
+    const onDocPointer = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        setOpen(false);
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', onDocPointer, true);
+
+    return () => {
+      document.removeEventListener('mousedown', onDocPointer, true);
+    };
+  }, [ open, menuOpen ]);
+
+  const select = useCallback((name) => {
+    if (disabled) {
+      return;
+    }
+
+    const instance = instances.find(instance => instance.name === name);
+
+    setValue(name ? toReference(name) : '', instance);
+    setOpen(false);
+    setMenuOpen(false);
+  }, [ disabled, instances, setValue ]);
+
+  useEffect(() => {
+    const onCreated = (event) => {
+      if (event.element !== element || event.property !== property) {
+        return;
+      }
+
+      const { instance } = event;
+
+      if (!instance || !configurationInstances.isCompatible(
+        instance,
+        configurationTemplate,
+        minimumConfigurationTemplateVersion
+      )) {
+        return;
+      }
+
+      setValue(toReference(instance.name), instance);
+      setOpen(false);
+      setMenuOpen(false);
+    };
+
+    eventBus.on('configuration.created', onCreated);
+
+    return () => {
+      eventBus.off('configuration.created', onCreated);
+    };
+  }, [
+    eventBus,
+    element,
+    property,
+    configurationInstances,
+    configurationTemplate,
+    minimumConfigurationTemplateVersion,
+    setValue
+  ]);
+
+  const createConfiguration = useCallback(() => {
+    setOpen(false);
+
+    eventBus.fire('configuration.create', {
+      element,
+      property,
+      configurationTemplate,
+      configurationTemplateVersion
+    });
+  }, [ eventBus, element, property, configurationTemplate, configurationTemplateVersion ]);
+
+  const editConfiguration = useCallback(() => {
+    setMenuOpen(false);
+
+    eventBus.fire('configuration.edit', {
+      element,
+      property,
+      instance: selected,
+      configurationTemplate,
+      configurationTemplateVersion
+    });
+  }, [ eventBus, element, property, selected, configurationTemplate, configurationTemplateVersion ]);
+
+  const upgradeConfiguration = useCallback(() => {
+    setMenuOpen(false);
+
+    eventBus.fire('configuration.upgrade', {
+      element,
+      property,
+      instance: boundInstance,
+      configurationTemplate,
+      configurationTemplateVersion
+    });
+  }, [ eventBus, element, property, boundInstance, configurationTemplate, configurationTemplateVersion ]);
+
+  const toggleOpen = useCallback(() => {
+    if (disabled || error || !clusterSelected) {
+      return;
+    }
+
+    setMenuOpen(false);
+    setOpen(value => !value);
+  }, [ disabled, error, clusterSelected ]);
+
+  const toggleMenu = useCallback((event) => {
+    if (disabled) {
+      return;
+    }
+
+    event.stopPropagation();
+    setOpen(false);
+    setMenuOpen(value => !value);
+  }, [ disabled ]);
+
+  return (
+    <div
+      ref={ ref }
+      class="bio-properties-panel-configuration-chooser"
+      data-entry-id={ id }>
+      <label class="bio-properties-panel-label">
+        { configurationLabel }
+      </label>
+
+      {
+        description
+          ? <PropertyDescription description={ description } />
+          : null
+      }
+
+      {
+        tooltip
+          ? <PropertyTooltip tooltip={ tooltip } />
+          : null
+      }
+
+      {
+        value && error
+          ? (
+            <ErrorConfiguration
+              value={ value }
+              cachedName={ cachedName }
+              disabled={ disabled }
+              menuOpen={ menuOpen }
+              onMenu={ toggleMenu }
+              translate={ translate } />
+          )
+          : selected
+            ? (
+              <SelectedConfiguration
+                instance={ selected }
+                disabled={ disabled }
+                menuOpen={ menuOpen }
+                onClick={ toggleOpen }
+                onMenu={ toggleMenu }
+                translate={ translate } />
+            )
+            : value && !selected && loading
+              ? (
+                <LoadingConfiguration cachedName={ cachedName } translate={ translate } />
+              )
+              : value && !selected && clusterSelected
+                ? (
+                  <MissingConfiguration
+                    value={ value }
+                    cachedName={ cachedName }
+                    instance={ incompatible ? boundInstance : null }
+                    minimumVersion={ minimumConfigurationTemplateVersion }
+                    typeIncompatible={ typeIncompatible }
+                    disabled={ disabled }
+                    menuOpen={ menuOpen }
+                    onClick={ toggleOpen }
+                    onMenu={ toggleMenu }
+                    translate={ translate } />
+                )
+                : value && !selected
+                  ? (
+                    <OfflineConfiguration
+                      value={ value }
+                      cachedName={ cachedName }
+                      disabled={ disabled }
+                      menuOpen={ menuOpen }
+                      icon={ configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.icon?.contents }
+                      onMenu={ toggleMenu }
+                      translate={ translate } />
+                  )
+                  : (
+                    <>
+                      <button
+                        type="button"
+                        class="bio-properties-panel-configuration-chooser-placeholder"
+                        disabled={ disabled || error || !available }
+                        aria-describedby={
+                          error
+                            ? `${ id }-error`
+                            : !available && unavailableMessage
+                              ? `${ id }-unavailable`
+                              : undefined
+                        }
+                        aria-expanded={ open }
+                        onClick={ toggleOpen }>
+                        <CreateIcon
+                          class="bio-properties-panel-configuration-chooser-create-icon"
+                          aria-hidden="true" />
+                        { translate('Choose {configuration}', { configuration: chooserLabel }) }
+                      </button>
+                      {
+                        error
+                          ? (
+                            <div
+                              id={ `${ id }-error` }
+                              class="bio-properties-panel-configuration-chooser-unavailable bio-properties-panel-configuration-chooser-unavailable--error"
+                              role="status">
+                              { translate('Could not load configurations') }
+                            </div>
+                          )
+                          : !available && unavailableMessage
+                            ? (
+                              <div
+                                id={ `${ id }-unavailable` }
+                                class="bio-properties-panel-configuration-chooser-unavailable"
+                                role="status">
+                                { unavailableMessage }
+                              </div>
+                            )
+                            : null
+                      }
+                    </>
+                  )
+      }
+
+      {
+        open
+          ? (
+            <ConfigurationPopover
+              instances={ instances }
+              selected={ selected }
+              canCreate={ canCreate }
+              configurationLabel={ configurationLabel }
+              onCreate={ createConfiguration }
+              onSelect={ select }
+              loading={ loading }
+              translate={ translate } />
+          )
+          : null
+      }
+
+      {
+        menuOpen
+          ? (
+            <ConfigurationContextMenu
+              onEdit={ selected && canUpdate ? editConfiguration : null }
+              onUpgrade={ versionIncompatible && canUpdate ? upgradeConfiguration : null }
+              onRemove={ () => select(null) }
+              translate={ translate } />
+          )
+          : null
+      }
+    </div>
+  );
+}
+
+function SelectedConfiguration(props) {
+  const {
+    disabled,
+    instance,
+    menuOpen,
+    onClick,
+    onMenu,
+    translate
+  } = props;
+
+  return (
+    <div
+      class="bio-properties-panel-configuration-chooser-selected"
+      role="button"
+      tabIndex={ disabled ? -1 : 0 }
+      onClick={ disabled ? null : onClick }
+      onKeyDown={ disabled ? null : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } }>
+      <ConfigurationLogo instance={ instance } />
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { getDisplayName(instance) }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
+        </span>
+      </span>
+      <button
+        type="button"
+        class="bio-properties-panel-configuration-chooser-menu"
+        title={ translate('More actions') }
+        aria-label={ translate('More actions') }
+        aria-expanded={ menuOpen }
+        disabled={ disabled }
+        onClick={ onMenu }>
+        …
+      </button>
+    </div>
+  );
+}
+
+function ConfigurationContextMenu(props) {
+  const { onEdit, onRemove, onUpgrade, translate } = props;
+
+  return (
+    <div class="bio-properties-panel-configuration-chooser-context-menu">
+      {
+        onEdit
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-context-menu-item"
+              onClick={ onEdit }>
+              { translate('Edit') }
+            </button>
+          )
+          : null
+      }
+      {
+        onUpgrade
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-context-menu-item"
+              onClick={ onUpgrade }>
+              { translate('Upgrade') }
+            </button>
+          )
+          : null
+      }
+      <button
+        type="button"
+        class="bio-properties-panel-configuration-chooser-context-menu-item bio-properties-panel-configuration-chooser-context-menu-item--danger"
+        onClick={ onRemove }>
+        { translate('Remove') }
+      </button>
+    </div>
+  );
+}
+
+function LoadingConfiguration(props) {
+  const { cachedName, translate } = props;
+
+  return (
+    <div class="bio-properties-panel-configuration-chooser-loading">
+      <span class="bio-properties-panel-configuration-chooser-loading-shimmer" />
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { cachedName || translate('Loading...') }
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function ErrorConfiguration(props) {
+  const {
+    cachedName,
+    disabled,
+    menuOpen,
+    onMenu,
+    translate,
+    value
+  } = props;
+
+  const refName = fromReference(value);
+
+  return (
+    <div class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error">
+      <span class="bio-properties-panel-configuration-chooser-missing-icon">⚠</span>
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { cachedName || refName }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          { translate('Could not load configurations') }
+        </span>
+      </span>
+      <button
+        type="button"
+        class="bio-properties-panel-configuration-chooser-menu"
+        title={ translate('More actions') }
+        aria-label={ translate('More actions') }
+        aria-expanded={ menuOpen }
+        disabled={ disabled }
+        onClick={ onMenu }>
+        …
+      </button>
+    </div>
+  );
+}
+
+function MissingConfiguration(props) {
+  const {
+    cachedName,
+    disabled,
+    instance,
+    menuOpen,
+    minimumVersion,
+    onClick,
+    onMenu,
+    translate,
+    typeIncompatible,
+    value
+  } = props;
+
+  // extract variable name from FEEL expression
+  const refName = fromReference(value);
+  const instanceVersion = instance?.metadata?.configurationTemplateVersion;
+
+  return (
+    <div
+      class="bio-properties-panel-configuration-chooser-missing"
+      role="button"
+      tabIndex={ disabled ? -1 : 0 }
+      onClick={ disabled ? null : onClick }
+      onKeyDown={ disabled ? null : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } }>
+      <span class="bio-properties-panel-configuration-chooser-missing-icon">⚠</span>
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          {
+            instance
+              ? getDisplayName(instance)
+              : cachedName || translate('Configuration not found')
+          }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          {
+            instance
+              ? typeIncompatible
+                ? translate('Incompatible configuration type')
+                : translate('Version {version} · Requires version {minimumVersion}+', {
+                  version: instanceVersion == null ? '?' : instanceVersion,
+                  minimumVersion
+                })
+              : cachedName ? translate('Not found on cluster') : refName
+          }
+        </span>
+      </span>
+      <button
+        type="button"
+        class="bio-properties-panel-configuration-chooser-menu"
+        title={ translate('More actions') }
+        aria-label={ translate('More actions') }
+        aria-expanded={ menuOpen }
+        disabled={ disabled }
+        onClick={ onMenu }>
+        …
+      </button>
+    </div>
+  );
+}
+
+function OfflineConfiguration(props) {
+  const {
+    cachedName,
+    disabled,
+    icon,
+    menuOpen,
+    onMenu,
+    translate,
+    value
+  } = props;
+
+  const refName = fromReference(value);
+
+  const instance = {
+    name: refName,
+    metadata: {
+      displayName: cachedName
+    },
+    icon
+  };
+
+  return (
+    <div
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline">
+      <ConfigurationLogo instance={ instance } />
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { cachedName || refName }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+        </span>
+      </span>
+      <button
+        type="button"
+        class="bio-properties-panel-configuration-chooser-menu"
+        title={ translate('More actions') }
+        aria-label={ translate('More actions') }
+        aria-expanded={ menuOpen }
+        disabled={ disabled }
+        onClick={ onMenu }>
+        …
+      </button>
+    </div>
+  );
+}
+
+function ConfigurationPopover(props) {
+  const {
+    canCreate,
+    configurationLabel,
+    instances,
+    loading,
+    onCreate,
+    onSelect,
+    selected,
+    translate
+  } = props;
+
+  return (
+    <div class="bio-properties-panel-configuration-chooser-popover">
+      {
+        loading
+          ? <span class="bio-properties-panel-configuration-chooser-refreshing">{ translate('Loading...') }</span>
+          : null
+      }
+
+      {
+        instances.length
+          ? (
+            <ul class="bio-properties-panel-configuration-chooser-popover-list">
+              {
+                instances.map((instance) => (
+                  <ConfigurationRow
+                    key={ instance.name }
+                    instance={ instance }
+                    selected={ selected === instance }
+                    onSelect={ () => onSelect(selected === instance ? null : instance.name) }
+                    translate={ translate } />
+                ))
+              }
+            </ul>
+          )
+          : (
+            <div class="bio-properties-panel-configuration-chooser-empty">
+              {
+                loading
+                  ? translate('Loading...')
+                  : translate('{configuration} not present in connected cluster')
+                    .replace('{configuration}', configurationLabel)
+              }
+            </div>
+          )
+      }
+
+      {
+        canCreate
+          ? (
+            <button
+              type="button"
+              class="bio-properties-panel-configuration-chooser-create"
+              onClick={ onCreate }>
+              <span class="bio-properties-panel-configuration-chooser-placeholder-plus">+</span>
+              { translate('Create') }
+            </button>
+          )
+          : null
+      }
+    </div>
+  );
+}
+
+function ConfigurationRow(props) {
+  const {
+    instance,
+    onSelect,
+    selected
+  } = props;
+
+  const onKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  };
+
+  const classes = [ 'bio-properties-panel-configuration-chooser-popover-row' ];
+
+  if (selected) {
+    classes.push('bio-properties-panel-configuration-chooser-popover-row--selected');
+  }
+
+  return (
+    <li
+      class={ classes.join(' ') }
+      role="button"
+      tabIndex={ 0 }
+      aria-pressed={ selected }
+      onClick={ onSelect }
+      onKeyDown={ onKeyDown }>
+      <ConfigurationLogo instance={ instance } />
+      <span class="bio-properties-panel-configuration-chooser-text">
+        <span class="bio-properties-panel-configuration-chooser-title">
+          { getDisplayName(instance) }
+        </span>
+        <span class="bio-properties-panel-configuration-chooser-subtitle">
+          <span class="bio-properties-panel-configuration-chooser-varname">{ instance.name }</span>
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function ConfigurationLogo(props) {
+  const { instance } = props;
+
+  if (instance.icon) {
+    return (
+      <img
+        class="bio-properties-panel-configuration-chooser-logo"
+        src={ instance.icon }
+        alt="" />
+    );
+  }
+
+  const initial = getDisplayName(instance).charAt(0).toUpperCase();
+
+  return (
+    <span class="bio-properties-panel-configuration-chooser-logo bio-properties-panel-configuration-chooser-logo--placeholder">
+      { initial }
+    </span>
+  );
+}
+
+/**
+ * Whether the configuration chooser has a non-empty selection.
+ *
+ * @param {HTMLElement} node
+ * @returns {boolean}
+ */
+export function isConfigurationChooserEdited(node) {
+  return !!domQuery('.bio-properties-panel-configuration-chooser-selected', node);
+}

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -383,6 +383,7 @@ export function ConfigurationProperty(props) {
                     <OfflineConfiguration
                       value={ value }
                       cachedName={ cachedName }
+                      unavailableMessage={ unavailableMessage }
                       disabled={ disabled }
                       menuOpen={ menuOpen }
                       icon={ configurationTemplates.get(configurationTemplate, configurationTemplateVersion)?.icon?.contents }
@@ -676,6 +677,7 @@ function OfflineConfiguration(props) {
     menuOpen,
     onMenu,
     translate,
+    unavailableMessage,
     value
   } = props;
 
@@ -698,7 +700,7 @@ function OfflineConfiguration(props) {
           { cachedName || refName }
         </span>
         <span class="bio-properties-panel-configuration-chooser-subtitle">
-          <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+          { unavailableMessage || translate('Cluster unavailable') }
         </span>
       </span>
       <button

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/index.js
@@ -35,7 +35,7 @@ import { JsonEditorProperty } from './JsonEditorProperty';
 import { DropdownProperty } from './DropdownProperty';
 import { BooleanProperty } from './BooleanProperty';
 import { NumberProperty } from './NumberProperty';
-
+import { ConfigurationProperty, isConfigurationChooserEdited } from './ConfigurationProperty';
 
 export function CustomProperties(props) {
   const {
@@ -136,6 +136,15 @@ export function createCustomEntry(id, element, property) {
 
   if (!type) {
     type = getDefaultType(property);
+  }
+
+  if (type === 'Configuration' || property.configurationTemplate) {
+    return {
+      id,
+      component: ConfigurationProperty,
+      isEdited: createIsEdited(isConfigurationChooserEdited, element, property),
+      property
+    };
   }
 
   if (feel === 'required') {

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
@@ -64,8 +64,8 @@ export function propertyGetter(element, property) {
 }
 
 export function propertySetter(bpmnFactory, commandStack, element, property) {
-  return function setValue(value) {
-    return setPropertyValue(bpmnFactory, commandStack, element, property, value);
+  return function setValue(value, additionalProperties) {
+    return setPropertyValue(bpmnFactory, commandStack, element, property, value, additionalProperties);
   };
 }
 

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -387,7 +387,7 @@ function getBooleanPropertyValue(value) {
 
 const NO_OP = null;
 
-export function setPropertyValue(bpmnFactory, commandStack, element, property, value) {
+export function setPropertyValue(bpmnFactory, commandStack, element, property, value, additionalProperties) {
   let businessObject = getBusinessObject(element);
 
   const {
@@ -676,7 +676,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
 
       // do not persist empty parameters when configured as <optional>
       if (shouldUpdate(value, property)) {
-        const newZeebeInputParameter = createInputParameter(binding, value, bpmnFactory, ioMapping);
+        const newZeebeInputParameter = createInputParameter(binding, value, bpmnFactory, ioMapping, additionalProperties);
         values.push(newZeebeInputParameter);
       }
 
@@ -781,7 +781,7 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
     const properties = zeebeProperties.get('properties').filter((property) => property !== oldZeebeProperty);
 
     if (shouldUpdate(value, property)) {
-      const newZeebeProperty = createZeebeProperty(binding, value, bpmnFactory);
+      const newZeebeProperty = createZeebeProperty(binding, value, bpmnFactory, additionalProperties);
 
       properties.push(newZeebeProperty);
     }

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -48,6 +48,8 @@ import ElementTemplatesPropertiesProviderModule from 'src/element-templates';
 
 import { ElementTemplateLinterPlugin } from 'src/cloud-element-templates/linting';
 
+import { connectors } from '@camunda/connectors-element-templates';
+
 const singleStart = window.__env__ && window.__env__.SINGLE_START;
 
 insertCoreStyles();
@@ -60,8 +62,8 @@ insertCSS('example.css', `
   }
 
   .test-container {
-    --example-properties-width: 20vw;
-    --example-bottom-height: 30vh;
+    --example-properties-width: 400px;
+    --example-bottom-height: 200px;
   }
 
   .bjs-container {
@@ -118,6 +120,258 @@ insertCSS('example.css', `
   .bottom-panel input {
     width: 200px;
   }
+
+  .ci-toggle-btn {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 99;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-family: sans-serif;
+    cursor: pointer;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  }
+
+  .ci-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.3);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .ci-modal {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    width: calc(100% - 40px);
+    height: calc(100% - 40px);
+    overflow-y: auto;
+    font-family: sans-serif;
+    font-size: 13px;
+  }
+
+  .ci-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #eee;
+  }
+
+  .ci-modal-header h3 {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .ci-modal-header button {
+    background: none;
+    border: none;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .ci-modal-body {
+    padding: 16px;
+  }
+
+  .ci-section {
+    margin-bottom: 16px;
+  }
+
+  .ci-section h4 {
+    margin: 0 0 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    color: #666;
+  }
+
+  .ci-instance-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .ci-instance-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 8px;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    margin-bottom: 4px;
+  }
+
+  .ci-instance-list li .ci-inst-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .ci-instance-list li .ci-inst-name {
+    font-weight: 600;
+  }
+
+  .ci-instance-list li .ci-inst-meta {
+    font-size: 11px;
+    color: #888;
+  }
+
+  .ci-instance-list li button {
+    width: auto;
+    padding: 2px 8px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+
+  .ci-create-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .ci-create-actions button {
+    flex: 1;
+    padding: 8px;
+    font-size: 12px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f7f7f8;
+  }
+
+  .ci-create-actions button:hover {
+    background: #e8e8ea;
+  }
+
+  .ci-form {
+    margin-top: 12px;
+    padding: 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fafafa;
+  }
+
+  .ci-form h5 {
+    margin: 0 0 8px;
+    font-size: 12px;
+  }
+
+  .ci-form label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    margin-bottom: 2px;
+    color: #444;
+  }
+
+  .ci-form input, .ci-form select {
+    width: 100%;
+    padding: 5px 8px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 12px;
+    margin-bottom: 8px;
+    box-sizing: border-box;
+  }
+
+  .ci-form .ci-form-row {
+    margin-bottom: 8px;
+  }
+
+  .ci-form .ci-form-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .ci-form .ci-form-actions button {
+    padding: 6px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  .ci-form .ci-form-actions button[data-primary] {
+    background: #0d47a1;
+    color: #fff;
+    border-color: #0d47a1;
+  }
+
+  .ci-empty {
+    color: #888;
+    font-style: italic;
+    padding: 8px 0;
+  }
+
+  .xml-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 1001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .xml-modal {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    width: calc(100% - 40px);
+    height: calc(100% - 40px);
+    display: flex;
+    flex-direction: column;
+    font-family: sans-serif;
+  }
+
+  .xml-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #eee;
+  }
+
+  .xml-modal-header h3 {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .xml-modal-header button {
+    background: none;
+    border: none;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .xml-modal pre {
+    flex: 1;
+    overflow: auto;
+    margin: 0;
+    padding: 16px;
+    font-size: 12px;
+    line-height: 1.5;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    border-radius: 0 0 8px 8px;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
 `);
 
 
@@ -150,6 +404,86 @@ const LogTemplateErrorsModule = {
   } ]
 };
 
+const SLACK_ICON = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJINDd6IiBmaWxsPSIjMzZDNUYwIi8+CiAgPHBhdGggZD0iTTk5LjkgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjIgNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yIDAgNy4zLTUuOSAxMy4yLTEzLjIgMTMuMkg5OS45VjQ2Ljl6bS02LjYgMGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUgNzIuOC42IDgwLjEuNmM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzMuMXoiIGZpbGw9IiMyRUI2N0QiLz4KICA8cGF0aCBkPSJNODAuMSA5OS44YzcuMyAwIDEzLjIgNS45IDEzLjIgMTMuMiAwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjk5LjhoMTMuMnptMC02LjZjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMiAwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo=';
+
+const SAMPLE_CONFIGURATIONS = [
+  {
+    name: 'awsProduction',
+    metadata: {
+      kind: 'CREDENTIAL',
+      displayName: 'AWS Production',
+      configurationTemplate: 'io.camunda:aws-credential:1',
+      configurationTemplateVersion: 1
+    }
+  },
+  {
+    name: 'awsDevelopment',
+    metadata: {
+      kind: 'CREDENTIAL',
+      displayName: 'AWS Development',
+      configurationTemplate: 'io.camunda:aws-credential:1',
+      configurationTemplateVersion: 1
+    }
+  },
+  {
+    name: 'restProduction',
+    metadata: {
+      kind: 'CREDENTIAL',
+      displayName: 'REST Production',
+      configurationTemplate: 'io.camunda.connectors:rest-authentication:1',
+      configurationTemplateVersion: 1
+    }
+  },
+  {
+    name: 'restDevelopment',
+    metadata: {
+      kind: 'CREDENTIAL',
+      displayName: 'REST Development',
+      configurationTemplate: 'io.camunda.connectors:rest-authentication:1',
+      configurationTemplateVersion: 1
+    }
+  },
+  {
+    name: 'jdbcReporting',
+    metadata: {
+      kind: 'CREDENTIAL',
+      displayName: 'JDBC Reporting',
+      configurationTemplate: 'io.camunda.connectors:jdbc-connection:1',
+      configurationTemplateVersion: 1
+    }
+  }
+];
+
+let demoConfigurations = [ ...SAMPLE_CONFIGURATIONS ];
+
+const DEFAULT_DEMO_FETCH_DELAY_SECONDS = 10;
+
+function reloadDemoConfigurations(configurationInstances, delaySeconds) {
+  configurationInstances.setLoading(true);
+
+  setTimeout(() => {
+    configurationInstances.setState({
+      selectableInstances: [ ...demoConfigurations ],
+      loading: false
+    });
+  }, delaySeconds * 1000);
+}
+
+const MockConfigurationInstancesModule = {
+
+  __init__: [ function(configurationInstances) {
+
+    demoConfigurations = [ ...SAMPLE_CONFIGURATIONS ];
+    configurationInstances.setState({
+      selectableInstances: demoConfigurations,
+      available: true,
+      permissions: {
+        create: true,
+        update: true
+      }
+    });
+  } ]
+};
 
 describe('<BpmnPropertiesPanelRenderer>', function() {
 
@@ -228,12 +562,19 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
   (singleStart === 'cloud-templates' ? it.only : it)('should import simple process (cloud-templates)', async function() {
 
+    this.timeout(10000);
+
     // given
     const diagramXml = require('test/spec/cloud-element-templates/fixtures/complex.bpmn').default;
 
-    const elementTemplateContext = require.context('test/spec/cloud-element-templates/fixtures', false, /\.json$/);
-
-    const elementTemplates = elementTemplateContext.keys().map(key => elementTemplateContext(key)).flat();
+    const elementTemplates = connectors.flatMap(connector => connector.default || connector),
+          configurationTemplates = new Set(
+            elementTemplates.flatMap((template) => {
+              return (template.configurationTemplates || []).map(({ id, version = 1 }) => {
+                return `${ id }@${ version }`;
+              });
+            })
+          );
 
     // when
     const result = await createModeler(
@@ -251,6 +592,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
           CreateAppendElementTemplatesModule,
           ChangeEnginesModule,
           LogTemplateErrorsModule,
+          MockConfigurationInstancesModule,
           LintingModule
         ],
         moddleExtensions: {
@@ -269,6 +611,22 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
     // then
     expect(result.error).not.to.exist;
+
+    const latestS3Template = result.modeler.get('elementTemplates').getLatest('io.camunda.connectors.aws.s3.v1')[0],
+          awsCredential = latestS3Template.properties.find(({ id }) => id === 'awsCredential');
+
+    expect(latestS3Template.version).to.equal(6);
+    expect(awsCredential).to.include({
+      type: 'Configuration',
+      configurationTemplate: 'io.camunda:aws-credential:1'
+    });
+    const missingMockConfigurationTemplates = SAMPLE_CONFIGURATIONS
+      .map(({ metadata }) => {
+        return `${ metadata.configurationTemplate }@${ metadata.configurationTemplateVersion }`;
+      })
+      .filter((configurationTemplate) => !configurationTemplates.has(configurationTemplate));
+
+    expect(missingMockConfigurationTemplates).to.be.empty;
 
     // and
     createTestUI(result.modeler);
@@ -338,6 +696,414 @@ function createTestUI(modeler) {
 
     propertiesPanel.attachTo(propertiesPanelParent);
   }
+
+  // --- Configuration instances modal ---
+  const configurationInstances = modeler.get('configurationInstances', false);
+
+  const configurationTemplates = modeler.get('configurationTemplates', false);
+
+  if (configurationInstances) {
+
+    let pendingCreation = null;
+
+    eventBus.on('configuration.create', (event) => {
+      pendingCreation = event;
+      openModal();
+    });
+
+    eventBus.on('configuration.edit', ({ instance }) => {
+      window.prompt('Edit configuration:', instance.name);
+    });
+
+    eventBus.on('configuration.upgrade', ({ instance, configurationTemplateVersion }) => {
+      window.prompt(`Upgrade configuration to v${ configurationTemplateVersion }:`, instance.name);
+    });
+
+    // Toggle button
+    const toggleBtn = domify('<button class="ci-toggle-btn">⚙ Configurations</button>');
+    container.appendChild(toggleBtn);
+
+    let backdrop = null;
+    let onInstancesChanged;
+
+    const closeModal = () => {
+      if (backdrop) {
+        eventBus.off('configurationInstances.changed', onInstancesChanged);
+        backdrop.remove();
+        backdrop = null;
+      }
+    };
+
+    const openModal = () => {
+      if (backdrop) return;
+
+      backdrop = domify('<div class="ci-modal-backdrop"></div>');
+      const modal = domify('<div class="ci-modal"></div>');
+      backdrop.appendChild(modal);
+      document.body.appendChild(backdrop);
+
+      backdrop.addEventListener('click', (e) => {
+        if (e.target === backdrop) closeModal();
+      });
+
+      renderModal(modal);
+
+      onInstancesChanged = () => {
+        if (backdrop) {
+          renderModal(modal);
+        }
+      };
+      eventBus.on('configurationInstances.changed', onInstancesChanged);
+    };
+
+    const renderModal = (modal) => {
+      const all = configurationInstances.getSelectableInstances();
+      const loading = configurationInstances.isLoading();
+      const available = configurationInstances.isAvailable();
+      const canCreate = configurationInstances.canCreate();
+      const canUpdate = configurationInstances.canUpdate();
+      const availableConfigurationTemplates = configurationTemplates.getLatest()
+        .sort((first, second) => first.name.localeCompare(second.name));
+      const configurationTemplateOptions = availableConfigurationTemplates.map((template) => {
+        return `<option value="${ escapeHTML(`${ template.id }@${ template.version }`) }">${ escapeHTML(template.name) }</option>`;
+      }).join('');
+
+      modal.innerHTML = `
+        <div class="ci-modal-header">
+          <h3>Configuration Instances (Hub simulation)</h3>
+          <button data-close>&times;</button>
+        </div>
+        <div class="ci-modal-body">
+          <div class="ci-section">
+            <h4>Existing instances${ loading ? ' (loading...)' : '' }</h4>
+            <div class="ci-list-container"></div>
+            <div class="ci-create-actions">
+              <label><input type="checkbox" data-field="cluster-connected" ${ available ? 'checked' : '' } ${ loading ? 'disabled' : '' } /> Cluster connected</label>
+              <label><input type="checkbox" data-field="permission-create" ${ canCreate ? 'checked' : '' } ${ !available || loading ? 'disabled' : '' } /> Can create</label>
+              <label><input type="checkbox" data-field="permission-update" ${ canUpdate ? 'checked' : '' } ${ !available || loading ? 'disabled' : '' } /> Can update</label>
+              <label>Loading seconds <input type="number" data-field="reload-delay" value="${ DEFAULT_DEMO_FETCH_DELAY_SECONDS }" min="0" step="1" ${ loading ? 'disabled' : '' } /></label>
+              <button data-action="reload" ${ loading ? 'disabled' : '' }>Reload</button>
+              <button data-action="fail-load" ${ !available || loading ? 'disabled' : '' }>Fail load</button>
+            </div>
+          </div>
+          <div class="ci-section">
+            <h4>Create new configuration</h4>
+            <div class="ci-create-actions">
+              <button data-action="random">Create random (AWS)</button>
+              <label>Configuration template
+                <select data-field="configuration-template">
+                  <option value="">Choose configuration template</option>
+                  ${ configurationTemplateOptions }
+                </select>
+              </label>
+            </div>
+            <div class="ci-form-container"></div>
+          </div>
+          <div class="ci-section">
+            <h4>Bulk actions</h4>
+            <div class="ci-create-actions">
+              <button data-action="load-samples">Load samples</button>
+              <button data-action="mark-loaded">Mark loaded (empty)</button>
+            </div>
+          </div>
+        </div>
+      `;
+
+      modal.querySelector('[data-close]').addEventListener('click', closeModal);
+
+      modal.querySelector('[data-field="cluster-connected"]').addEventListener('change', (event) => {
+        const available = event.target.checked;
+
+        configurationInstances.setState({
+          selectableInstances: available ? [ ...demoConfigurations ] : [],
+          loading: false,
+          available,
+          unavailableMessage: available ? null : 'No cluster selected'
+        });
+      });
+
+      modal.querySelector('[data-field="permission-create"]').addEventListener('change', (event) => {
+        configurationInstances.setState({
+          permissions: {
+            create: event.target.checked,
+            update: configurationInstances.canUpdate()
+          }
+        });
+      });
+
+      modal.querySelector('[data-field="permission-update"]').addEventListener('change', (event) => {
+        configurationInstances.setState({
+          permissions: {
+            create: configurationInstances.canCreate(),
+            update: event.target.checked
+          }
+        });
+      });
+
+      modal.querySelector('[data-action="reload"]').addEventListener('click', () => {
+        const delayInput = modal.querySelector('[data-field="reload-delay"]');
+        const delaySeconds = Number(delayInput.value);
+
+        reloadDemoConfigurations(
+          configurationInstances,
+          Number.isFinite(delaySeconds) ? Math.max(0, delaySeconds) : DEFAULT_DEMO_FETCH_DELAY_SECONDS
+        );
+      });
+
+      modal.querySelector('[data-action="fail-load"]').addEventListener('click', () => {
+        configurationInstances.setState({
+          loading: false,
+          error: true,
+          permissions: {
+            create: false,
+            update: false
+          }
+        });
+      });
+
+      // Render instance list
+      const listContainer = modal.querySelector('.ci-list-container');
+
+      if (all.length === 0) {
+        listContainer.innerHTML = '<p class="ci-empty">No configuration instances available.</p>';
+      } else {
+        const list = domify('<ul class="ci-instance-list"></ul>');
+
+        all.forEach((inst, idx) => {
+          const li = domify(
+            `<li>
+              <div class="ci-inst-info">
+                <span class="ci-inst-name">${ escapeHTML(inst.metadata.displayName || inst.name) }</span>
+                <span class="ci-inst-meta">${ escapeHTML(inst.metadata.configurationTemplate) } v${ inst.metadata.configurationTemplateVersion || '?' }</span>
+              </div>
+              <button data-change-type="${ idx }">Change type</button>
+              <button data-remove="${ idx }">Remove</button>
+            </li>`
+          );
+
+          li.querySelector('[data-change-type]').addEventListener('click', () => {
+            demoConfigurations = configurationInstances.getSelectableInstances().map((instance, index) => {
+              if (index !== idx) {
+                return instance;
+              }
+
+              return {
+                ...instance,
+                metadata: {
+                  ...instance.metadata,
+                  configurationTemplate: 'io.camunda:other-credential:1'
+                }
+              };
+            });
+            configurationInstances.setSelectableInstances(demoConfigurations);
+            renderModal(modal);
+          });
+
+          li.querySelector('[data-remove]').addEventListener('click', () => {
+            demoConfigurations = configurationInstances.getSelectableInstances().filter((_, i) => i !== idx);
+            configurationInstances.setSelectableInstances(demoConfigurations);
+            renderModal(modal);
+          });
+
+          list.appendChild(li);
+        });
+
+        listContainer.appendChild(list);
+      }
+
+      // Random creation
+      modal.querySelector('[data-action="random"]').addEventListener('click', () => {
+        const id = Math.random().toString(36).slice(2, 7);
+        const current = configurationInstances.getSelectableInstances();
+
+        demoConfigurations = [
+          ...current,
+          {
+            name: 'aws_' + id,
+            metadata: {
+              kind: 'CREDENTIAL',
+              displayName: 'AWS ' + id.charAt(0).toUpperCase() + id.slice(1),
+              configurationTemplate: 'io.camunda:aws-credential:1',
+              configurationTemplateVersion: 1
+            },
+            icon: SLACK_ICON
+          }
+        ];
+        configurationInstances.setSelectableInstances(demoConfigurations);
+
+        renderModal(modal);
+      });
+
+      // Explicit creation — render configuration template form
+      const formContainer = modal.querySelector('.ci-form-container'),
+            configurationTemplateSelect = modal.querySelector('[data-field="configuration-template"]');
+
+      const openForm = (tmpl) => {
+
+        formContainer.innerHTML = '';
+
+        const form = domify(
+          `<div class="ci-form">
+            <h5>New "${ escapeHTML(tmpl.name) }" — fill in fields as Hub would render them</h5>
+            <div class="ci-form-row">
+              <label>Instance name (cluster variable key)</label>
+              <input type="text" data-field="name" placeholder="e.g. awsProduction" />
+            </div>
+            <div class="ci-form-row">
+              <label>Display name</label>
+              <input type="text" data-field="displayName" placeholder="e.g. AWS Production" />
+            </div>
+            <div class="ci-form-row">
+              <label>Version (stamped from template)</label>
+              <label style="display:inline-flex;align-items:center;gap:4px;font-weight:normal;font-size:11px;color:#888;margin-bottom:4px;">
+                <input type="checkbox" data-field="overrideVersion" />
+                Override version (demo only — simulate outdated instances)
+              </label>
+              <input type="number" data-field="version" value="${ tmpl.version }" min="1" disabled />
+            </div>
+            <hr/>
+            <p style="font-size:11px;color:#666;margin:4px 0 8px;">
+              Below: configuration template properties (the JSON object stored as cluster variable)
+            </p>
+            ${ (tmpl.properties || []).map(property => {
+    const propertyName = property.binding?.name;
+
+    if (!propertyName) {
+      return '';
+    }
+
+    return `<div class="ci-form-row">
+      <label>${ escapeHTML(property.label || propertyName) }${ property.constraints?.notEmpty ? ' *' : '' }</label>
+      <input type="text" data-prop="${ escapeHTML(propertyName) }" placeholder="${ escapeHTML(propertyName) }" />
+    </div>`;
+  }).join('') }
+            <div class="ci-form-actions">
+              <button data-primary data-action="submit">Create configuration</button>
+              <button data-action="cancel">Cancel</button>
+            </div>
+          </div>`
+        );
+
+        // Toggle version override
+        form.querySelector('[data-field="overrideVersion"]').addEventListener('change', (e) => {
+          form.querySelector('[data-field="version"]').disabled = !e.target.checked;
+        });
+
+        form.querySelector('[data-action="cancel"]').addEventListener('click', () => {
+          pendingCreation = null;
+          formContainer.innerHTML = '';
+        });
+
+        form.querySelector('[data-action="submit"]').addEventListener('click', () => {
+          const name = form.querySelector('[data-field="name"]').value.trim();
+          const displayName = form.querySelector('[data-field="displayName"]').value.trim();
+          const version = parseInt(form.querySelector('[data-field="version"]').value, 10) || 1;
+
+          if (!name) {
+            alert('Instance name is required');
+            return;
+          }
+
+          const current = configurationInstances.getSelectableInstances();
+
+          demoConfigurations = [
+            ...current,
+            {
+              name,
+              metadata: {
+                kind: 'CREDENTIAL',
+                displayName: displayName || name,
+                configurationTemplate: tmpl.id,
+                configurationTemplateVersion: version
+              },
+              icon: tmpl.icon
+            }
+          ];
+          const instance = demoConfigurations[demoConfigurations.length - 1];
+
+          configurationInstances.setSelectableInstances(demoConfigurations);
+
+          if (pendingCreation) {
+            eventBus.fire('configuration.created', {
+              ...pendingCreation,
+              instance
+            });
+            pendingCreation = null;
+          }
+
+          formContainer.innerHTML = '';
+          renderModal(modal);
+        });
+
+        formContainer.appendChild(form);
+      };
+
+      configurationTemplateSelect.addEventListener('change', () => {
+        if (!configurationTemplateSelect.value) {
+          pendingCreation = null;
+          formContainer.innerHTML = '';
+          return;
+        }
+
+        const [ id, version ] = configurationTemplateSelect.value.split('@');
+        const tmpl = configurationTemplates.get(id, Number(version));
+
+        pendingCreation = null;
+        openForm(tmpl);
+      });
+
+      if (pendingCreation) {
+        const tmpl = configurationTemplates.get(
+          pendingCreation.configurationTemplate,
+          pendingCreation.configurationTemplateVersion
+        ) || configurationTemplates.get(pendingCreation.configurationTemplate);
+
+        configurationTemplateSelect.value = `${ tmpl.id }@${ tmpl.version }`;
+        openForm(tmpl);
+      }
+
+      // Bulk actions
+      modal.querySelector('[data-action="load-samples"]').addEventListener('click', () => {
+        demoConfigurations = [ ...SAMPLE_CONFIGURATIONS ];
+        configurationInstances.setSelectableInstances(demoConfigurations);
+        renderModal(modal);
+      });
+
+      modal.querySelector('[data-action="mark-loaded"]').addEventListener('click', () => {
+        demoConfigurations = [];
+        configurationInstances.setSelectableInstances(demoConfigurations);
+        renderModal(modal);
+      });
+    };
+
+    toggleBtn.addEventListener('click', openModal);
+  }
+
+  // --- XML viewer button ---
+  const xmlBtn = domify('<button class="ci-toggle-btn" style="left: 130px;">&#60;/&#62; XML</button>');
+  container.appendChild(xmlBtn);
+
+  xmlBtn.addEventListener('click', async () => {
+    const { xml } = await bpmnjs.saveXML({ format: true });
+
+    const backdrop = domify('<div class="xml-modal-backdrop"></div>');
+    const modal = domify(
+      `<div class="xml-modal">
+        <div class="xml-modal-header">
+          <h3>BPMN XML</h3>
+          <button data-close>&times;</button>
+        </div>
+        <pre></pre>
+      </div>`
+    );
+
+    modal.querySelector('pre').textContent = xml;
+    modal.querySelector('[data-close]').addEventListener('click', () => backdrop.remove());
+    backdrop.addEventListener('click', (e) => { if (e.target === backdrop) backdrop.remove(); });
+
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+  });
 
   if (linting && elementTemplates) {
     const linter = new Linter({

--- a/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
@@ -13,7 +13,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     // given
     const configurationInstances = createConfigurationInstances();
 
-    configurationInstances.setInstances([ {
+    configurationInstances.setSelectableInstances([ {
       name: 'compatible',
       metadata: {
         kind: 'CREDENTIAL',
@@ -49,7 +49,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     } ]);
 
     // when
-    const instances = configurationInstances.getByConfigurationTemplate('io.camunda:slack-connection:1', 2);
+    const instances = configurationInstances.getSelectableByConfigurationTemplate('io.camunda:slack-connection:1', 2);
 
     // then
     expect(instances.map(({ name }) => name)).to.eql([ 'compatible' ]);
@@ -72,7 +72,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     expect(configurationInstances.isLoading()).to.be.true;
     expect(changedSpy).to.have.been.calledOnce;
     expect(changedSpy).to.have.been.calledWith({
-      instances: [],
+      selectableInstances: [],
       loading: true,
       error: false,
       clusterSelected: false,
@@ -84,7 +84,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
 
     // when
     configurationInstances.setState({
-      instances: [ {
+      selectableInstances: [ {
         name: 'slack-production',
         metadata: {
           kind: 'CREDENTIAL',
@@ -102,7 +102,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     });
 
     // then
-    expect(configurationInstances.getAll()).to.have.length(1);
+    expect(configurationInstances.getSelectableInstances()).to.have.length(1);
     expect(configurationInstances.isLoading()).to.be.false;
     expect(configurationInstances.hasError()).to.be.false;
     expect(configurationInstances.isClusterSelected()).to.be.true;
@@ -110,7 +110,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     expect(configurationInstances.canUpdate()).to.be.true;
     expect(changedSpy).to.have.been.calledTwice;
     expect(changedSpy).to.have.been.calledWith({
-      instances: configurationInstances.getAll(),
+      selectableInstances: configurationInstances.getSelectableInstances(),
       loading: false,
       error: false,
       clusterSelected: true,
@@ -136,7 +136,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
   });
 
 
-  it('should get an instance by name', function() {
+  it('should get a referenced instance by name', function() {
 
     // given
     const configurationInstances = createConfigurationInstances();
@@ -149,11 +149,39 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
       }
     };
 
-    configurationInstances.setInstances([ instance ]);
+    configurationInstances.setState({
+      referencedInstances: [ instance ],
+      clusterSelected: true
+    });
 
     // then
-    expect(configurationInstances.getByName('slack-production')).to.equal(instance);
-    expect(configurationInstances.getByName('missing')).not.to.exist;
+    expect(configurationInstances.getReferencedInstanceByName('slack-production')).to.equal(instance);
+    expect(configurationInstances.getReferencedInstanceByName('missing')).not.to.exist;
+  });
+
+
+  it('should keep a referenced instance out of selectable instances', function() {
+
+    // given
+    const configurationInstances = createConfigurationInstances();
+    const resolvedInstance = {
+      name: 'slack-production',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 1
+      }
+    };
+
+    configurationInstances.setState({
+      selectableInstances: [],
+      referencedInstances: [ resolvedInstance ],
+      clusterSelected: true
+    });
+
+    // then
+    expect(configurationInstances.getReferencedInstanceByName('slack-production')).to.equal(resolvedInstance);
+    expect(configurationInstances.getSelectableInstances()).to.be.empty;
   });
 
 
@@ -174,6 +202,32 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     expect(configurationInstances.isCompatible(instance, 'io.camunda:slack-connection:1', 2)).to.be.true;
     expect(configurationInstances.isCompatible(instance, 'io.camunda:slack-connection:1', 3)).to.be.false;
     expect(configurationInstances.isCompatible(instance, 'io.camunda:aws-connection:1', 2)).to.be.false;
+  });
+
+
+  it('should support any template-derived configuration kind', function() {
+
+    // given
+    const configurationInstances = createConfigurationInstances();
+    const templateDerivedInstance = {
+      name: 'shared-connection',
+      metadata: {
+        kind: 'CONNECTION',
+        configurationTemplate: 'io.camunda:shared-connection:1',
+        configurationTemplateVersion: 1
+      }
+    };
+    const plainVariable = {
+      name: 'plain-variable',
+      metadata: {
+        configurationTemplate: 'io.camunda:shared-connection:1',
+        configurationTemplateVersion: 1
+      }
+    };
+
+    // then
+    expect(configurationInstances.isCompatible(templateDerivedInstance, 'io.camunda:shared-connection:1', 1)).to.be.true;
+    expect(configurationInstances.isCompatible(plainVariable, 'io.camunda:shared-connection:1', 1)).to.be.false;
   });
 
 });

--- a/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import ConfigurationInstances from 'src/cloud-element-templates/core/ConfigurationInstances';
+
+import { EventBus } from '../mocks';
+
+
+describe('provider/cloud-element-templates - ConfigurationInstances', function() {
+
+  it('should return only instances compatible with the template and version', function() {
+
+    // given
+    const configurationInstances = createConfigurationInstances();
+
+    configurationInstances.setInstances([ {
+      name: 'compatible',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2
+      }
+    }, {
+      name: 'incompatible',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 1
+      }
+    }, {
+      name: 'other-template',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:aws-connection:1',
+        configurationTemplateVersion: 2
+      }
+    }, {
+      name: 'plain-variable',
+      metadata: {
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2
+      }
+    }, {
+      name: 'unversioned',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1'
+      }
+    } ]);
+
+    // when
+    const instances = configurationInstances.getByConfigurationTemplate('io.camunda:slack-connection:1', 2);
+
+    // then
+    expect(instances.map(({ name }) => name)).to.eql([ 'compatible' ]);
+  });
+
+
+  it('should notify listeners when the host updates instance state', function() {
+
+    // given
+    const eventBus = new EventBus();
+    const configurationInstances = createConfigurationInstances(eventBus);
+    const changedSpy = spy();
+
+    eventBus.on('configurationInstances.changed', changedSpy);
+
+    // when
+    configurationInstances.setLoading(true);
+
+    // then
+    expect(configurationInstances.isLoading()).to.be.true;
+    expect(changedSpy).to.have.been.calledOnce;
+    expect(changedSpy).to.have.been.calledWith({
+      instances: [],
+      loading: true,
+      error: false,
+      clusterSelected: false,
+      permissions: {
+        create: false,
+        update: false
+      }
+    });
+
+    // when
+    configurationInstances.setState({
+      instances: [ {
+        name: 'slack-production',
+        metadata: {
+          kind: 'CREDENTIAL',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ],
+      loading: false,
+      error: false,
+      clusterSelected: true,
+      permissions: {
+        create: true,
+        update: true
+      }
+    });
+
+    // then
+    expect(configurationInstances.getAll()).to.have.length(1);
+    expect(configurationInstances.isLoading()).to.be.false;
+    expect(configurationInstances.hasError()).to.be.false;
+    expect(configurationInstances.isClusterSelected()).to.be.true;
+    expect(configurationInstances.canCreate()).to.be.true;
+    expect(configurationInstances.canUpdate()).to.be.true;
+    expect(changedSpy).to.have.been.calledTwice;
+    expect(changedSpy).to.have.been.calledWith({
+      instances: configurationInstances.getAll(),
+      loading: false,
+      error: false,
+      clusterSelected: true,
+      permissions: {
+        create: true,
+        update: true
+      }
+    });
+
+    // when
+    configurationInstances.setState({ error: true });
+
+    // then
+    expect(configurationInstances.hasError()).to.be.true;
+
+    // when
+    configurationInstances.setState({ clusterSelected: false });
+
+    // then
+    expect(configurationInstances.hasError()).to.be.false;
+    expect(configurationInstances.canCreate()).to.be.false;
+    expect(configurationInstances.canUpdate()).to.be.false;
+  });
+
+
+  it('should get an instance by name', function() {
+
+    // given
+    const configurationInstances = createConfigurationInstances();
+    const instance = {
+      name: 'slack-production',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2
+      }
+    };
+
+    configurationInstances.setInstances([ instance ]);
+
+    // then
+    expect(configurationInstances.getByName('slack-production')).to.equal(instance);
+    expect(configurationInstances.getByName('missing')).not.to.exist;
+  });
+
+
+  it('should check whether an instance is compatible', function() {
+
+    // given
+    const configurationInstances = createConfigurationInstances();
+    const instance = {
+      name: 'slack-production',
+      metadata: {
+        kind: 'CREDENTIAL',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2
+      }
+    };
+
+    // then
+    expect(configurationInstances.isCompatible(instance, 'io.camunda:slack-connection:1', 2)).to.be.true;
+    expect(configurationInstances.isCompatible(instance, 'io.camunda:slack-connection:1', 3)).to.be.false;
+    expect(configurationInstances.isCompatible(instance, 'io.camunda:aws-connection:1', 2)).to.be.false;
+  });
+
+});
+
+
+function createConfigurationInstances(eventBus = new EventBus()) {
+  return new ConfigurationInstances(eventBus);
+}

--- a/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationInstances.spec.js
@@ -75,7 +75,8 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
       selectableInstances: [],
       loading: true,
       error: false,
-      clusterSelected: false,
+      available: false,
+      unavailableMessage: null,
       permissions: {
         create: false,
         update: false
@@ -94,7 +95,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
       } ],
       loading: false,
       error: false,
-      clusterSelected: true,
+      available: true,
       permissions: {
         create: true,
         update: true
@@ -105,7 +106,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     expect(configurationInstances.getSelectableInstances()).to.have.length(1);
     expect(configurationInstances.isLoading()).to.be.false;
     expect(configurationInstances.hasError()).to.be.false;
-    expect(configurationInstances.isClusterSelected()).to.be.true;
+    expect(configurationInstances.isAvailable()).to.be.true;
     expect(configurationInstances.canCreate()).to.be.true;
     expect(configurationInstances.canUpdate()).to.be.true;
     expect(changedSpy).to.have.been.calledTwice;
@@ -113,7 +114,8 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
       selectableInstances: configurationInstances.getSelectableInstances(),
       loading: false,
       error: false,
-      clusterSelected: true,
+      available: true,
+      unavailableMessage: null,
       permissions: {
         create: true,
         update: true
@@ -127,10 +129,15 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     expect(configurationInstances.hasError()).to.be.true;
 
     // when
-    configurationInstances.setState({ clusterSelected: false });
+    configurationInstances.setState({
+      available: false,
+      unavailableMessage: 'No cluster selected'
+    });
 
     // then
     expect(configurationInstances.hasError()).to.be.false;
+    expect(configurationInstances.isAvailable()).to.be.false;
+    expect(configurationInstances.getUnavailableMessage()).to.equal('No cluster selected');
     expect(configurationInstances.canCreate()).to.be.false;
     expect(configurationInstances.canUpdate()).to.be.false;
   });
@@ -151,12 +158,23 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
 
     configurationInstances.setState({
       referencedInstances: [ instance ],
-      clusterSelected: true
+      available: true
     });
 
     // then
     expect(configurationInstances.getReferencedInstanceByName('slack-production')).to.equal(instance);
     expect(configurationInstances.getReferencedInstanceByName('missing')).not.to.exist;
+
+    // when
+    configurationInstances.setState({
+      available: false
+    });
+    configurationInstances.setState({
+      available: true
+    });
+
+    // then
+    expect(configurationInstances.getReferencedInstanceByName('slack-production')).not.to.exist;
   });
 
 
@@ -176,7 +194,7 @@ describe('provider/cloud-element-templates - ConfigurationInstances', function()
     configurationInstances.setState({
       selectableInstances: [],
       referencedInstances: [ resolvedInstance ],
-      clusterSelected: true
+      available: true
     });
 
     // then

--- a/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
@@ -13,7 +13,69 @@ import modelingModule from 'bpmn-js/lib/features/modeling';
 import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import diagramXML from './ElementTemplates.bpmn';
-import connectionsDesignTemplates from './fixtures/connections-design.json';
+
+const configurationTemplateDescriptors = [
+  {
+    id: 'io.camunda.connectors.Slack.v1',
+    configurationTemplates: [
+      {
+        id: 'io.camunda:slack-connection:1',
+        name: 'Slack Connection',
+        version: 1,
+        kind: 'CREDENTIAL',
+        properties: []
+      }
+    ]
+  },
+  {
+    id: 'io.camunda.connectors.Slack.v2',
+    configurationTemplates: [
+      {
+        id: 'io.camunda:slack-connection:1',
+        name: 'Slack Connection',
+        version: 2,
+        kind: 'CREDENTIAL',
+        properties: []
+      }
+    ]
+  },
+  {
+    id: 'io.camunda.examples.Configuration.v1',
+    properties: [
+      {
+        id: 'configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:example-configuration:1',
+        configurationTemplateVersion: 1,
+        optional: true,
+        binding: {
+          type: 'zeebe:input',
+          name: 'configuration'
+        }
+      }
+    ],
+    configurationTemplates: [
+      {
+        id: 'io.camunda:example-configuration:1',
+        name: 'Example configuration',
+        version: 1,
+        kind: 'CREDENTIAL',
+        properties: [
+          {
+            id: 'apiKey',
+            label: 'API key',
+            type: 'String',
+            secret: true,
+            binding: {
+              type: 'property',
+              name: 'apiKey'
+            }
+          }
+        ]
+      }
+    ]
+  }
+];
 
 
 describe('provider/cloud-element-templates - ConfigurationTemplates', function() {
@@ -36,7 +98,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
       inject(function(elementTemplates, configurationTemplates) {
 
         // when
-        elementTemplates.set(connectionsDesignTemplates);
+        elementTemplates.set(configurationTemplateDescriptors);
 
         // then
         const all = configurationTemplates.getAll();
@@ -51,7 +113,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
       inject(function(elementTemplates, configurationTemplates) {
 
         // when
-        elementTemplates.set(connectionsDesignTemplates);
+        elementTemplates.set(configurationTemplateDescriptors);
 
         // then
         const template = configurationTemplates.get('io.camunda:example-configuration:1');
@@ -72,7 +134,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
           }
         });
 
-        const example = connectionsDesignTemplates.find(({ id }) => id === 'io.camunda.examples.Configuration.v1');
+        const example = configurationTemplateDescriptors.find(({ id }) => id === 'io.camunda.examples.Configuration.v1');
         const chooser = example.properties.find(({ id }) => id === 'configuration');
 
         expect(chooser).to.include({
@@ -94,7 +156,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
       inject(function(elementTemplates, configurationTemplates) {
 
         // given
-        elementTemplates.set(connectionsDesignTemplates);
+        elementTemplates.set(configurationTemplateDescriptors);
 
         expect(configurationTemplates.getAll()).to.have.length.greaterThan(0);
 
@@ -116,7 +178,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
         eventBus.on('configurationTemplates.changed', changedSpy);
 
         // when
-        elementTemplates.set(connectionsDesignTemplates);
+        elementTemplates.set(configurationTemplateDescriptors);
 
         // then
         expect(changedSpy).to.have.been.calledOnce;
@@ -129,7 +191,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
   describe('#get', function() {
 
     beforeEach(inject(function(elementTemplates) {
-      elementTemplates.set(connectionsDesignTemplates);
+      elementTemplates.set(configurationTemplateDescriptors);
     }));
 
 
@@ -189,7 +251,7 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
   describe('#getLatest', function() {
 
     beforeEach(inject(function(elementTemplates) {
-      elementTemplates.set(connectionsDesignTemplates);
+      elementTemplates.set(configurationTemplateDescriptors);
     }));
 
 

--- a/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
@@ -185,6 +185,32 @@ describe('provider/cloud-element-templates - ConfigurationTemplates', function()
       })
     );
 
+
+    it('should keep the first definition for a repeated template identity',
+      inject(function(elementTemplates, configurationTemplates) {
+
+        // when
+        elementTemplates.set([ {
+          id: 'example.first',
+          configurationTemplates: [ {
+            id: 'io.camunda:example-credential:1',
+            name: 'First definition',
+            version: 1
+          } ]
+        }, {
+          id: 'example.second',
+          configurationTemplates: [ {
+            id: 'io.camunda:example-credential:1',
+            name: 'Conflicting later definition',
+            version: 1
+          } ]
+        } ]);
+
+        // then
+        expect(configurationTemplates.get('io.camunda:example-credential:1', 1).name).to.equal('First definition');
+      })
+    );
+
   });
 
 

--- a/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationTemplates.spec.js
@@ -1,0 +1,214 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'bpmn-js/lib/core';
+import elementTemplatesCoreModule from 'src/cloud-element-templates/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+
+import zeebeModdlePackage from 'zeebe-bpmn-moddle/resources/zeebe';
+
+import diagramXML from './ElementTemplates.bpmn';
+import connectionsDesignTemplates from './fixtures/connections-design.json';
+
+
+describe('provider/cloud-element-templates - ConfigurationTemplates', function() {
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      elementTemplatesCoreModule,
+      modelingModule
+    ],
+    moddleExtensions: {
+      zeebe: zeebeModdlePackage
+    }
+  }));
+
+
+  describe('extraction', function() {
+
+    it('should extract configuration templates when element templates are set',
+      inject(function(elementTemplates, configurationTemplates) {
+
+        // when
+        elementTemplates.set(connectionsDesignTemplates);
+
+        // then
+        const all = configurationTemplates.getAll();
+
+        expect(all).to.have.length.greaterThan(0);
+        expect(all[0].id).to.equal('io.camunda:slack-connection:1');
+      })
+    );
+
+
+    it('should extract the minimal configuration example',
+      inject(function(elementTemplates, configurationTemplates) {
+
+        // when
+        elementTemplates.set(connectionsDesignTemplates);
+
+        // then
+        const template = configurationTemplates.get('io.camunda:example-configuration:1');
+
+        expect(template).to.include({
+          id: 'io.camunda:example-configuration:1',
+          kind: 'CREDENTIAL',
+          version: 1
+        });
+        expect(template.properties).to.deep.include({
+          id: 'apiKey',
+          label: 'API key',
+          type: 'String',
+          secret: true,
+          binding: {
+            type: 'property',
+            name: 'apiKey'
+          }
+        });
+
+        const example = connectionsDesignTemplates.find(({ id }) => id === 'io.camunda.examples.Configuration.v1');
+        const chooser = example.properties.find(({ id }) => id === 'configuration');
+
+        expect(chooser).to.include({
+          id: 'configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:example-configuration:1',
+          configurationTemplateVersion: 1,
+          optional: true
+        });
+        expect(chooser.binding).to.deep.equal({
+          type: 'zeebe:input',
+          name: 'configuration'
+        });
+      })
+    );
+
+
+    it('should update when element templates change',
+      inject(function(elementTemplates, configurationTemplates) {
+
+        // given
+        elementTemplates.set(connectionsDesignTemplates);
+
+        expect(configurationTemplates.getAll()).to.have.length.greaterThan(0);
+
+        // when
+        elementTemplates.set([]);
+
+        // then
+        expect(configurationTemplates.getAll()).to.have.length(0);
+      })
+    );
+
+
+    it('should fire configurationTemplates.changed',
+      inject(function(elementTemplates, configurationTemplates, eventBus) {
+
+        // given
+        const changedSpy = spy();
+
+        eventBus.on('configurationTemplates.changed', changedSpy);
+
+        // when
+        elementTemplates.set(connectionsDesignTemplates);
+
+        // then
+        expect(changedSpy).to.have.been.calledOnce;
+      })
+    );
+
+  });
+
+
+  describe('#get', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(connectionsDesignTemplates);
+    }));
+
+
+    it('should get by ID (latest version)',
+      inject(function(configurationTemplates) {
+
+        // when
+        const template = configurationTemplates.get('io.camunda:slack-connection:1');
+
+        // then
+        expect(template).to.exist;
+        expect(template.id).to.equal('io.camunda:slack-connection:1');
+        expect(template.version).to.equal(2);
+      })
+    );
+
+
+    it('should get by ID and version',
+      inject(function(configurationTemplates) {
+
+        // when
+        const template = configurationTemplates.get('io.camunda:slack-connection:1', 2);
+
+        // then
+        expect(template).to.exist;
+        expect(template.version).to.equal(2);
+      })
+    );
+
+
+    it('should return null for unknown ID',
+      inject(function(configurationTemplates) {
+
+        // when
+        const template = configurationTemplates.get('unknown');
+
+        // then
+        expect(template).to.be.null;
+      })
+    );
+
+
+    it('should return null for unknown version',
+      inject(function(configurationTemplates) {
+
+        // when
+        const template = configurationTemplates.get('io.camunda:slack-connection:1', 999);
+
+        // then
+        expect(template).to.be.null;
+      })
+    );
+
+  });
+
+
+  describe('#getLatest', function() {
+
+    beforeEach(inject(function(elementTemplates) {
+      elementTemplates.set(connectionsDesignTemplates);
+    }));
+
+
+    it('should return one entry per unique ID',
+      inject(function(configurationTemplates) {
+
+        // when
+        const latest = configurationTemplates.getLatest();
+
+        // then
+        const ids = latest.map(t => t.id);
+        const uniqueIds = [ ...new Set(ids) ];
+        const slack = latest.find(({ id }) => id === 'io.camunda:slack-connection:1');
+
+        expect(ids).to.deep.equal(uniqueIds);
+        expect(slack.version).to.equal(2);
+      })
+    );
+
+  });
+
+});

--- a/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
+++ b/test/spec/cloud-element-templates/ElementTemplatesLoader.spec.js
@@ -3,6 +3,10 @@ import TestContainer from 'mocha-test-container-support';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
+import ElementTemplatesLoader from 'src/cloud-element-templates/ElementTemplatesLoader';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
 import { bootstrapModeler, inject } from 'test/TestHelper';
 
 import coreModule from 'bpmn-js/lib/core';
@@ -458,7 +462,130 @@ describe('provider/cloud-element-templates - ElementTemplatesLoader', function()
 
       });
 
+
+      describe('configuration validation', function() {
+
+        it('should load templates and emit a warning for a conflicting embedded configuration template', function() {
+
+          // given
+          const elementTemplates = createElementTemplates();
+          const loader = createLoader(elementTemplates);
+          const templates = [
+            createTemplate('example.first', createConfigurationTemplate()),
+            createTemplate('example.second', createConfigurationTemplate({
+              name: 'Different Credential'
+            }))
+          ];
+
+          // when
+          loader.setTemplates(templates);
+
+          // then
+          expect(elementTemplates.set).to.have.been.calledWith(templates);
+          const warningCall = elementTemplates._fire.getCalls().find(({ args }) => args[0] === 'warnings'),
+                [ , { warnings } ] = warningCall.args;
+
+          expect(warnings).to.have.length(1);
+          expect(warnings[0].message).to.contain('template(id: <example.second>, name: <example.second>): configuration template id <io.camunda:example-credential:1> and version <1> conflicts with the first embedded definition and will be ignored');
+        });
+
+
+        it('should only register valid element templates', function() {
+
+          // given
+          const elementTemplates = createElementTemplates();
+          const loader = createLoader(elementTemplates);
+          const templates = [
+            createTemplate('example.duplicate', createConfigurationTemplate()),
+            createTemplate('example.duplicate', createConfigurationTemplate())
+          ];
+
+          // when
+          loader.setTemplates(templates);
+
+          // then
+          expect(elementTemplates.set).to.have.been.calledOnce;
+          expect(elementTemplates.set.firstCall.args[0]).to.eql([ templates[0] ]);
+          const errorCall = elementTemplates._fire.getCalls().find(({ args }) => args[0] === 'errors'),
+                [ , { errors } ] = errorCall.args;
+
+          expect(errors).to.have.length(1);
+          expect(errors[0].message).to.contain('template id <example.duplicate> already used');
+        });
+
+
+        it('should report invalid configurationTemplates without aborting the load', function() {
+
+          // given
+          const elementTemplates = createElementTemplates();
+          const loader = createLoader(elementTemplates);
+          const template = createTemplate('example.invalid-configuration-templates', createConfigurationTemplate());
+
+          template.configurationTemplates = {};
+
+          // when
+          loader.setTemplates([ template ]);
+
+          // then
+          expect(elementTemplates.set).to.have.been.calledOnce;
+          expect(elementTemplates.set.firstCall.args[0]).to.eql([]);
+          const errorCall = elementTemplates._fire.getCalls().find(({ args }) => args[0] === 'errors'),
+                [ , { errors } ] = errorCall.args;
+
+          expect(errors).not.to.be.empty;
+        });
+
+      });
+
     });
+
+
+    function createLoader(elementTemplates) {
+      return new ElementTemplatesLoader(
+        [],
+        { on() {} },
+        elementTemplates,
+        new BpmnModdle()
+      );
+    }
+
+    function createElementTemplates() {
+      return {
+        set: spy(),
+        _fire: spy(),
+        isCompatible: () => true
+      };
+    }
+
+    function createTemplate(id, configurationTemplate) {
+      return {
+        $schema: SCHEMA,
+        id,
+        name: id,
+        appliesTo: [ 'bpmn:Task' ],
+        properties: [],
+        configurationTemplates: [ configurationTemplate ]
+      };
+    }
+
+    function createConfigurationTemplate(overrides = {}) {
+      return {
+        id: 'io.camunda:example-credential:1',
+        name: 'Example Credential',
+        version: 1,
+        kind: 'CREDENTIAL',
+        properties: [ {
+          id: 'apiKey',
+          label: 'API key',
+          type: 'String',
+          binding: {
+            type: 'property',
+            name: 'apiKey'
+          }
+        } ],
+        ...overrides
+      };
+    }
 
   });
 

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -20,10 +20,173 @@ describe('provider/cloud-element-templates - Validator', function() {
     return validator.getValidTemplates();
   }
 
+  function warnings(validator) {
+    return validator.getWarnings().map(function(warning) {
+      return warning.message;
+    });
+  }
+
   let moddle;
 
   beforeEach(function() {
     moddle = new BpmnModdle();
+  });
+
+  function createTemplate(id, configurationTemplate) {
+    return {
+      $schema: 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+      id,
+      name: id,
+      appliesTo: [ 'bpmn:Task' ],
+      properties: [],
+      configurationTemplates: [ configurationTemplate ]
+    };
+  }
+
+  function createConfigurationTemplate(overrides = {}) {
+    return {
+      id: 'io.camunda:example-credential:1',
+      name: 'Example Credential',
+      version: 1,
+      kind: 'CREDENTIAL',
+      properties: [ {
+        id: 'apiKey',
+        label: 'API key',
+        type: 'String',
+        binding: {
+          type: 'property',
+          name: 'apiKey'
+        }
+      } ],
+      ...overrides
+    };
+  }
+
+
+  describe('embedded configuration templates', function() {
+
+    it('should accept canonically equivalent repeated definitions', function() {
+
+      // given
+      const templates = new Validator(moddle);
+      const configurationTemplate = createConfigurationTemplate();
+      const reorderedConfigurationTemplate = {
+        properties: configurationTemplate.properties,
+        kind: configurationTemplate.kind,
+        version: configurationTemplate.version,
+        name: configurationTemplate.name,
+        id: configurationTemplate.id
+      };
+
+      // when
+      templates.addAll([
+        createTemplate('example.one', configurationTemplate),
+        createTemplate('example.two', reorderedConfigurationTemplate)
+      ]);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+      expect(valid(templates)).to.have.length(2);
+    });
+
+
+    it('should warn and preserve every template with a conflicting repeated definition', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      // when
+      templates.addAll([
+        createTemplate('example.one', createConfigurationTemplate()),
+        createTemplate('example.two', createConfigurationTemplate({
+          name: 'Different Credential'
+        }))
+      ]);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+      expect(valid(templates)).to.have.length(2);
+      expect(warnings(templates)).to.have.length(1);
+      expect(warnings(templates)[0]).to.contain('template(id: <example.two>, name: <example.two>): configuration template id <io.camunda:example-credential:1> and version <1> conflicts with the first embedded definition and will be ignored');
+    });
+
+
+    it('should reject incomplete embedded configuration templates', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      // when
+      templates.addAll([
+        createTemplate('example.invalid', {
+          id: 'io.camunda:example-credential:1'
+        })
+      ]);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+      expect(errors(templates)).to.include(
+        'template(id: <example.invalid>, name: <example.invalid>): configuration template name must be a non-empty string'
+      );
+    });
+
+  });
+
+
+  describe('configuration properties', function() {
+
+    it('should reject a configuration property without a template reference', function() {
+
+      // given
+      const templates = new Validator(moddle);
+      const template = createTemplate('example.invalid', createConfigurationTemplate());
+
+      template.properties = [ {
+        id: 'configuration',
+        type: 'Configuration',
+        binding: {
+          type: 'zeebe:input',
+          name: 'configuration'
+        }
+      } ];
+
+      // when
+      templates.addAll([ template ]);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+      expect(errors(templates)).to.include(
+        'template(id: <example.invalid>, name: <example.invalid>): configuration property requires a configurationTemplate'
+      );
+    });
+
+
+    it('should reject a configuration property with an unsupported binding', function() {
+
+      // given
+      const templates = new Validator(moddle);
+      const template = createTemplate('example.invalid', createConfigurationTemplate());
+
+      template.properties = [ {
+        id: 'configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:example-credential:1',
+        binding: {
+          type: 'zeebe:taskDefinition',
+          name: 'configuration'
+        }
+      } ];
+
+      // when
+      templates.addAll([ template ]);
+
+      // then
+      expect(valid(templates)).to.be.empty;
+      expect(errors(templates)).to.include(
+        'template(id: <example.invalid>, name: <example.invalid>): configuration property binding must be zeebe:input or zeebe:property'
+      );
+    });
+
   });
 
 

--- a/test/spec/cloud-element-templates/fixtures/complex.bpmn
+++ b/test/spec/cloud-element-templates/fixtures/complex.bpmn
@@ -1,185 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_165ah7c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.45.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
-  <bpmn:process id="Process_0vvlc66" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
-      <bpmn:outgoing>Flow_0gw5hlt</bpmn:outgoing>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1wd56qv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.47.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_1rrw1mn" isExecutable="true">
+    <bpmn:startEvent id="Event_18cltfd">
+      <bpmn:outgoing>Flow_1g317fm</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0gw5hlt" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
-    <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>Flow_0636r17</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0636r17" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
-    <bpmn:serviceTask id="ServiceTask_1" name="REST" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-s1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width=&#39;24&#39; height=&#39;24&#39; fill=&#39;none&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M16 2.5H8A5.5 5.5 0 0 0 2.5 8v8A5.5 5.5 0 0 0 8 21.5h8a5.5 5.5 0 0 0 5.5-5.5V8A5.5 5.5 0 0 0 16 2.5ZM8 1a7 7 0 0 0-7 7v8a7 7 0 0 0 7 7h8a7 7 0 0 0 7-7V8a7 7 0 0 0-7-7H8Z&#39; fill=&#39;%23505562&#39;/%3E%3Cpath d=&#39;M8.283 6.76v1.21c-.224 0-.416.02-.578.06a.612.612 0 0 0-.357.21c-.077.099-.106.242-.088.429l.17 1.622c.044.41-.001.742-.137.995a1.328 1.328 0 0 1-.61.584 3.306 3.306 0 0 1-.963.28c.392.059.724.154.995.286.272.132.47.323.594.572.125.25.165.583.121 1.001l-.17 1.623c-.018.183.011.326.088.429a.62.62 0 0 0 .363.209c.161.04.352.06.572.06v1.21c-.506 0-.935-.037-1.287-.11-.352-.073-.634-.19-.847-.352a1.214 1.214 0 0 1-.435-.627c-.077-.257-.097-.57-.06-.94l.165-1.573c.03-.28-.018-.497-.143-.655-.121-.158-.3-.268-.54-.33a3.102 3.102 0 0 0-.824-.099v-1.408c.308 0 .581-.031.82-.094.238-.066.42-.177.544-.335.125-.158.172-.376.143-.654L5.654 8.8c-.04-.378-.022-.697.055-.957.08-.26.225-.47.434-.627.213-.162.495-.277.847-.347a6.54 6.54 0 0 1 1.293-.11ZM9.527 16v-1.166h.77v-3.52h-.77v-1.155h2.096l.319 1.314c.209-.502.474-.876.797-1.122.326-.245.724-.368 1.194-.368a2.535 2.535 0 0 1 .962.176l-.528 1.435a2.48 2.48 0 0 0-.67-.087c-.382 0-.718.155-1.007.467-.286.312-.505.708-.655 1.188v1.672h1.155V16H9.527Zm3.955-3.399v-1.705l.258-.737h1.155l-.324 2.442h-1.09Zm2.239-5.841c.506 0 .935.037 1.287.11.352.073.633.19.842.352.212.158.36.367.44.627.08.257.1.57.06.94l-.165 1.574c-.029.278.019.496.143.654.125.158.305.27.54.335.238.063.513.094.824.094v1.408c-.308 0-.58.033-.82.099a.985.985 0 0 0-.544.33c-.124.158-.172.376-.143.655l.165 1.561c.04.378.02.697-.06.957-.077.26-.222.47-.435.628-.209.16-.491.276-.847.346a6.44 6.44 0 0 1-1.287.11v-1.21c.224 0 .415-.02.572-.06a.59.59 0 0 0 .358-.21c.08-.102.112-.245.093-.428l-.17-1.623c-.044-.414 0-.746.132-.995.136-.253.34-.446.616-.578.275-.136.598-.231.968-.286a3.52 3.52 0 0 1-1.001-.286 1.251 1.251 0 0 1-.594-.572c-.125-.253-.165-.587-.121-1.001l.17-1.622c.019-.187-.012-.33-.093-.43a.59.59 0 0 0-.358-.208 2.338 2.338 0 0 0-.572-.061V6.76Z&#39; fill=&#39;%23505562&#39;/%3E%3C/svg%3E">
+    <bpmn:serviceTask id="Activity_12jhq75" zeebe:modelerTemplate="io.camunda.connectors.aws.bedrock.codeinterpreter.v1" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNDBweCIgaGVpZ2h0PSI0MHB4IiB2aWV3Qm94PSIwIDAgNDAgNDAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8dGl0bGU+SWNvbi1BcmNoaXRlY3R1cmUvMzIvQXJjaF9BbWF6b24tQmVkcm9ja18zMjwvdGl0bGU+CiAgICA8ZyBpZD0iSWNvbi1BcmNoaXRlY3R1cmUvMzIvQXJjaF9BbWF6b24tQmVkcm9ja18zMiIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9Ikljb24tQXJjaGl0ZWN0dXJlLUJHLzMyL01hY2hpbmUtTGVhcm5pbmciIGZpbGw9IiMwMUE4OEQiPgogICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlIiB4PSIwIiB5PSIwIiB3aWR0aD0iNDAiIGhlaWdodD0iNDAiPjwvcmVjdD4KICAgICAgICA8L2c+CiAgICAgICAgPGcgaWQ9Ikljb24tU2VydmljZS8zMi9BbWF6b24tQmVkcm9ja18zMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNi4wMDAwMDAsIDYuMDAwMDAwKSIgZmlsbD0iI0ZGRkZGRiI+CiAgICAgICAgICAgIDxwYXRoIGQ9Ik0xMC41MTYsMjYuOTMzMjExNiBMOC4yOTMsMjUuNjYzMjExNiBMMTEuNzI0LDIzLjk0NzIxMTYgTDExLjI3NywyMy4wNTMyMTE2IEw3LjI3NywyNS4wNTMyMTE2IEw3LjI5NywyNS4wOTQyMTE2IEw0LDIzLjIxMDIxMTYgTDQsMTkuODA5MjExNiBMNy43MjQsMTcuOTQ3MjExNiBMNy4yNzcsMTcuMDUzMjExNiBMMy41MzYsMTguOTIzMjExNiBMMSwxNy4yMzIyMTE2IEwxLDE0LjgwOTIxMTYgTDQuNzI0LDEyLjk0NzIxMTYgTDQuMjc3LDEyLjA1MzIxMTYgTDEsMTMuNjkxMjExNiBMMSwxMC43NjcyMTE2IEwzLjUyMyw5LjA4NjIxMTU4IEw3LDExLjAzODIxMTYgTDcsMTQuMTkxMjExNiBMNS4yNzcsMTUuMDUzMjExNiBMNS43MjQsMTUuOTQ3MjExNiBMNy41LDE1LjA1OTIxMTYgTDkuMjc3LDE1Ljk0NzIxMTYgTDkuNzI0LDE1LjA1MzIxMTYgTDgsMTQuMTkxMjExNiBMOCwxMC43NjcyMTE2IEwxMC43NzgsOC45MTYyMTE1OCBDMTAuOTE2LDguODIzMjExNTggMTEsOC42NjcyMTE1OCAxMSw4LjUwMDIxMTU4IEwxMSw1LjAwMDIxMTU4IEwxMCw1LjAwMDIxMTU4IEwxMCw4LjIzMjIxMTU4IEw3LjI3OCwxMC4wNDcyMTE2IEw0LDguMjA3MjExNTggTDQsNC4wMzUyMTE1OCBMNywyLjY1NzIxMTU4IEw3LDcuMDAwMjExNTggTDgsNy4wMDAyMTE1OCBMOCwyLjE5ODIxMTU4IEwxMC40OTIsMS4wNTQyMTE1OCBMMTQsMi44MDkyMTE1OCBMMTQsMTcuMTkxMjExNiBMNi4yNzcsMjEuMDUzMjExNiBMNi43MjQsMjEuOTQ3MjExNiBMMTQsMTguMzA5MjExNiBMMTQsMjUuMTkxMjExNiBMMTAuNTE2LDI2LjkzMzIxMTYgWiBNMjUuNSwxOS41MDAyMTE2IEMyNS41LDIwLjA1MTIxMTYgMjUuMDUyLDIwLjUwMDIxMTYgMjQuNSwyMC41MDAyMTE2IEMyMy45NDksMjAuNTAwMjExNiAyMy41LDIwLjA1MTIxMTYgMjMuNSwxOS41MDAyMTE2IEMyMy41LDE4Ljk0OTIxMTYgMjMuOTQ5LDE4LjUwMDIxMTYgMjQuNSwxOC41MDAyMTE2IEMyNS4wNTIsMTguNTAwMjExNiAyNS41LDE4Ljk0OTIxMTYgMjUuNSwxOS41MDAyMTE2IEwyNS41LDE5LjUwMDIxMTYgWiBNMjAuNSwyNC4wMDAyMTE2IEMyMC41LDI0LjU1MTIxMTYgMjAuMDUyLDI1LjAwMDIxMTYgMTkuNSwyNS4wMDAyMTE2IEMxOC45NDksMjUuMDAwMjExNiAxOC41LDI0LjU1MTIxMTYgMTguNSwyNC4wMDAyMTE2IEMxOC41LDIzLjQ0OTIxMTYgMTguOTQ5LDIzLjAwMDIxMTYgMTkuNSwyMy4wMDAyMTE2IEMyMC4wNTIsMjMuMDAwMjExNiAyMC41LDIzLjQ0OTIxMTYgMjAuNSwyNC4wMDAyMTE2IEwyMC41LDI0LjAwMDIxMTYgWiBNMTkuNSw0LjAwMDIxMTU4IEMxOS41LDMuNDQ5MjExNTggMTkuOTQ5LDMuMDAwMjExNTggMjAuNSwzLjAwMDIxMTU4IEMyMS4wNTIsMy4wMDAyMTE1OCAyMS41LDMuNDQ5MjExNTggMjEuNSw0LjAwMDIxMTU4IEMyMS41LDQuNTUxMjExNTggMjEuMDUyLDUuMDAwMjExNTggMjAuNSw1LjAwMDIxMTU4IEMxOS45NDksNS4wMDAyMTE1OCAxOS41LDQuNTUxMjExNTggMTkuNSw0LjAwMDIxMTU4IEwxOS41LDQuMDAwMjExNTggWiBNMjYsMTEuNTAwMjExNiBDMjYuNTUyLDExLjUwMDIxMTYgMjcsMTEuOTQ5MjExNiAyNywxMi41MDAyMTE2IEMyNywxMy4wNTEyMTE2IDI2LjU1MiwxMy41MDAyMTE2IDI2LDEzLjUwMDIxMTYgQzI1LjQ0OSwxMy41MDAyMTE2IDI1LDEzLjA1MTIxMTYgMjUsMTIuNTAwMjExNiBDMjUsMTEuOTQ5MjExNiAyNS40NDksMTEuNTAwMjExNiAyNiwxMS41MDAyMTE2IEwyNiwxMS41MDAyMTE2IFogTTI0LjA3MSwxMy4wMDAyMTE2IEMyNC4yOTUsMTMuODYwMjExNiAyNS4wNzEsMTQuNTAwMjExNiAyNiwxNC41MDAyMTE2IEMyNy4xMDMsMTQuNTAwMjExNiAyOCwxMy42MDMyMTE2IDI4LDEyLjUwMDIxMTYgQzI4LDExLjM5NzIxMTYgMjcuMTAzLDEwLjUwMDIxMTYgMjYsMTAuNTAwMjExNiBDMjUuMDcxLDEwLjUwMDIxMTYgMjQuMjk1LDExLjE0MDIxMTYgMjQuMDcxLDEyLjAwMDIxMTYgTDE1LDEyLjAwMDIxMTYgTDE1LDkuMDAwMjExNTggTDIwLjUsOS4wMDAyMTE1OCBDMjAuNzc3LDkuMDAwMjExNTggMjEsOC43NzYyMTE1OCAyMSw4LjUwMDIxMTU4IEwyMSw1LjkyOTIxMTU4IEMyMS44Niw1LjcwNTIxMTU4IDIyLjUsNC45MjkyMTE1OCAyMi41LDQuMDAwMjExNTggQzIyLjUsMi44OTcyMTE1OCAyMS42MDMsMi4wMDAyMTE1OCAyMC41LDIuMDAwMjExNTggQzE5LjM5OCwyLjAwMDIxMTU4IDE4LjUsMi44OTcyMTE1OCAxOC41LDQuMDAwMjExNTggQzE4LjUsNC45MjkyMTE1OCAxOS4xNCw1LjcwNTIxMTU4IDIwLDUuOTI5MjExNTggTDIwLDguMDAwMjExNTggTDE1LDguMDAwMjExNTggTDE1LDIuNTAwMjExNTggQzE1LDIuMzEwMjExNTggMTQuODkzLDIuMTM4MjExNTggMTQuNzI0LDIuMDUzMjExNTggTDEwLjcyNCwwLjA1MzIxMTU4NDMgQzEwLjU4OCwtMC4wMTQ3ODg0MTU3IDEwLjQzLC0wLjAxNzc4ODQxNTcgMTAuMjkxLDAuMDQ1MjExNTg0MyBMMy4yOTEsMy4yNjAyMTE1OCBDMy4xMTUsMy4zNDEyMTE1OCAzLDMuNTE5MjExNTggMywzLjcxNDIxMTU4IEwzLDguMjMyMjExNTggTDAuMjIzLDEwLjA4NDIxMTYgQzAuMDg0LDEwLjE3NzIxMTYgMCwxMC4zMzMyMTE2IDAsMTAuNTAwMjExNiBMMCwxNy41MDAyMTE2IEMwLDE3LjY2NzIxMTYgMC4wODQsMTcuODIzMjExNiAwLjIyMywxNy45MTYyMTE2IEwzLDE5Ljc2NzIxMTYgTDMsMjMuNTAwMjExNiBDMywyMy42NzkyMTE2IDMuMDk2LDIzLjg0NTIxMTYgMy4yNTIsMjMuOTM0MjExNiBMMTAuMjUyLDI3LjkzNDIxMTYgQzEwLjMyOSwyNy45NzgyMTE2IDEwLjQxNCwyOC4wMDAyMTE2IDEwLjUsMjguMDAwMjExNiBDMTAuNTc3LDI4LjAwMDIxMTYgMTAuNjU0LDI3Ljk4MjIxMTYgMTAuNzI0LDI3Ljk0NzIxMTYgTDE0LjcyNCwyNS45NDcyMTE2IEMxNC44OTMsMjUuODYyMjExNiAxNSwyNS42ODkyMTE2IDE1LDI1LjUwMDIxMTYgTDE1LDIxLjAwMDIxMTYgTDE5LDIxLjAwMDIxMTYgTDE5LDIyLjA3MTIxMTYgQzE4LjE0LDIyLjI5NTIxMTYgMTcuNSwyMy4wNzEyMTE2IDE3LjUsMjQuMDAwMjExNiBDMTcuNSwyNS4xMDMyMTE2IDE4LjM5OCwyNi4wMDAyMTE2IDE5LjUsMjYuMDAwMjExNiBDMjAuNjAzLDI2LjAwMDIxMTYgMjEuNSwyNS4xMDMyMTE2IDIxLjUsMjQuMDAwMjExNiBDMjEuNSwyMy4wNzEyMTE2IDIwLjg2LDIyLjI5NTIxMTYgMjAsMjIuMDcxMjExNiBMMjAsMjAuNTAwMjExNiBDMjAsMjAuMjI0MjExNiAxOS43NzcsMjAuMDAwMjExNiAxOS41LDIwLjAwMDIxMTYgTDE1LDIwLjAwMDIxMTYgTDE1LDE3LjAwMDIxMTYgTDIxLjI5MywxNy4wMDAyMTE2IEwyMi43ODQsMTguNDkwMjExNiBDMjIuNjA4LDE4Ljc4ODIxMTYgMjIuNSwxOS4xMzAyMTE2IDIyLjUsMTkuNTAwMjExNiBDMjIuNSwyMC42MDMyMTE2IDIzLjM5OCwyMS41MDAyMTE2IDI0LjUsMjEuNTAwMjExNiBDMjUuNjAzLDIxLjUwMDIxMTYgMjYuNSwyMC42MDMyMTE2IDI2LjUsMTkuNTAwMjExNiBDMjYuNSwxOC4zOTcyMTE2IDI1LjYwMywxNy41MDAyMTE2IDI0LjUsMTcuNTAwMjExNiBDMjQuMTMxLDE3LjUwMDIxMTYgMjMuNzg4LDE3LjYwODIxMTYgMjMuNDkxLDE3Ljc4MzIxMTYgTDIxLjg1NCwxNi4xNDYyMTE2IEMyMS43NiwxNi4wNTMyMTE2IDIxLjYzMywxNi4wMDAyMTE2IDIxLjUsMTYuMDAwMjExNiBMMTUsMTYuMDAwMjExNiBMMTUsMTMuMDAwMjExNiBMMjQuMDcxLDEzLjAwMDIxMTYgWiIgaWQ9IkZpbGwtNSI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="http" />
-        <zeebe:taskHeaders>
-          <zeebe:header key="method" value="get" />
-          <zeebe:header key="url" />
-        </zeebe:taskHeaders>
+        <zeebe:taskDefinition type="io.camunda:aws-bedrock-codeinterpreter:1" retries="3" />
         <zeebe:ioMapping>
-          <zeebe:input source="= invoiceDetails" target="body" />
-          <zeebe:output source="= body" target="response" />
-        </zeebe:ioMapping>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0gw5hlt</bpmn:incoming>
-      <bpmn:outgoing>Flow_0636r17</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_14akiy6" name="entries visible" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-entriesVisible">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="http" />
-        <zeebe:taskHeaders>
-          <zeebe:header key="method" value="get" />
-          <zeebe:header key="url" />
-        </zeebe:taskHeaders>
-        <zeebe:ioMapping>
-          <zeebe:input source="= invoiceDetails" target="body" />
-          <zeebe:output source="= body" target="response" />
-        </zeebe:ioMapping>
-      </bpmn:extensionElements>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_1x04xy0" name="outdated" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-outdated" zeebe:modelerTemplateVersion="1" />
-    <bpmn:serviceTask id="Activity_166ntf9" name="missing template" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-missingTemplate" />
-    <bpmn:serviceTask id="Activity_1iof33f" name="groups" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-groups" />
-    <bpmn:serviceTask id="Activity_042oqko" name="optional" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-optional">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="http" />
-        <zeebe:taskHeaders>
-          <zeebe:header key="method" value="get" />
-          <zeebe:header key="url" />
-        </zeebe:taskHeaders>
-        <zeebe:ioMapping>
-          <zeebe:input source="= invoiceDetails" target="body" />
-          <zeebe:output source="= body" target="response" />
-        </zeebe:ioMapping>
-      </bpmn:extensionElements>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_1k5y89v" name="feel" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-feel" />
-    <bpmn:serviceTask id="Activity_1ftabot" name="documentationRef" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-documentationRef" />
-    <bpmn:serviceTask id="REST_deprecated" name="deprecated" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-outdated" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width=&#39;24&#39; height=&#39;24&#39; fill=&#39;none&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M16 2.5H8A5.5 5.5 0 0 0 2.5 8v8A5.5 5.5 0 0 0 8 21.5h8a5.5 5.5 0 0 0 5.5-5.5V8A5.5 5.5 0 0 0 16 2.5ZM8 1a7 7 0 0 0-7 7v8a7 7 0 0 0 7 7h8a7 7 0 0 0 7-7V8a7 7 0 0 0-7-7H8Z&#39; fill=&#39;%23505562&#39;/%3E%3Cpath d=&#39;M8.283 6.76v1.21c-.224 0-.416.02-.578.06a.612.612 0 0 0-.357.21c-.077.099-.106.242-.088.429l.17 1.622c.044.41-.001.742-.137.995a1.328 1.328 0 0 1-.61.584 3.306 3.306 0 0 1-.963.28c.392.059.724.154.995.286.272.132.47.323.594.572.125.25.165.583.121 1.001l-.17 1.623c-.018.183.011.326.088.429a.62.62 0 0 0 .363.209c.161.04.352.06.572.06v1.21c-.506 0-.935-.037-1.287-.11-.352-.073-.634-.19-.847-.352a1.214 1.214 0 0 1-.435-.627c-.077-.257-.097-.57-.06-.94l.165-1.573c.03-.28-.018-.497-.143-.655-.121-.158-.3-.268-.54-.33a3.102 3.102 0 0 0-.824-.099v-1.408c.308 0 .581-.031.82-.094.238-.066.42-.177.544-.335.125-.158.172-.376.143-.654L5.654 8.8c-.04-.378-.022-.697.055-.957.08-.26.225-.47.434-.627.213-.162.495-.277.847-.347a6.54 6.54 0 0 1 1.293-.11ZM9.527 16v-1.166h.77v-3.52h-.77v-1.155h2.096l.319 1.314c.209-.502.474-.876.797-1.122.326-.245.724-.368 1.194-.368a2.535 2.535 0 0 1 .962.176l-.528 1.435a2.48 2.48 0 0 0-.67-.087c-.382 0-.718.155-1.007.467-.286.312-.505.708-.655 1.188v1.672h1.155V16H9.527Zm3.955-3.399v-1.705l.258-.737h1.155l-.324 2.442h-1.09Zm2.239-5.841c.506 0 .935.037 1.287.11.352.073.633.19.842.352.212.158.36.367.44.627.08.257.1.57.06.94l-.165 1.574c-.029.278.019.496.143.654.125.158.305.27.54.335.238.063.513.094.824.094v1.408c-.308 0-.58.033-.82.099a.985.985 0 0 0-.544.33c-.124.158-.172.376-.143.655l.165 1.561c.04.378.02.697-.06.957-.077.26-.222.47-.435.628-.209.16-.491.276-.847.346a6.44 6.44 0 0 1-1.287.11v-1.21c.224 0 .415-.02.572-.06a.59.59 0 0 0 .358-.21c.08-.102.112-.245.093-.428l-.17-1.623c-.044-.414 0-.746.132-.995.136-.253.34-.446.616-.578.275-.136.598-.231.968-.286a3.52 3.52 0 0 1-1.001-.286 1.251 1.251 0 0 1-.594-.572c-.125-.253-.165-.587-.121-1.001l.17-1.622c.019-.187-.012-.33-.093-.43a.59.59 0 0 0-.358-.208 2.338 2.338 0 0 0-.572-.061V6.76Z&#39; fill=&#39;%23505562&#39;/%3E%3C/svg%3E">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="http" />
-        <zeebe:ioMapping>
-          <zeebe:output source="= body" target="response" />
+          <zeebe:input source="credentials" target="authentication.type" />
+          <zeebe:input target="authentication.accessKey" />
+          <zeebe:input target="authentication.secretKey" />
+          <zeebe:input target="configuration.region" />
+          <zeebe:input target="input.language" />
+          <zeebe:input target="input.code" />
+          <zeebe:input source="aws.codeinterpreter.v1" target="input.codeInterpreterIdentifier" />
+          <zeebe:input source="PT5M" target="input.sessionTimeout" />
+          <zeebe:input source="=10" target="input.maxFiles" />
+          <zeebe:input source="=10485760" target="input.maxTotalFileSize" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
-          <zeebe:header key="method" value="get" />
+          <zeebe:header key="elementTemplateVersion" value="2" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.aws.bedrock.codeinterpreter.v1" />
+          <zeebe:header key="resultVariable" />
+          <zeebe:header key="resultExpression" />
+          <zeebe:header key="errorExpression" />
+          <zeebe:header key="retryBackoff" value="PT30S" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1g317fm</bpmn:incoming>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="REST_outdated_deprecated" name="outdated + deprecated" zeebe:modelerTemplate="io.camunda.connectors.RestConnector-outdated" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width=&#39;24&#39; height=&#39;24&#39; fill=&#39;none&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M16 2.5H8A5.5 5.5 0 0 0 2.5 8v8A5.5 5.5 0 0 0 8 21.5h8a5.5 5.5 0 0 0 5.5-5.5V8A5.5 5.5 0 0 0 16 2.5ZM8 1a7 7 0 0 0-7 7v8a7 7 0 0 0 7 7h8a7 7 0 0 0 7-7V8a7 7 0 0 0-7-7H8Z&#39; fill=&#39;%23505562&#39;/%3E%3Cpath d=&#39;M8.283 6.76v1.21c-.224 0-.416.02-.578.06a.612.612 0 0 0-.357.21c-.077.099-.106.242-.088.429l.17 1.622c.044.41-.001.742-.137.995a1.328 1.328 0 0 1-.61.584 3.306 3.306 0 0 1-.963.28c.392.059.724.154.995.286.272.132.47.323.594.572.125.25.165.583.121 1.001l-.17 1.623c-.018.183.011.326.088.429a.62.62 0 0 0 .363.209c.161.04.352.06.572.06v1.21c-.506 0-.935-.037-1.287-.11-.352-.073-.634-.19-.847-.352a1.214 1.214 0 0 1-.435-.627c-.077-.257-.097-.57-.06-.94l.165-1.573c.03-.28-.018-.497-.143-.655-.121-.158-.3-.268-.54-.33a3.102 3.102 0 0 0-.824-.099v-1.408c.308 0 .581-.031.82-.094.238-.066.42-.177.544-.335.125-.158.172-.376.143-.654L5.654 8.8c-.04-.378-.022-.697.055-.957.08-.26.225-.47.434-.627.213-.162.495-.277.847-.347a6.54 6.54 0 0 1 1.293-.11ZM9.527 16v-1.166h.77v-3.52h-.77v-1.155h2.096l.319 1.314c.209-.502.474-.876.797-1.122.326-.245.724-.368 1.194-.368a2.535 2.535 0 0 1 .962.176l-.528 1.435a2.48 2.48 0 0 0-.67-.087c-.382 0-.718.155-1.007.467-.286.312-.505.708-.655 1.188v1.672h1.155V16H9.527Zm3.955-3.399v-1.705l.258-.737h1.155l-.324 2.442h-1.09Zm2.239-5.841c.506 0 .935.037 1.287.11.352.073.633.19.842.352.212.158.36.367.44.627.08.257.1.57.06.94l-.165 1.574c-.029.278.019.496.143.654.125.158.305.27.54.335.238.063.513.094.824.094v1.408c-.308 0-.58.033-.82.099a.985.985 0 0 0-.544.33c-.124.158-.172.376-.143.655l.165 1.561c.04.378.02.697-.06.957-.077.26-.222.47-.435.628-.209.16-.491.276-.847.346a6.44 6.44 0 0 1-1.287.11v-1.21c.224 0 .415-.02.572-.06a.59.59 0 0 0 .358-.21c.08-.102.112-.245.093-.428l-.17-1.623c-.044-.414 0-.746.132-.995.136-.253.34-.446.616-.578.275-.136.598-.231.968-.286a3.52 3.52 0 0 1-1.001-.286 1.251 1.251 0 0 1-.594-.572c-.125-.253-.165-.587-.121-1.001l.17-1.622c.019-.187-.012-.33-.093-.43a.59.59 0 0 0-.358-.208 2.338 2.338 0 0 0-.572-.061V6.76Z&#39; fill=&#39;%23505562&#39;/%3E%3C/svg%3E">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="http" />
-        <zeebe:ioMapping>
-          <zeebe:output source="= body" target="response" />
-        </zeebe:ioMapping>
-        <zeebe:taskHeaders>
-          <zeebe:header key="method" value="get" />
-        </zeebe:taskHeaders>
-      </bpmn:extensionElements>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_070m932" name="update template properties order" zeebe:modelerTemplate="cloud-element-templates.properties.update-properties-order">
-      <bpmn:extensionElements>
-        <zeebe:ioMapping>
-          <zeebe:input source="input-1-source" target="input-1-target" />
-          <zeebe:input source="input-3-source" target="input-3-target" />
-          <zeebe:output source="output-1-source" target="output-1-target" />
-          <zeebe:output source="output-3-source" target="output-3-target" />
-        </zeebe:ioMapping>
-        <zeebe:taskHeaders>
-          <zeebe:header key="header-1-key" value="header-1-value" />
-          <zeebe:header key="header-2-key" value="header-2-value" />
-        </zeebe:taskHeaders>
-        <zeebe:properties>
-          <zeebe:property name="property-1-name" value="property-1-value" />
-          <zeebe:property name="property-3-name" value="property-3-value" />
-        </zeebe:properties>
-      </bpmn:extensionElements>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_1dnqc94" name="incompatible" zeebe:modelerTemplate="example.engines.test.incompatible" />
-    <bpmn:serviceTask id="Activity_1ofw5tu" name="incompatible (update available)" zeebe:modelerTemplate="example.engines.test.basic" zeebe:modelerTemplateVersion="3" />
-    <bpmn:subProcess id="Activity_16bxle5" name="SubProcess" zeebe:modelerTemplate="subprocess" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg%20height%3D%22100%22%20width%3D%22100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ccircle%20r%3D%2245%22%20cx%3D%2250%22%20cy%3D%2250%22%20fill%3D%22green%22%20%2F%3E%3C%2Fsvg%3E" />
-    <bpmn:task id="Activity_04iadre" name="Falsy version" zeebe:modelerTemplate="falsy-template" />
-    <bpmn:serviceTask id="DynamicOutputs" name="dynamic outputs (outdated)" zeebe:modelerTemplate="user-outputs-template" zeebe:modelerTemplateVersion="1" >
-      <bpmn:extensionElements>
-        <zeebe:ioMapping>
-          <zeebe:input source="input-1-value" target="input-1-target" />
-          <zeebe:output source="=output" target="custom" />
-          <zeebe:output source="=output + 1" target="anotherCustom" />
-        </zeebe:ioMapping>
-        <zeebe:taskDefinition type="task-type-value" />
-      </bpmn:extensionElements>
-    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1g317fm" sourceRef="Event_18cltfd" targetRef="Activity_12jhq75" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vvlc66">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1rrw1mn">
+      <bpmndi:BPMNShape id="Event_18cltfd_di" bpmnElement="Event_18cltfd">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0vyda7b_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="432" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_12jhq75_di" bpmnElement="Activity_12jhq75">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1328y3k_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14akiy6_di" bpmnElement="Activity_14akiy6">
-        <dc:Bounds x="270" y="240" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x04xy0_di" bpmnElement="Activity_1x04xy0">
-        <dc:Bounds x="270" y="360" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_166ntf9_di" bpmnElement="Activity_166ntf9">
-        <dc:Bounds x="410" y="240" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1iof33f_di" bpmnElement="Activity_1iof33f">
-        <dc:Bounds x="550" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_042oqko_di" bpmnElement="Activity_042oqko">
-        <dc:Bounds x="410" y="360" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0dk5at4" bpmnElement="Activity_1k5y89v">
-        <dc:Bounds x="270" y="470" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1ftabot_di" bpmnElement="Activity_1ftabot">
-        <dc:Bounds x="270" y="580" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="REST_deprecated_di" bpmnElement="REST_deprecated">
-        <dc:Bounds x="410" y="470" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="REST_outdated_deprecated_di" bpmnElement="REST_outdated_deprecated">
-        <dc:Bounds x="410" y="580" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0xl49z8_di" bpmnElement="Activity_070m932">
-        <dc:Bounds x="270" y="690" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0wdqmez" bpmnElement="Activity_1dnqc94">
-        <dc:Bounds x="650" y="240" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0xbqyuv" bpmnElement="Activity_1ofw5tu">
-        <dc:Bounds x="800" y="240" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v33is2_di" bpmnElement="DynamicOutputs">
-        <dc:Bounds x="650" y="580" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_16bxle5_di" bpmnElement="Activity_16bxle5" isExpanded="true">
-        <dc:Bounds x="650" y="370" width="200" height="120" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_04iadre_di" bpmnElement="Activity_04iadre">
-        <dc:Bounds x="410" y="690" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0gw5hlt_di" bpmnElement="Flow_0gw5hlt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0636r17_di" bpmnElement="Flow_0636r17">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="432" y="117" />
+      <bpmndi:BPMNEdge id="Flow_1g317fm_di" bpmnElement="Flow_1g317fm">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/fixtures/connections-design.json
+++ b/test/spec/cloud-element-templates/fixtures/connections-design.json
@@ -1,0 +1,1110 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Slack Outbound Connector",
+    "id": "io.camunda.connectors.Slack.v1",
+    "description": "Create a channel or send a message to a channel or user",
+    "metadata": {
+      "keywords": [],
+      "upstreamRef": "https://raw.githubusercontent.com/camunda/connectors/67844366b94c9f2401657e510ad198d11bf6b64d/connectors/slack/element-templates/versioned/slack-outbound-connector-8.json"
+    },
+    "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
+    "version": 8,
+    "category": {
+      "id": "connectors",
+      "name": "Connectors"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "engines": {
+      "camunda": "^8.3"
+    },
+    "configurationTemplates": [
+      {
+        "id": "io.camunda:slack-connection:1",
+        "name": "Slack Connection",
+        "version": 2,
+        "kind": "CREDENTIAL",
+        "icon": {
+          "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJINDd6IiBmaWxsPSIjMzZDNUYwIi8+CiAgPHBhdGggZD0iTTk5LjkgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjIgNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yIDAgNy4zLTUuOSAxMy4yLTEzLjIgMTMuMkg5OS45VjQ2Ljl6bS02LjYgMGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUgNzIuOC42IDgwLjEuNmM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzMuMXoiIGZpbGw9IiMyRUI2N0QiLz4KICA8cGF0aCBkPSJNODAuMSA5OS44YzcuMyAwIDEzLjIgNS45IDEzLjIgMTMuMiAwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjk5LjhoMTMuMnptMC02LjZjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMiAwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo="
+        },
+        "properties": [
+          {
+            "label": "Slack API Token",
+            "type": "String",
+            "constraints": {
+              "notEmpty": true
+            },
+            "binding": {
+              "type": "property",
+              "name": "slackOauthToken"
+            }
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "id": "connection",
+        "label": "Connection"
+      },
+      {
+        "id": "method",
+        "label": "Method"
+      },
+      {
+        "id": "message",
+        "label": "Message"
+      },
+      {
+        "id": "channel",
+        "label": "Channel"
+      },
+      {
+        "id": "invite",
+        "label": "Invite"
+      },
+      {
+        "id": "reaction",
+        "label": "Reaction"
+      },
+      {
+        "id": "pinMessage",
+        "label": "Pin Message"
+      },
+      {
+        "id": "unpinMessage",
+        "label": "Unpin Message"
+      },
+      {
+        "id": "connector",
+        "label": "Connector"
+      },
+      {
+        "id": "output",
+        "label": "Output mapping"
+      },
+      {
+        "id": "error",
+        "label": "Error handling"
+      },
+      {
+        "id": "retries",
+        "label": "Retries"
+      }
+    ],
+    "properties": [
+      {
+        "value": "io.camunda:slack:1",
+        "binding": {
+          "property": "type",
+          "type": "zeebe:taskDefinition"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "connection",
+        "label": "Slack connection",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:slack-connection:1",
+        "configurationTemplateVersion": 2,
+        "group": "connection",
+        "optional": true,
+        "binding": {
+          "name": "configuration",
+          "type": "zeebe:input"
+        }
+      },
+      {
+        "id": "method",
+        "label": "Method",
+        "value": "chat.postMessage",
+        "group": "method",
+        "binding": {
+          "name": "method",
+          "type": "zeebe:input"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Post message",
+            "value": "chat.postMessage"
+          },
+          {
+            "name": "Create channel",
+            "value": "conversations.create"
+          },
+          {
+            "name": "Invite to channel",
+            "value": "conversations.invite"
+          },
+          {
+            "name": "Add reaction",
+            "value": "reactions.add"
+          },
+          {
+            "name": "Pin Message",
+            "value": "pins.add"
+          },
+          {
+            "name": "Unpin Message",
+            "value": "pins.remove"
+          }
+        ]
+      },
+      {
+        "id": "data.messageType",
+        "label": "Message type",
+        "optional": false,
+        "value": "plainText",
+        "group": "message",
+        "binding": {
+          "name": "data.messageType",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "method",
+              "equals": "chat.postMessage",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "chat.postMessage",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Plain text",
+            "value": "plainText"
+          },
+          {
+            "name": "Message block",
+            "value": "messageBlock"
+          }
+        ]
+      },
+      {
+        "id": "data.text",
+        "label": "Message",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "message",
+        "binding": {
+          "name": "data.text",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "data.messageType",
+              "equals": "plainText",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "chat.postMessage",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "Text"
+      },
+      {
+        "id": "data.blockContent",
+        "label": "Message block",
+        "description": "An array of rich message content blocks. Learn more at the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">official Slack documentation page</a>",
+        "optional": false,
+        "value": "=[\n\t{\n\t\t\"type\": \"header\",\n\t\t\"text\": {\n\t\t\t\"type\": \"plain_text\",\n\t\t\t\"text\": \"New request\"\n\t\t}\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Type:*\\nPaid Time Off\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Created by:*\\n<example.com|John Doe>\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*When:*\\nAug 10 - Aug 13\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"text\": {\n\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\"text\": \"<https://example.com|View request>\"\n\t\t}\n\t}\n]",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "message",
+        "binding": {
+          "name": "data.blockContent",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "data.messageType",
+              "equals": "messageBlock",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "chat.postMessage",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.documents",
+        "label": "attachments",
+        "description": "<a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda documents</a> can be added as attachments",
+        "optional": true,
+        "feel": "required",
+        "group": "message",
+        "binding": {
+          "name": "data.documents",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "chat.postMessage",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.channel",
+        "label": "Channel/user name/email",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "channel",
+        "binding": {
+          "name": "data.channel",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "chat.postMessage",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.thread",
+        "label": "Thread",
+        "optional": true,
+        "feel": "optional",
+        "group": "channel",
+        "binding": {
+          "name": "data.thread",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "chat.postMessage",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.newChannelName",
+        "label": "Channel name",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^(=|([-_a-z0-9]{1,80}$))",
+            "message": "May contain up to 80 lowercase letters, digits, underscores, and dashes"
+          }
+        },
+        "feel": "optional",
+        "group": "channel",
+        "binding": {
+          "name": "data.newChannelName",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "conversations.create",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.visibility",
+        "label": "Visibility",
+        "optional": false,
+        "value": "PUBLIC",
+        "constraints": {
+          "notEmpty": true
+        },
+        "group": "channel",
+        "binding": {
+          "name": "data.visibility",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "conversations.create",
+          "type": "simple"
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Public",
+            "value": "PUBLIC"
+          },
+          {
+            "name": "Private",
+            "value": "PRIVATE"
+          }
+        ]
+      },
+      {
+        "id": "data.channelType",
+        "label": "Invite By",
+        "optional": false,
+        "value": "channelId",
+        "group": "invite",
+        "binding": {
+          "name": "data.channelType",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "method",
+              "equals": "conversations.invite",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "conversations.invite",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "Channel ID",
+            "value": "channelId"
+          },
+          {
+            "name": "Channel name",
+            "value": "channelName"
+          }
+        ]
+      },
+      {
+        "id": "data.channelName",
+        "label": "Channel name",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^(=|([-_a-z0-9]{1,80}$))",
+            "message": "May contain up to 80 lowercase letters, digits, underscores, and dashes"
+          }
+        },
+        "feel": "optional",
+        "group": "invite",
+        "binding": {
+          "name": "data.channelName",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "data.channelType",
+              "equals": "channelName",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "conversations.invite",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.channelId",
+        "label": "Channel ID",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^(=|([-_a-z0-9]{1,80}$))",
+            "message": "May contain up to 80 lowercase letters, digits, underscores, and dashes"
+          }
+        },
+        "feel": "optional",
+        "group": "invite",
+        "binding": {
+          "name": "data.channelId",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "allMatch": [
+            {
+              "property": "data.channelType",
+              "equals": "channelId",
+              "type": "simple"
+            },
+            {
+              "property": "method",
+              "equals": "conversations.invite",
+              "type": "simple"
+            }
+          ]
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.users",
+        "label": "Users",
+        "description": "Comma-separated list of users, e.g., '@user1,@user2' or '=[ \"@user1\", \"user2@company.com\"]'",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "invite",
+        "binding": {
+          "name": "data.users",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "conversations.invite",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "reaction.channel",
+        "label": "Channel",
+        "description": "Channel ID of the message to react to",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "reaction",
+        "binding": {
+          "name": "data.channel",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "reactions.add",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.emoji",
+        "label": "Emoji name",
+        "description": "Emoji name (e.g. eyes)",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "reaction",
+        "binding": {
+          "name": "data.emoji",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "reactions.add",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "data.timestamp",
+        "label": "Message timestamp",
+        "description": "Timestamp of the Slack message to react to",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "reaction",
+        "binding": {
+          "name": "data.timestamp",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "reactions.add",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "pinMessage.channel",
+        "label": "Channel",
+        "description": "Channel ID of the message to pin",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "pinMessage",
+        "binding": {
+          "name": "data.channel",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "pins.add",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "pinMessage.timestamp",
+        "label": "Message timestamp",
+        "description": "Timestamp of the Slack message to pin",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "pinMessage",
+        "binding": {
+          "name": "data.timestamp",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "pins.add",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "unpinMessage.channel",
+        "label": "Channel",
+        "description": "Channel ID of the message to unpin",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "optional",
+        "group": "unpinMessage",
+        "binding": {
+          "name": "data.channel",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "pins.remove",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "unpinMessage.timestamp",
+        "label": "Message timestamp",
+        "description": "Timestamp of the Slack message to unpin",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "unpinMessage",
+        "binding": {
+          "name": "data.timestamp",
+          "type": "zeebe:input"
+        },
+        "condition": {
+          "property": "method",
+          "equals": "pins.remove",
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "version",
+        "label": "Version",
+        "description": "Version of the element template",
+        "value": "8",
+        "group": "connector",
+        "binding": {
+          "key": "elementTemplateVersion",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "id",
+        "label": "ID",
+        "description": "ID of the element template",
+        "value": "io.camunda.connectors.Slack.v1",
+        "group": "connector",
+        "binding": {
+          "key": "elementTemplateId",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "resultVariable",
+        "label": "Result variable",
+        "description": "Name of variable to store the response in",
+        "group": "output",
+        "binding": {
+          "key": "resultVariable",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "String"
+      },
+      {
+        "id": "resultExpression",
+        "label": "Result expression",
+        "description": "Expression to map the response into process variables",
+        "feel": "required",
+        "group": "output",
+        "binding": {
+          "key": "resultExpression",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Text"
+      },
+      {
+        "id": "errorExpression",
+        "label": "Error expression",
+        "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+        "feel": "required",
+        "group": "error",
+        "binding": {
+          "key": "errorExpression",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "Text"
+      },
+      {
+        "id": "retryCount",
+        "label": "Retries",
+        "description": "Number of retries",
+        "value": "3",
+        "feel": "optional",
+        "group": "retries",
+        "binding": {
+          "property": "retries",
+          "type": "zeebe:taskDefinition"
+        },
+        "type": "String"
+      },
+      {
+        "id": "retryBackoff",
+        "label": "Retry backoff",
+        "description": "ISO-8601 duration to wait between retries",
+        "value": "PT0S",
+        "group": "retries",
+        "binding": {
+          "key": "retryBackoff",
+          "type": "zeebe:taskHeader"
+        },
+        "type": "String"
+      }
+    ],
+    "icon": {
+      "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJINDd6IiBmaWxsPSIjMzZDNUYwIi8+CiAgPHBhdGggZD0iTTk5LjkgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjIgNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yIDAgNy4zLTUuOSAxMy4yLTEzLjIgMTMuMkg5OS45VjQ2Ljl6bS02LjYgMGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUgNzIuOC42IDgwLjEuNmM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzMuMXoiIGZpbGw9IiMyRUI2N0QiLz4KICA8cGF0aCBkPSJNODAuMSA5OS44YzcuMyAwIDEzLjIgNS45IDEzLjIgMTMuMiAwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjk5LjhoMTMuMnptMC02LjZjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMiAwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo="
+    }
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Slack Webhook Receive Task Connector",
+    "id": "io.camunda.connectors.inbound.Slack.ReceiveTask.v1",
+    "description": "Receive events from Slack",
+    "keywords": [
+      "message received",
+      "event received",
+      "channel event",
+      "webhook",
+      "messaging",
+      "new message"
+    ],
+    "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=inbound",
+    "version": 8,
+    "category": {
+      "id": "connectors",
+      "name": "Connectors"
+    },
+    "appliesTo": [
+      "bpmn:ReceiveTask"
+    ],
+    "elementType": {
+      "value": "bpmn:ReceiveTask"
+    },
+    "engines": {
+      "camunda": "^8.3"
+    },
+    "configurationTemplates": [
+      {
+        "id": "io.camunda:slack-connection:1",
+        "name": "Slack Connection",
+        "version": 2,
+        "kind": "CREDENTIAL",
+        "icon": {
+          "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMi0xMy4yLTEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUsIDcyLjYuOCA0Ny4wLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yIDAgMTMuMiA1LjkgMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo="
+        },
+        "properties": [
+          {
+            "label": "Slack API Token",
+            "type": "String",
+            "constraints": {
+              "notEmpty": true
+            },
+            "binding": {
+              "type": "property",
+              "name": "slackOauthToken"
+            }
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "id": "endpoint",
+        "label": "Webhook configuration"
+      },
+      {
+        "id": "activation",
+        "label": "Activation"
+      },
+      {
+        "id": "correlation",
+        "label": "Correlation",
+        "tooltip": "Learn more about message correlation in the <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-correlation-overview\">documentation</a>."
+      },
+      {
+        "id": "deduplication",
+        "label": "Deduplication",
+        "tooltip": "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+      },
+      {
+        "id": "output",
+        "label": "Output mapping"
+      }
+    ],
+    "properties": [
+      {
+        "value": "io.camunda:slack-webhook:1",
+        "binding": {
+          "name": "inbound.type",
+          "type": "zeebe:property"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "connection",
+        "label": "Slack connection",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:slack-connection:1",
+        "configurationTemplateVersion": 2,
+        "group": "endpoint",
+        "optional": true,
+        "binding": {
+          "name": "configuration",
+          "type": "zeebe:property"
+        }
+      },
+      {
+        "id": "inbound.context",
+        "label": "Webhook ID",
+        "description": "The webhook ID is a part of the URL endpoint",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "group": "endpoint",
+        "binding": {
+          "name": "inbound.context",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "inbound.slackSigningSecret",
+        "label": "Slack signing secret",
+        "description": "Slack signing secret. <a href='https://api.slack.com/authentication/verifying-requests-from-slack' target='_blank'>See documentation</a> regarding the Slack signing secret",
+        "optional": false,
+        "constraints": {
+          "notEmpty": true
+        },
+        "group": "endpoint",
+        "binding": {
+          "name": "inbound.slackSigningSecret",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "inbound.verificationExpression",
+        "label": "Verification expression",
+        "optional": true,
+        "value": "=if (body.type != null and body.type = \"url_verification\") then {body:{\"challenge\":body.challenge}, statusCode: 200} else null",
+        "group": "endpoint",
+        "binding": {
+          "name": "inbound.verificationExpression",
+          "type": "zeebe:property"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "activationCondition",
+        "label": "Activation condition",
+        "description": "Condition under which the Connector triggers. Leave empty to catch all events",
+        "optional": true,
+        "feel": "required",
+        "group": "activation",
+        "binding": {
+          "name": "activationCondition",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "consumeUnmatchedEvents",
+        "label": "Consume unmatched events",
+        "value": true,
+        "group": "activation",
+        "binding": {
+          "name": "consumeUnmatchedEvents",
+          "type": "zeebe:property"
+        },
+        "tooltip": "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+        "type": "Boolean"
+      },
+      {
+        "id": "correlationKeyProcess",
+        "label": "Correlation key (process)",
+        "description": "Sets up the correlation key from process variables",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "correlation",
+        "binding": {
+          "name": "correlationKey",
+          "type": "bpmn:Message#zeebe:subscription#property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "correlationKeyPayload",
+        "label": "Correlation key (payload)",
+        "description": "Extracts the correlation key from the incoming message payload",
+        "constraints": {
+          "notEmpty": true
+        },
+        "feel": "required",
+        "group": "correlation",
+        "binding": {
+          "name": "correlationKeyExpression",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "messageIdExpression",
+        "label": "Message ID expression",
+        "description": "Expression to extract unique identifier of a message",
+        "optional": true,
+        "feel": "required",
+        "group": "correlation",
+        "binding": {
+          "name": "messageIdExpression",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "messageTtl",
+        "label": "Message TTL",
+        "description": "Time-to-live for the message in the broker (ISO-8601 duration)",
+        "optional": true,
+        "constraints": {
+          "notEmpty": false,
+          "pattern": {
+            "value": "^(PT.*|)$",
+            "message": "must be an ISO-8601 duration"
+          }
+        },
+        "feel": "optional",
+        "group": "correlation",
+        "binding": {
+          "name": "messageTtl",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "messageNameUuid",
+        "label": "Message name",
+        "generatedValue": {
+          "type": "uuid"
+        },
+        "feel": "optional",
+        "group": "correlation",
+        "binding": {
+          "name": "name",
+          "type": "bpmn:Message#property"
+        },
+        "tooltip": "By default, this is an auto-generated random UUID. We recommend using a unique message name for each connector element in the diagram. Override to set a custom message name. Learn more about <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-subscriptions\">message subscriptions</a> that power inbound connectors.",
+        "type": "String"
+      },
+      {
+        "id": "deduplicationModeManualFlag",
+        "label": "Manual mode",
+        "description": "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+        "value": false,
+        "group": "deduplication",
+        "binding": {
+          "name": "deduplicationModeManualFlag",
+          "type": "zeebe:property"
+        },
+        "type": "Boolean"
+      },
+      {
+        "id": "deduplicationId",
+        "label": "Deduplication ID",
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^[a-zA-Z0-9_-]+$",
+            "message": "can only contain alphanumeric characters, dashes, and underscores"
+          }
+        },
+        "group": "deduplication",
+        "binding": {
+          "name": "deduplicationId",
+          "type": "zeebe:property"
+        },
+        "condition": {
+          "property": "deduplicationModeManualFlag",
+          "equals": true,
+          "type": "simple"
+        },
+        "type": "String"
+      },
+      {
+        "id": "deduplicationModeManual",
+        "value": "MANUAL",
+        "group": "deduplication",
+        "binding": {
+          "name": "deduplicationMode",
+          "type": "zeebe:property"
+        },
+        "condition": {
+          "property": "deduplicationId",
+          "isActive": true,
+          "type": "simple"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "deduplicationModeAuto",
+        "value": "AUTO",
+        "group": "deduplication",
+        "binding": {
+          "name": "deduplicationMode",
+          "type": "zeebe:property"
+        },
+        "condition": {
+          "property": "deduplicationId",
+          "isActive": false,
+          "type": "simple"
+        },
+        "type": "Hidden"
+      },
+      {
+        "id": "resultVariable",
+        "label": "Result variable",
+        "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>.",
+        "group": "output",
+        "binding": {
+          "name": "resultVariable",
+          "type": "zeebe:property"
+        },
+        "type": "String"
+      },
+      {
+        "id": "resultExpression",
+        "label": "Result expression",
+        "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>.",
+        "value": "{\n  myRequestBody: request.body\n  // Use FEEL to extract values, e.g.,:\n  // myUserId: request.body.event.user\n}",
+        "feel": "required",
+        "group": "output",
+        "binding": {
+          "name": "resultExpression",
+          "type": "zeebe:property"
+        },
+        "type": "Text"
+      }
+    ],
+    "icon": {
+      "contents": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJINDd6IiBmaWxsPSIjMzZDNUYwIi8+CiAgPHBhdGggZD0iTTk5LjkgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjIgNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yIDAgNy4zLTUuOSAxMy4yLTEzLjIgMTMuMkg5OS45VjQ2Ljl6bS02LjYgMGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUgNzIuOC42IDgwLjEuNmM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzMuMXoiIGZpbGw9IiMyRUI2N0QiLz4KICA8cGF0aCBkPSJNODAuMSA5OS44YzcuMyAwIDEzLjIgNS45IDEzLjIgMTMuMiAwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjk5LjhoMTMuMnptMC02LjZjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMiAwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo="
+    },
+    "metadata": {
+      "upstreamRef": "https://raw.githubusercontent.com/camunda/connectors/44aeee0e6f446f58ba605829c056a78a3ec63c8a/connectors/slack/element-templates/slack-inbound-receive.json"
+    }
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Configuration Example",
+    "id": "io.camunda.examples.Configuration.v1",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "engines": {
+      "camunda": "^8.3"
+    },
+    "configurationTemplates": [
+      {
+        "id": "io.camunda:example-configuration:1",
+        "name": "Example configuration",
+        "version": 1,
+        "kind": "CREDENTIAL",
+        "properties": [
+          {
+            "id": "apiKey",
+            "label": "API key",
+            "type": "String",
+            "secret": true,
+            "binding": {
+              "type": "property",
+              "name": "apiKey"
+            }
+          }
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "id": "configuration",
+        "label": "Example configuration",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:example-configuration:1",
+        "configurationTemplateVersion": 1,
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "configuration"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.configuration-metadata-cleanup.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.configuration-metadata-cleanup.json
@@ -1,0 +1,35 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Configuration metadata cleanup",
+    "id": "configuration-metadata-cleanup",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "id": "propertyConfiguration",
+        "label": "Property configuration",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:slack-connection:1",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "propertyConfiguration"
+        }
+      },
+      {
+        "id": "inputConfiguration",
+        "label": "Input configuration",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:slack-connection:1",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "inputConfiguration"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -90,6 +90,8 @@ import bpmnExpressionTemplates from '../fixtures/completion-condition.json';
 
 import complexPropertyTemplates from './CustomProperties.complex-property.json';
 
+import configurationMetadataCleanupTemplates from './CustomProperties.configuration-metadata-cleanup.json';
+
 import timerDiagramXML from './CustomProperties.timer.bpmn';
 import timerElementTemplates from './CustomProperties.timer.json';
 
@@ -1066,6 +1068,877 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('configuration labels', function() {
+
+    it('should use the property label or configuration template name', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-labels',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'destinationConfiguration',
+          label: 'Destination AWS credential',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:aws-credential:1',
+          binding: {
+            type: 'zeebe:property',
+            name: 'destinationConfiguration'
+          }
+        }, {
+          id: 'configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:aws-credential:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ],
+        configurationTemplates: [ {
+          id: 'io.camunda:aws-credential:1',
+          kind: 'CREDENTIAL',
+          name: 'AWS Credential',
+          version: 2,
+          properties: []
+        } ]
+      };
+
+      configurationInstances.setState({
+        instances: [],
+        clusterSelected: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const labeledEntry = findEntry('custom-entry-configuration-labels-0', container),
+            fallbackEntry = findEntry('custom-entry-configuration-labels-1', container);
+
+      // then
+      expect(domQuery('.bio-properties-panel-label', labeledEntry).textContent).to.equal('Destination AWS credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', labeledEntry).textContent).to.equal('+Choose destination AWS credential');
+      expect(domQuery('.bio-properties-panel-label', fallbackEntry).textContent).to.equal('AWS Credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry).textContent).to.equal('+Choose AWS Credential');
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry));
+      });
+
+      // then
+      expect(domQuery('.bio-properties-panel-configuration-chooser-empty', fallbackEntry).textContent).to.equal('AWS Credential not present in connected cluster');
+
+      // when
+      await act(() => {
+        configurationInstances.setInstances([ {
+          name: 'awsProduction',
+          metadata: {
+            kind: 'CREDENTIAL',
+            displayName: 'AWS Production',
+            configurationTemplate: 'io.camunda:aws-credential:1',
+            configurationTemplateVersion: 2
+          }
+        } ]);
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', fallbackEntry));
+
+      await act(() => {
+        configurationInstances.setInstances([ {
+          name: 'awsProduction',
+          metadata: {
+            kind: 'CREDENTIAL',
+            displayName: 'AWS Production',
+            configurationTemplate: 'io.camunda:aws-credential:1',
+            configurationTemplateVersion: 1
+          }
+        } ]);
+      });
+
+      // then
+      expect(domQuery('.bio-properties-panel-configuration-chooser-missing', fallbackEntry).textContent).to.contain('AWS Production');
+
+      // when
+      await act(() => {
+        configurationInstances.setState({
+          instances: [ {
+            name: 'awsProduction',
+            metadata: {
+              kind: 'CREDENTIAL',
+              displayName: 'AWS Production',
+              configurationTemplate: 'io.camunda:other-credential:1',
+              configurationTemplateVersion: 2
+            }
+          } ],
+          permissions: {
+            update: true
+          }
+        });
+      });
+
+      // then
+      const typeMismatch = domQuery('.bio-properties-panel-configuration-chooser-missing', fallbackEntry);
+
+      expect(typeMismatch.textContent).to.contain('AWS Production');
+      expect(typeMismatch.textContent).to.contain('Incompatible configuration type');
+      expect(typeMismatch.textContent).not.to.contain('AWS Credential');
+      expect(typeMismatch.textContent).not.to.contain('io.camunda:other-credential:1');
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', fallbackEntry));
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', fallbackEntry)).not.to.exist;
+    }));
+
+
+    it('should clear metadata when removing a configuration', inject(async function(elementTemplates, configurationInstances, commandStack) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const template = configurationMetadataCleanupTemplates[0];
+      const instance = {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+
+      configurationInstances.setInstances([ instance ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const propertyEntry = findEntry('custom-entry-configuration-metadata-cleanup-0', container),
+            inputEntry = findEntry('custom-entry-configuration-metadata-cleanup-1', container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', propertyEntry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', propertyEntry));
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', inputEntry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', inputEntry));
+
+      // when
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', inputEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', inputEntry));
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+
+      expect(findInputParameter(ioMapping, { name: 'inputConfiguration' })).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: '',
+        target: 'inputConfiguration'
+      });
+
+      // when
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', propertyEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', propertyEntry));
+
+      // then
+      const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+
+      expect(findZeebeProperty(zeebeProperties, { name: 'propertyConfiguration' })).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'propertyConfiguration',
+        value: ''
+      });
+
+      commandStack.undo();
+
+      expect(findZeebeProperty(zeebeProperties, { name: 'propertyConfiguration' })).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'propertyConfiguration',
+        value: '=camunda.vars.env.slackProduction',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+    }));
+
+  });
+
+
+  describe('configuration', function() {
+
+    it('should store metadata on zeebe:Property', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+      expect(placeholder.textContent).to.equal('+Choose configuration');
+
+      // when
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
+      });
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container));
+
+      // then
+      const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
+            zeebeProperty = findZeebeProperty(zeebeProperties, { name: 'configuration' });
+
+      expect(zeebeProperty).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'configuration',
+        value: '=camunda.vars.env.slackProduction',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+
+    }));
+
+
+    it('should store metadata on zeebe:Input', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const template = {
+        id: 'configuration-input',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:input',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-input-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
+      });
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container));
+
+      // then
+      const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
+            inputParameter = findInputParameter(ioMapping, { name: 'configuration' });
+
+      expect(inputParameter).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: '=camunda.vars.env.slackProduction',
+        target: 'configuration',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+
+    }));
+
+
+    it('should hide creation and show only the remove action for an offline configuration', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      template.configurationTemplates = [ {
+        id: 'io.camunda:slack-connection:1',
+        kind: 'CREDENTIAL',
+        name: 'Slack Connection',
+        version: 2,
+        properties: [],
+        icon: {
+          contents: 'data:image/svg+xml;base64,offline-icon'
+        }
+      } ];
+
+      configurationInstances.setInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      } ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+
+      configurationInstances.setState({
+        instances: [],
+        clusterSelected: false
+      });
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-configuration-chooser-selected', entry)).to.exist;
+        expect(domQuery('.bio-properties-panel-configuration-chooser-selected--offline', entry)).to.exist;
+        expect(domQuery('.bio-properties-panel-configuration-chooser-logo', entry).getAttribute('src')).to.equal('data:image/svg+xml;base64,offline-icon');
+        expect(domQuery('.bio-properties-panel-configuration-chooser-missing', entry)).not.to.exist;
+      });
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-selected', entry));
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).not.to.exist;
+
+      // when
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+
+      // then
+      const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
+
+      expect(menuItems).to.have.length(1);
+      expect(menuItems[0].textContent).to.equal('Remove');
+    }));
+
+
+    it('should distinguish a missing configuration from a load error', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setState({
+        instances: [ {
+          name: 'slackProduction',
+          metadata: {
+            kind: 'CREDENTIAL',
+            displayName: 'Slack Production',
+            configurationTemplate: 'io.camunda:slack-connection:1',
+            configurationTemplateVersion: 2
+          }
+        } ],
+        clusterSelected: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+
+      // when - successful empty response
+      await act(() => {
+        configurationInstances.setState({
+          instances: [],
+          error: false
+        });
+      });
+
+      // then
+      expect(entry.textContent).to.contain('Not found on cluster');
+      expect(entry.textContent).not.to.contain('Could not load configurations');
+
+      // when - failed response
+      await act(() => {
+        configurationInstances.setState({
+          error: true,
+          permissions: {
+            create: false,
+            update: false
+          }
+        });
+      });
+
+      // then
+      const error = domQuery('.bio-properties-panel-configuration-chooser-error', entry);
+
+      expect(error).to.exist;
+      expect(error.textContent).to.contain('Slack Production');
+      expect(error.textContent).to.contain('Could not load configurations');
+      expect(entry.textContent).not.to.contain('Not found on cluster');
+
+      fireEvent.click(error);
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+
+      const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
+
+      expect(menuItems).to.have.length(1);
+      expect(menuItems[0].textContent).to.equal('Remove');
+    }));
+
+
+    it('should fire configuration.create', inject(async function(elementTemplates, eventBus, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const property = {
+        id: 'configuration',
+        label: 'Configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2,
+        binding: {
+          type: 'zeebe:property',
+          name: 'configuration'
+        }
+      };
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ property ]
+      };
+      const createSpy = spy();
+
+      configurationInstances.setState({
+        clusterSelected: true
+      });
+      eventBus.on('configuration.create', createSpy);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+      // when
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).not.to.exist;
+
+      await act(() => {
+        configurationInstances.setState({
+          permissions: {
+            create: true
+          }
+        });
+      });
+
+      await waitFor(() => {
+        expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).to.exist;
+      });
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-create', entry));
+
+      // then
+      expect(createSpy).to.have.been.calledOnce;
+      const [ event ] = createSpy.firstCall.args;
+
+      expect(event.element).to.equal(element);
+      expect(event.property).to.equal(property);
+      expect(event.configurationTemplate).to.equal('io.camunda:slack-connection:1');
+      expect(event.configurationTemplateVersion).to.equal(2);
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.not.exist;
+    }));
+
+
+    it('should select a compatible configuration.created instance', inject(async function(elementTemplates, eventBus, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const property = {
+        id: 'configuration',
+        label: 'Configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2,
+        binding: {
+          type: 'zeebe:property',
+          name: 'configuration'
+        }
+      };
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ property ]
+      };
+      const instance = {
+        name: 'newSlack',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'New Slack',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+
+      configurationInstances.setState({
+        clusterSelected: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      // when - incompatible completion for this chooser
+      await act(() => {
+        eventBus.fire('configuration.created', {
+          element,
+          property,
+          instance: {
+            ...instance,
+            metadata: {
+              ...instance.metadata,
+              configurationTemplateVersion: 1
+            }
+          }
+        });
+      });
+
+      // then
+      let zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+
+      expect(findZeebeProperty(zeebeProperties, { name: 'configuration' }).value).not.to.equal('=camunda.vars.env.newSlack');
+
+      // when - compatible completion for another chooser
+      await act(() => {
+        eventBus.fire('configuration.created', {
+          element,
+          property: { ...property },
+          instance
+        });
+      });
+
+      // then
+      zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+
+      expect(findZeebeProperty(zeebeProperties, { name: 'configuration' }).value).not.to.equal('=camunda.vars.env.newSlack');
+
+      // when - compatible completion for this chooser
+      await act(() => {
+        eventBus.fire('configuration.created', {
+          element,
+          property,
+          instance
+        });
+      });
+
+      // then
+      zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
+      const zeebeProperty = findZeebeProperty(zeebeProperties, { name: 'configuration' });
+
+      expect(zeebeProperty).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'configuration',
+        value: '=camunda.vars.env.newSlack',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'New Slack'
+      });
+    }));
+
+
+    it('should fire configuration.edit when update is permitted', inject(async function(elementTemplates, eventBus, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const property = {
+        id: 'configuration',
+        label: 'Configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2,
+        binding: {
+          type: 'zeebe:property',
+          name: 'configuration'
+        }
+      };
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ property ]
+      };
+      const instance = {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+      const editSpy = spy();
+
+      configurationInstances.setState({
+        instances: [ instance ],
+        clusterSelected: true
+      });
+      eventBus.on('configuration.edit', editSpy);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry)).not.to.exist;
+
+      await act(() => {
+        configurationInstances.setState({
+          permissions: {
+            update: true
+          }
+        });
+      });
+
+      const edit = domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry);
+
+      expect(edit.textContent).to.equal('Edit');
+
+      // when
+      fireEvent.click(edit);
+
+      // then
+      expect(editSpy).to.have.been.calledOnce;
+      const [ event ] = editSpy.firstCall.args;
+
+      expect(event.element).to.equal(element);
+      expect(event.property).to.equal(property);
+      expect(event.instance).to.equal(instance);
+      expect(event.configurationTemplate).to.equal('io.camunda:slack-connection:1');
+      expect(event.configurationTemplateVersion).to.equal(2);
+    }));
+
+
+    it('should fire configuration.upgrade for a resolved below-floor instance', inject(async function(elementTemplates, eventBus, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const property = {
+        id: 'configuration',
+        label: 'Configuration',
+        type: 'Configuration',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        configurationTemplateVersion: 2,
+        binding: {
+          type: 'zeebe:property',
+          name: 'configuration'
+        }
+      };
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ property ]
+      };
+      const compatibleInstance = {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+      const outdatedInstance = {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 1
+        }
+      };
+      const upgradeSpy = spy();
+
+      configurationInstances.setState({
+        instances: [ compatibleInstance ],
+        clusterSelected: true,
+        permissions: {
+          update: true
+        }
+      });
+      eventBus.on('configuration.upgrade', upgradeSpy);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+
+      await act(() => {
+        configurationInstances.setState({
+          instances: [ outdatedInstance ]
+        });
+      });
+
+      const missing = domQuery('.bio-properties-panel-configuration-chooser-missing', entry);
+
+      expect(missing).to.exist;
+      expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+
+      const upgrade = domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry);
+
+      expect(upgrade.textContent).to.equal('Upgrade');
+
+      // when
+      fireEvent.click(upgrade);
+
+      // then
+      expect(upgradeSpy).to.have.been.calledOnce;
+      const [ event ] = upgradeSpy.firstCall.args;
+
+      expect(event.element).to.equal(element);
+      expect(event.property).to.equal(property);
+      expect(event.instance).to.equal(outdatedInstance);
+      expect(event.configurationTemplate).to.equal('io.camunda:slack-connection:1');
+      expect(event.configurationTemplateVersion).to.equal(2);
+    }));
+
+  });
+
+
   describe('bpmn:Message#property', function() {
 
 
@@ -1522,7 +2395,6 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const task = elementRegistry.get('BusinessRuleTask_empty');
 
 
-
       // when
       await act(() => {
         elementTemplates.applyTemplate(task, template);
@@ -1540,9 +2412,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(calledDecision).to.exist;
       expect(calledDecision).to.have.property('resultVariable', 'aResultVariableName');
       expect(calledDecision).to.have.property('decisionId', 'aReusableRule');
-    })
-    );
-
+    }));
 
   });
 
@@ -1608,6 +2478,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(formDefinition).to.exist;
       expect(formDefinition).to.have.property('formId', 'aFormId');
     }));
+
   });
 
 
@@ -1763,6 +2634,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(assignmentDefinition).to.have.property('candidateGroups', 'aCandidateGroup, anotherCandidateGroup');
       expect(assignmentDefinition).to.have.property('candidateUsers', 'aCandidateUser');
     }));
+
   });
 
 
@@ -1868,6 +2740,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(jobPriorityDefinition).to.have.property('priority', 20);
     });
 
+
     it('should change, setting priority value to 0', async function() {
 
       // given
@@ -1910,6 +2783,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(input.value).to.equal('10');
       expect(jobPriorityDefinition).to.have.property('priority', 10);
     }));
+
 
     it('should create zeebe:jobPriorityDefinition for conditioned property', inject(async function(commandStack, elementTemplates, elementRegistry) {
 
@@ -2283,6 +3157,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(timeDate).to.exist;
       expect(timeDate.get('body')).to.equal('2025-12-25T10:00:00Z');
     }));
+
   });
 
 
@@ -2584,6 +3459,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(description).to.not.exist;
     });
+
   });
 
 
@@ -2749,6 +3625,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       // then
       expect(tooltipWrapper).to.not.exist;
     });
+
   });
 
 
@@ -2860,6 +3737,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(editor).to.exist;
       expect(editor.contentEditable).to.equal('false');
     });
+
   });
 
 
@@ -3016,6 +3894,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expectValid(entry);
       })
     );
+
   });
 
 
@@ -3228,6 +4107,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-dot', group), 'marker should be removed').not.to.exist;
       });
     });
+
   });
 
 
@@ -3273,7 +4153,6 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
-
     it('should be marked as edited for generated values when input is cleared', function() {
 
       // given
@@ -3289,6 +4168,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-dot', group)).to.exist;
       });
     });
+
   });
 
 
@@ -3700,8 +4580,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       // then
       expect(input.textContent).to.eql('Placeholder');
     });
-  });
 
+  });
 
 });
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -51,6 +51,7 @@ import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import { BpmnPropertiesPanelModule as BpmnPropertiesPanel } from 'bpmn-js-properties-panel';
 import elementTemplatesModule from 'src/cloud-element-templates';
+import { isConfigurationChooserEdited } from 'src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty';
 
 import diagramXML from './CustomProperties.bpmn';
 import templates from './CustomProperties.json';
@@ -97,6 +98,26 @@ import timerElementTemplates from './CustomProperties.timer.json';
 
 
 describe('provider/cloud-element-templates - CustomProperties', function() {
+
+  describe('configuration edited state', function() {
+
+    it('should treat every bound configuration state as edited', function() {
+
+      const selected = document.createElement('div');
+      selected.innerHTML = '<div class="bio-properties-panel-configuration-chooser-selected"></div>';
+      const missing = document.createElement('div');
+      missing.innerHTML = '<div class="bio-properties-panel-configuration-chooser-missing"></div>';
+      const loading = document.createElement('div');
+      loading.innerHTML = '<div class="bio-properties-panel-configuration-chooser-loading"></div>';
+      const empty = document.createElement('div');
+
+      expect(isConfigurationChooserEdited(selected)).to.be.true;
+      expect(isConfigurationChooserEdited(missing)).to.be.true;
+      expect(isConfigurationChooserEdited(loading)).to.be.true;
+      expect(isConfigurationChooserEdited(empty)).to.be.false;
+    });
+
+  });
 
   let container;
 
@@ -1109,7 +1130,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       };
 
       configurationInstances.setState({
-        instances: [],
+        selectableInstances: [],
         clusterSelected: true
       });
       elementTemplates.set([ ...templates, template ]);
@@ -1137,7 +1158,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // when
       await act(() => {
-        configurationInstances.setInstances([ {
+        configurationInstances.setSelectableInstances([ {
           name: 'awsProduction',
           metadata: {
             kind: 'CREDENTIAL',
@@ -1150,7 +1171,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', fallbackEntry));
 
       await act(() => {
-        configurationInstances.setInstances([ {
+        configurationInstances.setSelectableInstances([ {
           name: 'awsProduction',
           metadata: {
             kind: 'CREDENTIAL',
@@ -1167,7 +1188,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       // when
       await act(() => {
         configurationInstances.setState({
-          instances: [ {
+          selectableInstances: [],
+          referencedInstances: [ {
             name: 'awsProduction',
             metadata: {
               kind: 'CREDENTIAL',
@@ -1196,6 +1218,53 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     }));
 
 
+    it('should use the latest configuration template name when the floor definition is not embedded', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-label-fallback',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:aws-credential:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ],
+        configurationTemplates: [ {
+          id: 'io.camunda:aws-credential:1',
+          kind: 'CREDENTIAL',
+          name: 'AWS Credential',
+          version: 3,
+          properties: []
+        } ]
+      };
+
+      configurationInstances.setState({
+        selectableInstances: [],
+        clusterSelected: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-label-fallback-0', container);
+
+      // then
+      expect(domQuery('.bio-properties-panel-label', entry).textContent).to.equal('AWS Credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry).textContent).to.equal('+Choose AWS Credential');
+    }));
+
+
     it('should clear metadata when removing a configuration', inject(async function(elementTemplates, configurationInstances, commandStack) {
 
       // given
@@ -1212,7 +1281,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         }
       };
 
-      configurationInstances.setInstances([ instance ]);
+      configurationInstances.setSelectableInstances([ instance ]);
       elementTemplates.set([ ...templates, template ]);
 
       await act(() => {
@@ -1298,7 +1367,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         } ]
       };
 
-      configurationInstances.setInstances([ {
+      configurationInstances.setSelectableInstances([ {
         name: 'slackProduction',
         metadata: {
           kind: 'CREDENTIAL',
@@ -1368,7 +1437,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         } ]
       };
 
-      configurationInstances.setInstances([ {
+      configurationInstances.setSelectableInstances([ {
         name: 'slackProduction',
         metadata: {
           kind: 'CREDENTIAL',
@@ -1445,7 +1514,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         }
       } ];
 
-      configurationInstances.setInstances([ {
+      configurationInstances.setSelectableInstances([ {
         name: 'slackProduction',
         metadata: {
           kind: 'CREDENTIAL',
@@ -1469,7 +1538,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
 
       configurationInstances.setState({
-        instances: [],
+        selectableInstances: [],
         clusterSelected: false
       });
 
@@ -1520,7 +1589,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       };
 
       configurationInstances.setState({
-        instances: [ {
+        selectableInstances: [ {
           name: 'slackProduction',
           metadata: {
             kind: 'CREDENTIAL',
@@ -1547,7 +1616,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       // when - successful empty response
       await act(() => {
         configurationInstances.setState({
-          instances: [],
+          selectableInstances: [],
           error: false
         });
       });
@@ -1726,7 +1795,10 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         eventBus.fire('configuration.created', {
           element,
-          property: { ...property },
+          property: {
+            ...property,
+            id: 'otherConfiguration'
+          },
           instance
         });
       });
@@ -1736,11 +1808,13 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(findZeebeProperty(zeebeProperties, { name: 'configuration' }).value).not.to.equal('=camunda.vars.env.newSlack');
 
-      // when - compatible completion for this chooser
+      // when - compatible completion for this chooser, reconstructed by the host
       await act(() => {
         eventBus.fire('configuration.created', {
-          element,
-          property,
+          element: {
+            id: element.id
+          },
+          property: { ...property },
           instance
         });
       });
@@ -1794,7 +1868,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const editSpy = spy();
 
       configurationInstances.setState({
-        instances: [ instance ],
+        selectableInstances: [ instance ],
         clusterSelected: true
       });
       eventBus.on('configuration.edit', editSpy);
@@ -1882,10 +1956,19 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
           configurationTemplateVersion: 1
         }
       };
+      const selectableInstance = {
+        name: 'slackDevelopment',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Development',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
       const upgradeSpy = spy();
 
       configurationInstances.setState({
-        instances: [ compatibleInstance ],
+        selectableInstances: [ compatibleInstance ],
         clusterSelected: true,
         permissions: {
           update: true
@@ -1906,8 +1989,13 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
 
       await act(() => {
+
         configurationInstances.setState({
-          instances: [ outdatedInstance ]
+
+          // The compatible search result and the directly resolved bound
+          // instance are separate host inputs.
+          selectableInstances: [ selectableInstance ],
+          referencedInstances: [ outdatedInstance ]
         });
       });
 
@@ -1915,6 +2003,14 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(missing).to.exist;
       expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
+
+      fireEvent.click(missing);
+
+      const rows = domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry);
+
+      expect(rows).to.have.length(1);
+      expect(rows[0].textContent).to.contain('Slack Development');
+      expect(rows[0].textContent).not.to.contain('Slack Production');
 
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1131,7 +1131,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       configurationInstances.setState({
         selectableInstances: [],
-        clusterSelected: true
+        available: true,
+        loading: true
       });
       elementTemplates.set([ ...templates, template ]);
 
@@ -1144,9 +1145,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(domQuery('.bio-properties-panel-label', labeledEntry).textContent).to.equal('Destination AWS credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', labeledEntry).textContent).to.equal('+Choose destination AWS credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', labeledEntry).textContent).to.equal('Choose destination AWS credential');
       expect(domQuery('.bio-properties-panel-label', fallbackEntry).textContent).to.equal('AWS Credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry).textContent).to.equal('+Choose AWS Credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', fallbackEntry).textContent).to.equal('Choose AWS Credential');
 
       // when
       await act(() => {
@@ -1154,7 +1155,18 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      expect(domQuery('.bio-properties-panel-configuration-chooser-empty', fallbackEntry).textContent).to.equal('AWS Credential not present in connected cluster');
+      const refreshing = domQuery('.bio-properties-panel-configuration-chooser-refreshing', fallbackEntry);
+
+      expect(refreshing.getAttribute('role')).to.equal('status');
+      expect(refreshing.textContent).to.contain('Refreshing configurations...');
+
+      // when
+      await act(() => {
+        configurationInstances.setLoading(false);
+      });
+
+      // then
+      expect(domQuery('.bio-properties-panel-configuration-chooser-empty', fallbackEntry).textContent).to.equal('No compatible configurations are available in the connected cluster');
 
       // when
       await act(() => {
@@ -1168,6 +1180,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
           }
         } ]);
       });
+
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', fallbackEntry));
 
       await act(() => {
@@ -1249,7 +1262,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       configurationInstances.setState({
         selectableInstances: [],
-        clusterSelected: true
+        available: true
       });
       elementTemplates.set([ ...templates, template ]);
 
@@ -1261,7 +1274,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(domQuery('.bio-properties-panel-label', entry).textContent).to.equal('AWS Credential');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry).textContent).to.equal('+Choose AWS Credential');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry).textContent).to.equal('Choose AWS Credential');
     }));
 
 
@@ -1338,6 +1351,78 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
     }));
 
+
+    it('should update metadata when replacing a configuration', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData'),
+            businessObject = getBusinessObject(element);
+      const template = configurationMetadataCleanupTemplates[0];
+      const production = {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+      const development = {
+        name: 'slackDevelopment',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Development',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2
+        }
+      };
+
+      configurationInstances.setSelectableInstances([ production, development ]);
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const propertyEntry = findEntry('custom-entry-configuration-metadata-cleanup-0', container),
+            inputEntry = findEntry('custom-entry-configuration-metadata-cleanup-1', container);
+
+      const select = async (entry, index) => {
+        await act(() => {
+          fireEvent.click(domQuery(
+            '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-selected',
+            entry
+          ));
+        });
+        fireEvent.click(domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry)[ index ]);
+      };
+
+      await select(propertyEntry, 0);
+      await select(inputEntry, 0);
+      await select(propertyEntry, 1);
+      await select(inputEntry, 1);
+
+      // then
+      const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
+            ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
+
+      expect(findZeebeProperty(zeebeProperties, { name: 'propertyConfiguration' })).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'propertyConfiguration',
+        value: '=camunda.vars.env.slackDevelopment',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Development'
+      });
+      expect(findInputParameter(ioMapping, { name: 'inputConfiguration' })).to.jsonEqual({
+        $type: 'zeebe:Input',
+        source: '=camunda.vars.env.slackDevelopment',
+        target: 'inputConfiguration',
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Development'
+      });
+    }));
+
+
   });
 
 
@@ -1385,7 +1470,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const entry = findEntry('custom-entry-configuration-property-0', container),
             placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
 
-      expect(placeholder.textContent).to.equal('+Choose configuration');
+      expect(placeholder.textContent).to.equal('Choose configuration');
 
       // when
       await act(() => {
@@ -1396,7 +1481,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
       });
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container));
+      fireEvent.keyDown(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container), {
+        key: ' '
+      });
 
       // then
       const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
@@ -1409,6 +1496,14 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
         modelerConfigurationName: 'Slack Production'
       });
+
+      // when
+      fireEvent.keyDown(domQuery('.bio-properties-panel-configuration-chooser-selected', entry), {
+        key: 'Enter'
+      });
+
+      // then
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.exist;
 
     }));
 
@@ -1537,9 +1632,11 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
 
-      configurationInstances.setState({
-        selectableInstances: [],
-        clusterSelected: false
+      await act(() => {
+        configurationInstances.setState({
+          selectableInstances: [],
+          available: false
+        });
       });
 
       await waitFor(() => {
@@ -1562,6 +1659,199 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(menuItems).to.have.length(1);
       expect(menuItems[0].textContent).to.equal('Remove');
+    }));
+
+
+    it('should show a static loading state for a selected configuration', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setState({
+        selectableInstances: [ {
+          name: 'slackProduction',
+          metadata: {
+            kind: 'CREDENTIAL',
+            displayName: 'Slack Production',
+            configurationTemplate: 'io.camunda:slack-connection:1',
+            configurationTemplateVersion: 2
+          }
+        } ],
+        available: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+      });
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+
+      // when
+      await act(() => {
+        configurationInstances.setState({
+          selectableInstances: [],
+          loading: true
+        });
+      });
+
+      // then
+      const loading = domQuery('.bio-properties-panel-configuration-chooser-loading', entry);
+
+      expect(loading).to.exist;
+      expect(loading.getAttribute('role')).to.equal('status');
+      expect(loading.textContent).to.contain('Slack Production');
+      expect(loading.textContent).to.contain('Loading configuration');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-loading-shimmer', entry)).not.to.exist;
+    }));
+
+
+    it('should show the host-provided unavailable message for an unselected configuration', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setState({
+        selectableInstances: [ {
+          name: 'slackProduction',
+          metadata: {
+            kind: 'CREDENTIAL',
+            displayName: 'Slack Production',
+            configurationTemplate: 'io.camunda:slack-connection:1',
+            configurationTemplateVersion: 2
+          }
+        } ],
+        available: true,
+        error: false
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+
+      await act(() => {
+        fireEvent.click(placeholder);
+      });
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).to.exist;
+
+      // when
+      await act(() => {
+        configurationInstances.setState({
+          available: false,
+          unavailableMessage: 'No cluster selected'
+        });
+      });
+
+      // then
+      const unavailable = domQuery('.bio-properties-panel-configuration-chooser-unavailable', entry);
+
+      expect(placeholder.disabled).to.be.true;
+      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-unavailable');
+      expect(unavailable.getAttribute('role')).to.equal('status');
+      expect(unavailable.textContent).to.equal('No cluster selected');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
+    }));
+
+
+    it('should show an error message for an unselected configuration when loading fails', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      configurationInstances.setState({
+        available: true,
+        error: true
+      });
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry),
+            error = domQuery('.bio-properties-panel-configuration-chooser-unavailable--error', entry);
+
+      // then
+      expect(placeholder.disabled).to.be.true;
+      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-error');
+      expect(error.getAttribute('role')).to.equal('status');
+      expect(error.textContent).to.equal('Could not load configurations');
+
+      // when
+      await act(() => {
+        configurationInstances.setState({
+          error: false
+        });
+      });
+
+      // then
+      expect(placeholder.disabled).to.be.false;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-unavailable--error', entry)).not.to.exist;
     }));
 
 
@@ -1598,7 +1888,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
             configurationTemplateVersion: 2
           }
         } ],
-        clusterSelected: true
+        available: true
       });
       elementTemplates.set([ ...templates, template ]);
 
@@ -1625,6 +1915,10 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(entry.textContent).to.contain('Not found on cluster');
       expect(entry.textContent).not.to.contain('Could not load configurations');
 
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).to.exist;
+
       // when - failed response
       await act(() => {
         configurationInstances.setState({
@@ -1643,6 +1937,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(error.textContent).to.contain('Slack Production');
       expect(error.textContent).to.contain('Could not load configurations');
       expect(entry.textContent).not.to.contain('Not found on cluster');
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).not.to.exist;
 
       fireEvent.click(error);
 
@@ -1683,7 +1978,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const createSpy = spy();
 
       configurationInstances.setState({
-        clusterSelected: true
+        available: true
       });
       eventBus.on('configuration.create', createSpy);
       elementTemplates.set([ ...templates, template ]);
@@ -1763,7 +2058,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       };
 
       configurationInstances.setState({
-        clusterSelected: true
+        available: true
       });
       elementTemplates.set([ ...templates, template ]);
 
@@ -1869,7 +2164,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       configurationInstances.setState({
         selectableInstances: [ instance ],
-        clusterSelected: true
+        available: true
       });
       eventBus.on('configuration.edit', editSpy);
       elementTemplates.set([ ...templates, template ]);
@@ -1969,7 +2264,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       configurationInstances.setState({
         selectableInstances: [ compatibleInstance ],
-        clusterSelected: true,
+        available: true,
         permissions: {
           update: true
         }
@@ -2004,7 +2299,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(missing).to.exist;
       expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
 
-      fireEvent.click(missing);
+      fireEvent.keyDown(missing, {
+        key: 'Enter'
+      });
 
       const rows = domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry);
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1635,7 +1635,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         configurationInstances.setState({
           selectableInstances: [],
-          available: false
+          available: false,
+          unavailableMessage: 'No cluster selected'
         });
       });
 
@@ -1643,6 +1644,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-configuration-chooser-selected', entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-selected--offline', entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-logo', entry).getAttribute('src')).to.equal('data:image/svg+xml;base64,offline-icon');
+        expect(domQuery('.bio-properties-panel-configuration-chooser-subtitle', entry).textContent).to.equal('No cluster selected');
         expect(domQuery('.bio-properties-panel-configuration-chooser-missing', entry)).not.to.exist;
       });
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1225,9 +1225,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(typeMismatch.textContent).not.to.contain('AWS Credential');
       expect(typeMismatch.textContent).not.to.contain('io.camunda:other-credential:1');
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', fallbackEntry));
-
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', fallbackEntry)).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-menu', fallbackEntry)).not.to.exist;
     }));
 
 
@@ -1315,8 +1313,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', inputEntry));
 
       // when
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', inputEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', inputEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-selected', inputEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row--empty', inputEntry));
 
       // then
       const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
@@ -1328,8 +1326,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // when
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', propertyEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', propertyEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-selected', propertyEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row--empty', propertyEntry));
 
       // then
       const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
@@ -1388,13 +1386,15 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
             inputEntry = findEntry('custom-entry-configuration-metadata-cleanup-1', container);
 
       const select = async (entry, index) => {
+        const hasSelection = !!domQuery('.bio-properties-panel-configuration-chooser-selected', entry);
+
         await act(() => {
           fireEvent.click(domQuery(
             '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-selected',
             entry
           ));
         });
-        fireEvent.click(domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry)[ index ]);
+        fireEvent.click(domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry)[ index + (hasSelection ? 1 : 0) ]);
       };
 
       await select(propertyEntry, 0);
@@ -1575,7 +1575,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     }));
 
 
-    it('should hide creation and show only the remove action for an offline configuration', inject(async function(elementTemplates, configurationInstances) {
+    it('should hide creation and show only the clear selection action for an offline configuration', inject(async function(elementTemplates, configurationInstances) {
 
       // given
       const element = await expectSelected('RestTask_noData');
@@ -1660,7 +1660,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
 
       expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Remove');
+      expect(menuItems[0].textContent).to.equal('Clear selection');
     }));
 
 
@@ -1917,9 +1917,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(entry.textContent).to.contain('Not found on cluster');
       expect(entry.textContent).not.to.contain('Could not load configurations');
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
-
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-menu', entry)).not.to.exist;
 
       // when - failed response
       await act(() => {
@@ -1950,7 +1948,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
 
       expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Remove');
+      expect(menuItems[0].textContent).to.equal('Clear selection');
     }));
 
 
@@ -2181,9 +2179,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry)).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-menu', entry)).not.to.exist;
 
       await act(() => {
         configurationInstances.setState({
@@ -2192,6 +2189,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
           }
         });
       });
+
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 
       const edit = domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry);
 
@@ -2307,9 +2306,10 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       const rows = domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry);
 
-      expect(rows).to.have.length(1);
-      expect(rows[0].textContent).to.contain('Slack Development');
-      expect(rows[0].textContent).not.to.contain('Slack Production');
+      expect(rows).to.have.length(2);
+      expect(rows[0].textContent).to.equal('No selection');
+      expect(rows[1].textContent).to.contain('Slack Development');
+      expect(rows[1].textContent).not.to.contain('Slack Production');
 
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Replace the "Remove" button in the actions menu with a placeholder "No selection" item in the credentials select field.

Related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/263#issuecomment-5283287350

<img width="429" height="557" alt="image" src="https://github.com/user-attachments/assets/b459215c-8c3d-4f8e-bf84-fbb57aa20f8e" />


### Try it

`npm start` and choose credentials on the AWS connector.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
