### PR TITLE
feat(configuration): use shared properties-panel focus ring

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -155,10 +155,6 @@
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
-.bio-properties-panel-configuration-chooser-placeholder:focus-visible {
-  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
-}
-
 .bio-properties-panel-configuration-chooser-placeholder:disabled {
   cursor: default;
   opacity: 0.5;
@@ -264,10 +260,6 @@
   background-color: #fef3e0;
 }
 
-.bio-properties-panel-configuration-chooser-missing:focus-within {
-  box-shadow: 0 0 0 2px #f0ad4e;
-}
-
 .bio-properties-panel-configuration-chooser-error {
   cursor: default;
 }
@@ -277,10 +269,6 @@
   overflow-wrap: anywhere;
   text-overflow: clip;
   white-space: normal;
-}
-
-.bio-properties-panel-configuration-chooser-selected:focus-within {
-  box-shadow: 0 0 0 2px var(--color-blue-205-100-50, #1a75ff);
 }
 
 /* logo */

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -622,7 +622,7 @@ function SelectedConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected"
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-focus-ring"
       interactive
       disabled={ disabled }
       open={ open }
@@ -887,7 +887,7 @@ function PlaceholderConfiguration(props) {
       <button
         ref={ showEntryRef }
         type="button"
-        class="bio-properties-panel-configuration-chooser-placeholder"
+        class="bio-properties-panel-configuration-chooser-placeholder bio-properties-panel-focus-ring"
         disabled={ disabled || error || !available }
         aria-haspopup="listbox"
         aria-controls={ open ? listboxId : undefined }
@@ -959,7 +959,7 @@ function ErrorConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error"
+      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }
@@ -1007,7 +1007,7 @@ function MissingConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing"
+      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-focus-ring"
       interactive
       disabled={ disabled }
       open={ open }
@@ -1048,7 +1048,7 @@ function OfflineConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline"
+      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }


### PR DESCRIPTION
### Proposed Changes

Adopt the reusable `bio-properties-panel-focus-ring` primitive from properties-panel for the configuration chooser controls (placeholder, selected, missing, error and offline cards), remove the component's custom `box-shadow` focus styles:

<img width="1122" height="689" alt="capture JpoU6F_optimized" src="https://github.com/user-attachments/assets/7ba5d008-919f-4b52-bae1-660c7119626f" />

Depends on https://github.com/bpmn-io/properties-panel/pull/535

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)