### PR TITLE
chore(ConfigurationProperty): rename Remove action menu button to Unset

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -430,11 +430,3 @@
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
-.bio-properties-panel-configuration-chooser-context-menu-item--danger {
-  color: var(--color-red-360-100-45, #e60000);
-}
-
-.bio-properties-panel-configuration-chooser-context-menu-item--danger:hover,
-.bio-properties-panel-configuration-chooser-context-menu-item--danger:focus-visible {
-  background-color: #fff0f0;
-}

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -536,9 +536,9 @@ function ConfigurationContextMenu(props) {
       }
       <button
         type="button"
-        class="bio-properties-panel-configuration-chooser-context-menu-item bio-properties-panel-configuration-chooser-context-menu-item--danger"
+        class="bio-properties-panel-configuration-chooser-context-menu-item"
         onClick={ onRemove }>
-        { translate('Remove') }
+        { translate('Unset') }
       </button>
     </div>
   );

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -16,7 +16,8 @@ import {
   act,
   cleanup,
   fireEvent,
-  waitFor
+  waitFor,
+  within
 } from '@testing-library/preact';
 
 import {
@@ -1225,9 +1226,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(typeMismatch.textContent).not.to.contain('AWS Credential');
       expect(typeMismatch.textContent).not.to.contain('io.camunda:other-credential:1');
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', fallbackEntry));
+      openConfigurationMenu(fallbackEntry);
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', fallbackEntry).textContent).to.equal('Unset');
+      expect(getConfigurationMenuItem(fallbackEntry, 'Unset')).to.exist;
     }));
 
 
@@ -1315,8 +1316,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', inputEntry));
 
       // when
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', inputEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', inputEntry));
+      clickConfigurationMenuItem(inputEntry, 'Unset');
 
       // then
       const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
@@ -1328,8 +1328,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // when
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', propertyEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', propertyEntry));
+      clickConfigurationMenuItem(propertyEntry, 'Unset');
 
       // then
       const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
@@ -1654,13 +1653,10 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(domQuery('.bio-properties-panel-configuration-chooser-create', entry)).not.to.exist;
 
       // when
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+      openConfigurationMenu(entry);
 
       // then
-      const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
-
-      expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Unset');
+      expect(getConfigurationMenuItem(entry, 'Unset')).to.exist;
     }));
 
 
@@ -1917,7 +1913,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(entry.textContent).to.contain('Not found on cluster');
       expect(entry.textContent).not.to.contain('Could not load configurations');
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+      openConfigurationMenu(entry);
 
       expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu', entry)).to.exist;
 
@@ -1945,12 +1941,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       expect(domQuery('.bio-properties-panel-configuration-chooser-popover', entry)).not.to.exist;
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+      openConfigurationMenu(entry);
 
-      const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
-
-      expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Unset');
+      expect(getConfigurationMenuItem(entry, 'Unset')).to.exist;
     }));
 
 
@@ -2181,9 +2174,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+      openConfigurationMenu(entry);
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', entry).textContent).to.equal('Unset');
+      expect(getConfigurationMenuItem(entry, 'Unset')).to.exist;
 
       await act(() => {
         configurationInstances.setState({
@@ -2193,9 +2186,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         });
       });
 
-      const edit = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry)[ 0 ];
-
-      expect(edit.textContent).to.equal('Edit');
+      const edit = getConfigurationMenuItem(entry, 'Edit');
 
       // when
       fireEvent.click(edit);
@@ -2311,11 +2302,9 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(rows[0].textContent).to.contain('Slack Development');
       expect(rows[0].textContent).not.to.contain('Slack Production');
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
+      openConfigurationMenu(entry);
 
-      const upgrade = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry)[ 0 ];
-
-      expect(upgrade.textContent).to.equal('Upgrade');
+      const upgrade = getConfigurationMenuItem(entry, 'Upgrade');
 
       // when
       fireEvent.click(upgrade);
@@ -4982,6 +4971,20 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
 
 // helpers //////////
+
+function clickConfigurationMenuItem(entry, label) {
+  openConfigurationMenu(entry);
+
+  fireEvent.click(getConfigurationMenuItem(entry, label));
+}
+
+function getConfigurationMenuItem(entry, label) {
+  return within(entry).getByText(label, { selector: 'button' });
+}
+
+function openConfigurationMenu(entry) {
+  fireEvent.click(within(entry).getByTitle('More actions'));
+}
 
 function expectSelected(id) {
   return getBpmnJS().invoke(async function(elementRegistry, selection) {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1227,7 +1227,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', fallbackEntry));
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', fallbackEntry)).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', fallbackEntry).textContent).to.equal('Unset');
     }));
 
 
@@ -1316,7 +1316,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // when
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', inputEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', inputEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', inputEntry));
 
       // then
       const ioMapping = findExtension(businessObject, 'zeebe:IoMapping');
@@ -1329,7 +1329,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // when
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', propertyEntry));
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item--danger', propertyEntry));
+      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', propertyEntry));
 
       // then
       const zeebeProperties = findExtension(businessObject, 'zeebe:Properties');
