### PR TITLE
fix: wire configuration chooser to showEntry and constraints

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -123,6 +123,15 @@
   padding-bottom: 10px;
 }
 
+/* constraint violation, cf. .bio-properties-panel-entry.has-error */
+.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-placeholder,
+.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-selected,
+.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-loading,
+.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-missing {
+  border-color: var(--input-error-border-color);
+  background-color: var(--input-error-background-color);
+}
+
 /* placeholder trigger (no selection) */
 .bio-properties-panel-configuration-chooser-placeholder {
   display: flex;

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1,7 +1,7 @@
 import { useService } from 'bpmn-js-properties-panel';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
-import { CreateIcon } from '@bpmn-io/properties-panel';
+import { CreateIcon, useShowEntryEvent } from '@bpmn-io/properties-panel';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -180,6 +180,7 @@ export function ConfigurationProperty(props) {
   const [ open, setOpen ] = useState(false);
   const [ menuOpen, setMenuOpen ] = useState(false);
   const ref = useRef(null);
+  const showEntryRef = useShowEntryEvent(id);
   const availabilityRef = useRef({ error, available });
 
   useEffect(() => {
@@ -393,6 +394,7 @@ export function ConfigurationProperty(props) {
                   : (
                     <>
                       <button
+                        ref={ showEntryRef }
                         type="button"
                         class="bio-properties-panel-configuration-chooser-placeholder"
                         disabled={ disabled || error || !available }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -144,7 +144,7 @@ export function ConfigurationProperty(props) {
   const setValue = useCallback((value, instance) => {
     const selectedInstance = instance || instances.find(({ name }) => toReference(name) === value);
 
-    baseSetValue(value, {
+    baseSetValue(value, null, {
       modelerConfigurationTemplate: value && configurationTemplate || undefined,
       modelerConfigurationName: selectedInstance ? getDisplayName(selectedInstance) : undefined
     });

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1,15 +1,17 @@
 import { useService } from 'bpmn-js-properties-panel';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
-import { CreateIcon, useShowEntryEvent } from '@bpmn-io/properties-panel';
+import { CreateIcon, useError, useShowEntryEvent } from '@bpmn-io/properties-panel';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import { query as domQuery } from 'min-dom';
 
+import classnames from 'classnames';
+
 import { PropertyDescription } from '../../../../components/PropertyDescription';
 import { PropertyTooltip } from '../../components/PropertyTooltip';
-import { propertyGetter, propertySetter } from './util';
+import { propertyGetter, propertySetter, propertyValidator } from './util';
 
 import { findExtension, findInputParameter, findZeebeProperty } from '../../../Helper';
 
@@ -177,6 +179,21 @@ export function ConfigurationProperty(props) {
     return bindingElement && bindingElement.modelerConfigurationName;
   }, [ element, property, value ]);
 
+  // apply the template's `constraints`, as every other custom property does
+  const validate = useMemo(
+    () => propertyValidator(translate, property),
+    [ translate, property ]
+  );
+
+  const globalValidationError = useError(id);
+  const [ localValidationError, setLocalValidationError ] = useState(null);
+
+  useEffect(() => {
+    setLocalValidationError(validate(value) || null);
+  }, [ validate, value ]);
+
+  const validationError = globalValidationError || localValidationError;
+
   const [ open, setOpen ] = useState(false);
   const [ menuOpen, setMenuOpen ] = useState(false);
   const ref = useRef(null);
@@ -322,7 +339,11 @@ export function ConfigurationProperty(props) {
   return (
     <div
       ref={ ref }
-      class="bio-properties-panel-configuration-chooser"
+      class={ classnames(
+        'bio-properties-panel-entry',
+        'bio-properties-panel-configuration-chooser',
+        validationError ? 'has-error' : ''
+      ) }
       data-entry-id={ id }>
       <label class="bio-properties-panel-label">
         { configurationLabel }
@@ -435,6 +456,16 @@ export function ConfigurationProperty(props) {
                       }
                     </>
                   )
+      }
+
+      {
+        validationError
+          ? (
+            <div class="bio-properties-panel-error">
+              { validationError }
+            </div>
+          )
+          : null
       }
 
       {

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
@@ -64,7 +64,11 @@ export function propertyGetter(element, property) {
 }
 
 export function propertySetter(bpmnFactory, commandStack, element, property) {
-  return function setValue(value, additionalProperties) {
+
+  // entry components call setValue(value, validationError); the validation error
+  // is never persisted, callers that need to stamp extra moddle properties pass
+  // them explicitly as the third argument instead
+  return function setValue(value, error, additionalProperties) {
     return setPropertyValue(bpmnFactory, commandStack, element, property, value, additionalProperties);
   };
 }

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -52,6 +52,8 @@ import { connectors } from '@camunda/connectors-element-templates';
 
 import connectionsDesignTemplates from 'test/spec/cloud-element-templates/fixtures/connections-design.json';
 
+import configurationConstraintsTemplates from 'test/spec/cloud-element-templates/fixtures/configuration-constraints.json';
+
 const singleStart = window.__env__ && window.__env__.SINGLE_START;
 
 insertCoreStyles();
@@ -575,7 +577,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
 
     const elementTemplates = [
       ...connectors.flatMap(connector => connector.default || connector),
-      ...exampleConfigurationTemplates
+      ...exampleConfigurationTemplates,
+      ...configurationConstraintsTemplates
     ];
 
     const configurationTemplates = new Set(
@@ -637,6 +640,10 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
       .filter((configurationTemplate) => !configurationTemplates.has(configurationTemplate));
 
     expect(missingMockConfigurationTemplates).to.be.empty;
+
+    expect(
+      result.modeler.get('elementTemplates').getLatest('io.camunda.examples.ConfigurationConstraints.v1')
+    ).to.have.length(1);
 
     // and
     createTestUI(result.modeler);

--- a/test/spec/cloud-element-templates/fixtures/configuration-constraints.json
+++ b/test/spec/cloud-element-templates/fixtures/configuration-constraints.json
@@ -1,0 +1,44 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Configuration Constraints Example",
+    "id": "io.camunda.examples.ConfigurationConstraints.v1",
+    "description": "Declares the same notEmpty constraint on a String and on a Configuration property, so their validation can be compared side by side.",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "engines": {
+      "camunda": "^8.3"
+    },
+    "properties": [
+      {
+        "id": "requiredText",
+        "label": "Required text",
+        "type": "String",
+        "constraints": {
+          "notEmpty": true
+        },
+        "binding": {
+          "type": "zeebe:property",
+          "name": "requiredText"
+        }
+      },
+      {
+        "id": "requiredConfiguration",
+        "label": "Required configuration",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:aws-credential:1",
+        "constraints": {
+          "notEmpty": true
+        },
+        "binding": {
+          "type": "zeebe:property",
+          "name": "requiredConfiguration"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -13,6 +13,7 @@
         </zeebe:taskHeaders>
         <zeebe:properties>
           <zeebe:property name="property-1-name" value="property-1-value" />
+          <zeebe:property name="property-required-name" value="property-required-value" />
         </zeebe:properties>
       </bpmn:extensionElements>
     </bpmn:serviceTask>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -70,6 +70,18 @@
           "type": "zeebe:property",
           "name": "property-1-name"
         }
+      },
+      {
+        "label": "property-required",
+        "type": "String",
+        "value": "property-required-value",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "property-required-name"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
       }
     ]
   },

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1089,6 +1089,32 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       expect(zeebeProperty).not.to.exist;
     }));
 
+
+    it('should not leak the validation error into the moddle element when clearing a required property', inject(async function() {
+
+      // given
+      const task = await expectSelected('RestTask'),
+            businessObject = getBusinessObject(task);
+
+      const entry = findEntry('custom-entry-com.example.rest-8', container),
+            input = findInput('text', entry);
+
+      // when
+      changeInput(input, '');
+
+      // then
+      const zeebeProperties = findExtension(businessObject, 'zeebe:Properties'),
+            zeebeProperty = findZeebeProperty(zeebeProperties, { name: 'property-required-name' });
+
+      expect(zeebeProperty).to.exist;
+      expect(zeebeProperty).to.jsonEqual({
+        $type: 'zeebe:Property',
+        name: 'property-required-name',
+        value: ''
+      });
+      expect(zeebeProperty.$attrs).to.eql({});
+    }));
+
   });
 
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1425,6 +1425,138 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('configuration showEntry', function() {
+
+    const template = {
+      id: 'configuration-show-entry',
+      appliesTo: [ 'bpmn:ServiceTask' ],
+      elementType: {
+        value: 'bpmn:ServiceTask'
+      },
+      groups: [ {
+        id: 'credentials',
+        label: 'Credentials'
+      } ],
+      properties: [ {
+        id: 'stringProperty',
+        label: 'String property',
+        type: 'String',
+        group: 'credentials',
+        binding: {
+          type: 'zeebe:property',
+          name: 'stringProperty'
+        }
+      }, {
+        id: 'configurationProperty',
+        label: 'Configuration property',
+        type: 'Configuration',
+        group: 'credentials',
+        configurationTemplate: 'io.camunda:slack-connection:1',
+        binding: {
+          type: 'zeebe:property',
+          name: 'configurationProperty'
+        }
+      } ],
+      configurationTemplates: [ {
+        id: 'io.camunda:slack-connection:1',
+        kind: 'CREDENTIAL',
+        name: 'Slack Connection',
+        version: 1,
+        properties: []
+      } ]
+    };
+
+    const STRING_ENTRY_ID = 'custom-entry-configuration-show-entry-credentials-0',
+          CONFIGURATION_ENTRY_ID = 'custom-entry-configuration-show-entry-credentials-1',
+          GROUP_ID = 'ElementTemplates__CustomProperties-credentials';
+
+    beforeEach(inject(async function(elementTemplates, configurationInstances) {
+      const element = await expectSelected('RestTask_noData');
+
+      configurationInstances.setSelectableInstances([ {
+        name: 'slackProduction',
+        metadata: {
+          kind: 'CREDENTIAL',
+          displayName: 'Slack Production',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 1
+        }
+      } ]);
+
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+    }));
+
+
+    it('should reveal the collapsed group of a String property', inject(async function(eventBus) {
+
+      // given
+      expectGroupOpen(getGroupById(GROUP_ID, container), false);
+
+      // when
+      await act(() => {
+        eventBus.fire('propertiesPanel.showEntry', { id: STRING_ENTRY_ID });
+      });
+
+      // then
+      expectGroupOpen(getGroupById(GROUP_ID, container), true);
+    }));
+
+
+    it('should reveal the collapsed group of a Configuration property', inject(async function(eventBus) {
+
+      // given
+      expectGroupOpen(getGroupById(GROUP_ID, container), false);
+
+      // when
+      await act(() => {
+        eventBus.fire('propertiesPanel.showEntry', { id: CONFIGURATION_ENTRY_ID });
+      });
+
+      // then
+      expectGroupOpen(getGroupById(GROUP_ID, container), true);
+    }));
+
+
+    it('should focus a String property entry', inject(async function(eventBus) {
+
+      // given
+      await act(() => {
+        eventBus.fire('propertiesPanel.showEntry', { id: STRING_ENTRY_ID });
+      });
+
+      const entry = findEntry(STRING_ENTRY_ID, container);
+
+      // when
+      const focussed = document.activeElement;
+
+      // then
+      expect(entry.contains(focussed)).to.be.true;
+    }));
+
+
+    it('should focus a Configuration property entry', inject(async function(eventBus) {
+
+      // given
+      await act(() => {
+        eventBus.fire('propertiesPanel.showEntry', { id: CONFIGURATION_ENTRY_ID });
+      });
+
+      const entry = findEntry(CONFIGURATION_ENTRY_ID, container);
+
+      // when
+      const focussed = document.activeElement;
+
+      // then
+      expect(entry.contains(focussed)).to.be.true;
+    }));
+
+  });
+
+
   describe('configuration', function() {
 
     it('should store metadata on zeebe:Property', inject(async function(elementTemplates, configurationInstances) {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -94,6 +94,8 @@ import complexPropertyTemplates from './CustomProperties.complex-property.json';
 
 import configurationMetadataCleanupTemplates from './CustomProperties.configuration-metadata-cleanup.json';
 
+import configurationConstraintsTemplates from '../fixtures/configuration-constraints.json';
+
 import timerDiagramXML from './CustomProperties.timer.bpmn';
 import timerElementTemplates from './CustomProperties.timer.json';
 
@@ -1552,6 +1554,101 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(entry.contains(focussed)).to.be.true;
+    }));
+
+  });
+
+
+  describe('configuration constraints', function() {
+
+    const template = configurationConstraintsTemplates[0];
+
+    const TEXT_ENTRY_ID = 'custom-entry-io.camunda.examples.ConfigurationConstraints.v1-0',
+          CONFIGURATION_ENTRY_ID = 'custom-entry-io.camunda.examples.ConfigurationConstraints.v1-1';
+
+    const awsProduction = {
+      name: 'awsProduction',
+      metadata: {
+        kind: 'CREDENTIAL',
+        displayName: 'AWS Production',
+        configurationTemplate: 'io.camunda:aws-credential:1',
+        configurationTemplateVersion: 1
+      }
+    };
+
+    beforeEach(inject(async function(elementTemplates, configurationInstances) {
+      const element = await expectSelected('RestTask_noData');
+
+      configurationInstances.setSelectableInstances([]);
+
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+    }));
+
+
+    it('should reject an empty String property', async function() {
+
+      // when
+      const entry = findEntry(TEXT_ENTRY_ID, container);
+
+      // then
+      expectError(entry, 'Required text must not be empty.');
+    });
+
+
+    it('should reject an empty Configuration property', async function() {
+
+      // when
+      const entry = findEntry(CONFIGURATION_ENTRY_ID, container);
+
+      // then
+      expectError(entry, 'Required configuration must not be empty.');
+      expect(domClasses(entry).contains('has-error')).to.be.true;
+    });
+
+
+    it('should accept a selected Configuration property', inject(async function(configurationInstances) {
+
+      // given
+      await act(() => {
+        configurationInstances.setSelectableInstances([ awsProduction ]);
+      });
+
+      const entry = findEntry(CONFIGURATION_ENTRY_ID, container);
+
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry));
+      });
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-popover-row', entry));
+      });
+
+      // then
+      expectValid(findEntry(CONFIGURATION_ENTRY_ID, container));
+    }));
+
+
+    it('should render an external error on a Configuration property', inject(async function(eventBus) {
+
+      // when
+      await act(() => {
+        eventBus.fire('propertiesPanel.setErrors', {
+          errors: {
+            [ CONFIGURATION_ENTRY_ID ]: 'Configuration is not available on the cluster.'
+          }
+        });
+      });
+
+      // then
+      expectError(
+        findEntry(CONFIGURATION_ENTRY_ID, container),
+        'Configuration is not available on the cluster.'
+      );
     }));
 
   });


### PR DESCRIPTION
### Proposed Changes

Follow-up from reviewing #263. Two properties-panel entry behaviors that every other custom property gets for free were missing on the `Configuration` chooser, because it renders its own markup instead of delegating to a `@bpmn-io/properties-panel` entry component:

- `propertiesPanel.showEntry` — how Modeler expands a collapsed group and focuses an entry, e.g. from a linting problem — silently did nothing for it.
- Template `constraints` (`notEmpty`, `minLength`, `maxLength`, `pattern`) are declarable on a `Configuration` property like on any other, but were never enforced, so a required configuration could be left empty with no error.

Changes:

* Wire `useShowEntryEvent`, the same hook `TextfieldEntry` & co. use, so the chooser reveals its group and focuses the placeholder on `propertiesPanel.showEntry`.
* Run the same `propertyValidator` the other custom properties use, prefer an externally provided error over the local one (mirroring `TextfieldEntry`), and render it. Errors now also reach the chooser via `propertiesPanel.setErrors`, which is how linting surfaces problems on an entry.
* Add a named `Configuration Constraints Example` element template fixture (`test/spec/cloud-element-templates/fixtures/configuration-constraints.json`) and register it in the cloud-templates playground.


https://github.com/user-attachments/assets/a0bb84c2-da7a-43c3-9ad7-120d17726793



Steps to try out:

1. `npm start`
2. Apply *Configuration Constraints Example* to any task
3. "Required text" and "Required configuration" both report `must not be empty.` when left unset

Related to #263

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
