### PR TITLE
fix(custom-properties): conform property getter to panel value contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: align property getter to panel value contract to not defeat changed detection ([#283](https://github.com/bpmn-io/bpmn-js-element-templates/pull/283))
+
 ## 2.30.0
 
 * `FEAT`: attach `template` to template errors ([#273](https://github.com/bpmn-io/bpmn-js-element-templates/pull/273))

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/util.js
@@ -59,7 +59,11 @@ const feelEnabled = (property, value) => {
 
 export function propertyGetter(element, property) {
   return function getValue() {
-    return getPropertyValue(element, property);
+    const value = getPropertyValue(element, property);
+
+    // conform to the properties panel value contract, which represents an
+    // empty value as `undefined`; our domain layer uses '' for empty
+    return value === '' ? undefined : value;
   };
 }
 

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -70,6 +70,13 @@ export function clickInput(input) {
   fireEvent.click(input);
 }
 
+export function blurInput(input) {
+  return act(() => {
+    input.focus();
+    input.blur();
+  });
+}
+
 export function insertCoreStyles() {
   insertCSS(
     'properties-panel.css',

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -20,6 +20,13 @@
     <bpmn:userTask id="DropdownTask" name="low" zeebe:modelerTemplate="my.example.dropdown" />
     <bpmn:task id="ValidateTask" zeebe:modelerTemplate="com.validated-inputs.Task" />
     <bpmn:serviceTask id="RestTask_noData" name="REST Task no data" zeebe:modelerTemplate="com.example.rest" />
+    <bpmn:serviceTask id="RestTask_empty" name="REST Task empty" zeebe:modelerTemplate="com.example.rest">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="property-1-name" value="" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
     <bpmn:serviceTask id="RestTask_hidden" name="Hidden Task Type" zeebe:modelerTemplate="com.example.rest-hidden">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="task-type" />
@@ -173,6 +180,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1hbryo1_di" bpmnElement="RestTask_noData">
         <dc:Bounds x="430" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="RestTask_empty_di" bpmnElement="RestTask_empty">
+        <dc:Bounds x="430" y="480" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0sz43pp_di" bpmnElement="RestTask_hidden">
         <dc:Bounds x="600" y="80" width="100" height="80" />

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -9,7 +9,8 @@ import {
   getBpmnJS,
   withPropertiesPanel,
   inject,
-  setEditorValue
+  setEditorValue,
+  blurInput
 } from 'test/TestHelper';
 
 import {
@@ -1016,6 +1017,30 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         value: 'property-1-changed-value'
       });
     });
+
+
+    it('should not commit unchanged property on blur', inject(async function(eventBus) {
+
+      // given
+      await expectSelected('RestTask_empty');
+
+      // open the (collapsed) custom properties group to focus the input
+      await openGroup(getGroupById('ElementTemplates__CustomProperties', container));
+
+      const entry = findEntry('custom-entry-com.example.rest-7', container),
+            input = findInput('text', entry);
+
+      const changedSpy = spy();
+
+      eventBus.on('commandStack.changed', changedSpy);
+
+      // when
+      // re-committing the unchanged (empty) value, as save-on-blur does
+      await blurInput(input);
+
+      // then
+      expect(changedSpy).not.to.have.been.called;
+    }));
 
 
     it('should keep property (non optional)', inject(async function() {
@@ -3767,6 +3792,14 @@ function getGroupById(id, container) {
   );
 
   return group;
+}
+
+function openGroup(group) {
+  const header = domQuery('.bio-properties-panel-group-header', group);
+
+  return act(() => {
+    header.click();
+  });
 }
 
 function withoutPrefix(groupId) {


### PR DESCRIPTION
### Proposed Changes

The properties panel represents an empty field value as `undefined` and relies on it to skip no-op commits: its entry guard compares the committed value against `getValue()`. Our custom-properties getter returned `''` for an empty value, so on save-on-blur the panel committed `undefined` while the getter reported `''`, defeating that guard and creating a redundant command.

Follow-up impact: Redundant commands are costly and re-trigger downstream behaviors, i.e. linting and a properties panel rebuild - only do if necessary.

`propertyGetter` now returns `undefined` for an empty value, conforming to the panel value contract so the panel's own no-op guard applies.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__: focus an empty required custom property field, blur it, then click a lint error for another entry — it now focuses on the first click