### PR TITLE
fix(properties-panel): remove stray template entry text

### DIFF
--- a/src/components/TemplateProps.js
+++ b/src/components/TemplateProps.js
@@ -44,7 +44,7 @@ export function TemplateProps({
       component: TemplateDescription,
       template
     }
-  ];
+  ].filter(Boolean);
 }
 
 function TemplateName({ id, template }) {


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Applied element templates added a falsy placeholder to the Template section entries. The properties panel rendered it as [object Object].

Filtered out falsy entries so only valid template properties are rendered.

#### This is now gone

<img width="455" height="329" alt="image" src="https://github.com/user-attachments/assets/5f328ae3-8acf-42d9-8364-f6043faac0cb" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