@@ -1660,7 +1660,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
 
       expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Remove');
+      expect(menuItems[0].textContent).to.equal('Unset');
     }));
 
 
@@ -1950,7 +1950,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const menuItems = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry);
 
       expect(menuItems).to.have.length(1);
-      expect(menuItems[0].textContent).to.equal('Remove');
+      expect(menuItems[0].textContent).to.equal('Unset');
     }));
 
 
@@ -2183,7 +2183,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 
-      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry)).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-context-menu-item', entry).textContent).to.equal('Unset');
 
       await act(() => {
         configurationInstances.setState({
@@ -2193,7 +2193,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         });
       });
 
-      const edit = domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry);
+      const edit = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry)[ 0 ];
 
       expect(edit.textContent).to.equal('Edit');
 
@@ -2313,7 +2313,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-menu', entry));
 
-      const upgrade = domQuery('.bio-properties-panel-configuration-chooser-context-menu-item:not(.bio-properties-panel-configuration-chooser-context-menu-item--danger)', entry);
+      const upgrade = domQueryAll('.bio-properties-panel-configuration-chooser-context-menu-item', entry)[ 0 ];
 
       expect(upgrade.textContent).to.equal('Upgrade');
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1182,7 +1182,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         } ]);
       });
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', fallbackEntry));
+      clickConfigurationOption(fallbackEntry, 'AWS Production');
 
       await act(() => {
         configurationInstances.setSelectableInstances([ {
@@ -1308,12 +1308,12 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', propertyEntry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', propertyEntry));
+      clickConfigurationOption(propertyEntry, 'Slack Production');
 
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', inputEntry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', inputEntry));
+      clickConfigurationOption(inputEntry, 'Slack Production');
 
       // when
       clickConfigurationMenuItem(inputEntry, 'Unset');
@@ -1386,20 +1386,20 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const propertyEntry = findEntry('custom-entry-configuration-metadata-cleanup-0', container),
             inputEntry = findEntry('custom-entry-configuration-metadata-cleanup-1', container);
 
-      const select = async (entry, index) => {
+      const select = async (entry, name) => {
         await act(() => {
           fireEvent.click(domQuery(
             '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-selected',
             entry
           ));
         });
-        fireEvent.click(domQueryAll('.bio-properties-panel-configuration-chooser-popover-row', entry)[ index ]);
+        clickConfigurationOption(entry, name);
       };
 
-      await select(propertyEntry, 0);
-      await select(inputEntry, 0);
-      await select(propertyEntry, 1);
-      await select(inputEntry, 1);
+      await select(propertyEntry, 'Slack Production');
+      await select(inputEntry, 'Slack Production');
+      await select(propertyEntry, 'Slack Development');
+      await select(inputEntry, 'Slack Development');
 
       // then
       const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
@@ -1480,7 +1480,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
       });
 
-      fireEvent.keyDown(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container), {
+      fireEvent.keyDown(getConfigurationOption(container, 'Slack Production'), {
         key: ' '
       });
 
@@ -1557,7 +1557,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container)).to.exist;
       });
 
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', container));
+      clickConfigurationOption(container, 'Slack Production');
 
       // then
       const ioMapping = findExtension(businessObject, 'zeebe:IoMapping'),
@@ -1629,7 +1629,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(placeholder);
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      clickConfigurationOption(entry, 'Slack Production');
 
       await act(() => {
         configurationInstances.setState({
@@ -1706,7 +1706,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      clickConfigurationOption(entry, 'Slack Production');
 
       // when
       await act(() => {
@@ -1899,7 +1899,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      clickConfigurationOption(entry, 'Slack Production');
 
       // when - successful empty response
       await act(() => {
@@ -2173,7 +2173,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      clickConfigurationOption(entry, 'Slack Production');
       openConfigurationMenu(entry);
 
       expect(getConfigurationMenuItem(entry, 'Unset')).to.exist;
@@ -2274,7 +2274,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       await act(() => {
         fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
       });
-      fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      clickConfigurationOption(entry, 'Slack Production');
 
       await act(() => {
 
@@ -4976,6 +4976,16 @@ function clickConfigurationMenuItem(entry, label) {
   openConfigurationMenu(entry);
 
   fireEvent.click(getConfigurationMenuItem(entry, label));
+}
+
+function clickConfigurationOption(entry, name) {
+  fireEvent.click(getConfigurationOption(entry, name));
+}
+
+function getConfigurationOption(entry, name) {
+  return within(entry).getAllByText(name).find(option => {
+    return option.closest('li[role="button"]');
+  }).closest('li[role="button"]');
 }
 
 function getConfigurationMenuItem(entry, label) {


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Rename "Remove" button to "Unset", and change color to black, as the action is not actually destructive.

<img width="424" height="275" alt="image" src="https://github.com/user-attachments/assets/3da681a2-956c-475a-ad53-3e69bf797b6d" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
