### PR TITLE
feat: support zeebe:agentDefinition binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.32.0
+
+* `FEAT`: support `zeebe:agentDefinition` binding for `bpmn:ServiceTask` and `bpmn:AdHocSubProcess` element templates ([#286](https://github.com/bpmn-io/bpmn-js-element-templates/pull/286))
+* `DEPS`: update to `zeebe-bpmn-moddle@1.18.0`
+* `DEPS`: update to `@bpmn-io/element-templates-validator@2.26.0`
+
 ## 2.31.1
 
 * `FIX`: remove stray template entry text ([285](https://github.com/bpmn-io/bpmn-js-element-templates/pull/285))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.31.1",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/element-templates-validator": "^2.25.0",
+        "@bpmn-io/element-templates-validator": "^2.26.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
         "@bpmn-io/moddle-utils": "^0.3.0",
         "@bpmn-io/semver-compat": "^0.1.0",
@@ -73,7 +73,7 @@
         "sinon": "^22.1.0",
         "sinon-chai": "^4.0.0",
         "webpack": "^5.109.2",
-        "zeebe-bpmn-moddle": "^1.17.0"
+        "zeebe-bpmn-moddle": "^1.18.0"
       },
       "engines": {
         "node": "*"
@@ -478,14 +478,14 @@
       }
     },
     "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.25.0.tgz",
-      "integrity": "sha512-ESoxljIChKo4Nm5Ge+j66RBK30ei46EFjQ51EdXlAbyeWD8h7mK448ypH58TRT8CSvBBiOI/SCtpzFK46Mp+xQ==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.26.0.tgz",
+      "integrity": "sha512-ZHcEJtYX5GmaNHKXZqzJE96beN4d8xbCIsm+ynTLUZEg5Q4l8lpUOZmnwKF5npsdEg9L4hRuHMrgytU21zcXlQ==",
       "license": "MIT",
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.22.0",
+        "@camunda/element-templates-json-schema": "^0.22.1",
         "@camunda/zeebe-configuration-templates-json-schema": "^0.2.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.45.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.46.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       }
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.22.0.tgz",
-      "integrity": "sha512-fknIeRvnej9CpJvSHsQm9VhxcruxmdRI8IZGh2bth0qiZZLNAwQpSF139m1H//Fz/nmP/VpHwI0Tbhqh3JK9aA==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.22.1.tgz",
+      "integrity": "sha512-nDmSI66Lt/YjuW/myemLH1j2Fgw9ldD9eK6vmhTdMW7lgn0V+8AaVL5lJyQCEQa4lVgTIXrqttyCn/EGwHP8+Q==",
       "license": "MIT"
     },
     "node_modules/@camunda/feel-builtins": {
@@ -798,9 +798,9 @@
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.45.0.tgz",
-      "integrity": "sha512-cfh0PjqggGVbdlfg/qYi1NCL+rNnIe7UQA4Ku1MVFoCV1Bo/r6ijivRw1kx/2VJpMBfvvEOUnhuR/Azed3rdPg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.46.0.tgz",
+      "integrity": "sha512-BrgDPX3JLUIg4Xkbn7n+0pxvBGYKZ9T3+Z49fnTnlgQXS5Ep9WTupJsBXr6WSW8hGrwAyKzWuoTuBel/Ze4nGQ==",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
@@ -10599,11 +10599,14 @@
       }
     },
     "node_modules/zeebe-bpmn-moddle": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.17.0.tgz",
-      "integrity": "sha512-b+0AKsY90Kg+ewf8fiI9gGQkHhcs/4RTkVtVpKwZMaWvq3GoeBEP91GKxbeOxan7cKD9yQinKazPFb0BSE5lew==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.18.0.tgz",
+      "integrity": "sha512-tFlAzeADwrkszJzz17Izh12p/nzpufaNDRXVEoWns7XK8ZcA+C0WzC1+mpKFTlwg9r70BS5+At/wo0HFwd6kjg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "moddle": ">=8.2.0"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/element-templates-validator": "^2.25.0",
+    "@bpmn-io/element-templates-validator": "^2.26.0",
     "@bpmn-io/extract-process-variables": "^2.2.1",
     "@bpmn-io/moddle-utils": "^0.3.0",
     "@bpmn-io/semver-compat": "^0.1.0",
@@ -124,7 +124,7 @@
     "sinon": "^22.1.0",
     "sinon-chai": "^4.0.0",
     "webpack": "^5.109.2",
-    "zeebe-bpmn-moddle": "^1.17.0"
+    "zeebe-bpmn-moddle": "^1.18.0"
   },
   "peerDependencies": {
     "@bpmn-io/properties-panel": ">= 3.41.3",

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -49,6 +49,7 @@ import {
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
+  ZEEBE_AGENT_DEFINITION,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
   ZEEBE_TASK_LISTENER
@@ -170,6 +171,8 @@ export default class ChangeElementTemplateHandler {
     this._updateZeebeJobPriorityDefinition(element, oldTemplate, newTemplate);
 
     this._updateAdHoc(element, oldTemplate, newTemplate);
+
+    this._updateAgentDefinition(element, oldTemplate, newTemplate);
 
     this._updateZeebeTaskSchedule(element, oldTemplate, newTemplate);
 
@@ -1566,6 +1569,19 @@ export default class ChangeElementTemplateHandler {
     );
   }
 
+  _updateAgentDefinition(element, oldTemplate, newTemplate) {
+    this._updateSingleExtensionElement(
+      element,
+      oldTemplate,
+      newTemplate,
+      {
+        bindingTypes: [ ZEEBE_AGENT_DEFINITION ],
+        extensionType: 'zeebe:AgentDefinition',
+        getPropertyName: (binding) => binding.property
+      }
+    );
+  }
+
 
   _updateZeebeTaskSchedule(element, oldTemplate, newTemplate) {
     this._updateSingleExtensionElement(
@@ -2381,6 +2397,19 @@ export function findOldProperty(oldTemplate, newProperty) {
     });
   }
 
+  if (newBindingType === ZEEBE_AGENT_DEFINITION) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_AGENT_DEFINITION) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
+
   if (newBindingType === ZEEBE_TASK_SCHEDULE) {
     return oldProperties.find(oldProperty => {
       const oldBinding = oldProperty.binding,
@@ -2581,6 +2610,10 @@ function getPropertyValue(element, property) {
   }
 
   if (bindingType === ZEEBE_AD_HOC) {
+    return businessObject.get(bindingProperty);
+  }
+
+  if (bindingType === ZEEBE_AGENT_DEFINITION) {
     return businessObject.get(bindingProperty);
   }
 

--- a/src/cloud-element-templates/create/AgentDefinitionBindingProvider.js
+++ b/src/cloud-element-templates/create/AgentDefinitionBindingProvider.js
@@ -1,0 +1,22 @@
+import { ensureExtension } from '../CreateHelper';
+import { getDefaultValue } from '../Helper';
+
+/**
+ * Provider for the `zeebe:agentDefinition` binding. Ensures a single
+ * zeebe:AgentDefinition extension element exists and sets the configured
+ * property on it.
+ */
+export default class AgentDefinitionBindingProvider {
+  static create(element, options) {
+    const { property, bpmnFactory } = options;
+
+    const { binding } = property;
+    const { property: propertyName } = binding;
+
+    const value = getDefaultValue(property);
+
+    const agentDefinition = ensureExtension(element, 'zeebe:AgentDefinition', bpmnFactory);
+
+    agentDefinition.set(propertyName, value);
+  }
+}

--- a/src/cloud-element-templates/create/TemplateElementFactory.js
+++ b/src/cloud-element-templates/create/TemplateElementFactory.js
@@ -28,6 +28,7 @@ import ZeebeAssignmentDefinitionBindingProvider from './AssignmentDefinitionBind
 import ZeebePriorityDefinitionBindingProvider from './PriorityDefinitionBindingProvider';
 import ZeebeJobPriorityDefinitionBindingProvider from './JobPriorityDefinitionBindingProvider';
 import AdHocBindingProvider from './AdHocBindingProvider';
+import AgentDefinitionBindingProvider from './AgentDefinitionBindingProvider';
 import TaskScheduleBindingProvider from './TaskScheduleBindingProvider';
 import {
   ExecutionListenerBindingProvider,
@@ -58,6 +59,7 @@ import {
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
+  ZEEBE_AGENT_DEFINITION,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
   ZEEBE_TASK_LISTENER
@@ -101,6 +103,7 @@ export default class TemplateElementFactory {
       [ZEEBE_PRIORITY_DEFINITION]: ZeebePriorityDefinitionBindingProvider,
       [ZEEBE_JOB_PRIORITY_DEFINITION]: ZeebeJobPriorityDefinitionBindingProvider,
       [ZEEBE_AD_HOC]: AdHocBindingProvider,
+      [ZEEBE_AGENT_DEFINITION]: AgentDefinitionBindingProvider,
       [ZEEBE_TASK_SCHEDULE]: TaskScheduleBindingProvider,
       [ZEEBE_EXECUTION_LISTENER]: ExecutionListenerBindingProvider,
       [ZEEBE_TASK_LISTENER]: TaskListenerBindingProvider

--- a/src/cloud-element-templates/util/bindingPath.js
+++ b/src/cloud-element-templates/util/bindingPath.js
@@ -26,6 +26,7 @@ import {
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
+  ZEEBE_AGENT_DEFINITION,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
   ZEEBE_TASK_LISTENER
@@ -120,6 +121,9 @@ export function getBindingPath(element, binding) {
 
   case ZEEBE_AD_HOC:
     return getExtensionBindingPath(businessObject, 'zeebe:AdHoc', binding.property);
+
+  case ZEEBE_AGENT_DEFINITION:
+    return getExtensionBindingPath(businessObject, 'zeebe:AgentDefinition', binding.property);
 
   case ZEEBE_LINKED_RESOURCE_PROPERTY:
     return getLinkedResourceBindingPath(businessObject, binding);

--- a/src/cloud-element-templates/util/bindingTypes.js
+++ b/src/cloud-element-templates/util/bindingTypes.js
@@ -23,6 +23,7 @@ export const ZEEBE_ASSIGNMENT_DEFINITION = 'zeebe:assignmentDefinition';
 export const ZEEBE_PRIORITY_DEFINITION = 'zeebe:priorityDefinition';
 export const ZEEBE_JOB_PRIORITY_DEFINITION = 'zeebe:jobPriorityDefinition';
 export const ZEEBE_AD_HOC = 'zeebe:adHoc';
+export const ZEEBE_AGENT_DEFINITION = 'zeebe:agentDefinition';
 export const ZEEBE_TASK_SCHEDULE = 'zeebe:taskSchedule';
 export const ZEEBE_EXECUTION_LISTENER = 'zeebe:executionListener';
 export const ZEEBE_TASK_LISTENER = 'zeebe:taskListener';
@@ -44,6 +45,7 @@ export const EXTENSION_BINDING_TYPES = [
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
+  ZEEBE_AGENT_DEFINITION,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
   ZEEBE_TASK_LISTENER

--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -36,6 +36,7 @@ import {
   ZEEBE_PRIORITY_DEFINITION,
   ZEEBE_JOB_PRIORITY_DEFINITION,
   ZEEBE_AD_HOC,
+  ZEEBE_AGENT_DEFINITION,
   ZEEBE_TASK_SCHEDULE,
   ZEEBE_EXECUTION_LISTENER,
   ZEEBE_TASK_LISTENER
@@ -352,6 +353,11 @@ function getRawPropertyValue(element, property) {
   if (type === ZEEBE_AD_HOC) {
     const adHoc = findExtension(businessObject, 'zeebe:AdHoc');
     return adHoc ? adHoc.get(bindingProperty) : defaultValue;
+  }
+
+  if (type === ZEEBE_AGENT_DEFINITION) {
+    const agentDefinition = findExtension(businessObject, 'zeebe:AgentDefinition');
+    return agentDefinition ? agentDefinition.get(bindingProperty) : defaultValue;
   }
 
   // zeebe:executionListener
@@ -1153,6 +1159,38 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
           ...context,
           moddleElement: extensionElements,
           properties: { values: [ ...extensionElements.get('values'), adHoc ] }
+        }
+      });
+    }
+  }
+
+  // zeebe:agentDefinition
+  if (type === ZEEBE_AGENT_DEFINITION) {
+    let agentDefinition = findExtension(element, 'zeebe:AgentDefinition');
+    const propertyName = binding.property;
+
+    const properties = {
+      [ propertyName ]: value || ''
+    };
+
+    if (agentDefinition) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          properties,
+          moddleElement: agentDefinition
+        }
+      });
+    } else {
+      agentDefinition = createElement('zeebe:AgentDefinition', properties, extensionElements, bpmnFactory);
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          ...context,
+          moddleElement: extensionElements,
+          properties: { values: [ ...extensionElements.get('values'), agentDefinition ] }
         }
       });
     }

--- a/test/spec/cloud-element-templates/Validator.spec.js
+++ b/test/spec/cloud-element-templates/Validator.spec.js
@@ -538,6 +538,23 @@ describe('provider/cloud-element-templates - Validator', function() {
     });
 
 
+    it('should accept zeebe:agentDefinition binding', function() {
+
+      // given
+      const templates = new Validator(moddle);
+
+      const templateDescriptor = require('./fixtures/agent-definition');
+
+      // when
+      templates.addAll(templateDescriptor);
+
+      // then
+      expect(errors(templates)).to.be.empty;
+
+      expect(valid(templates)).to.have.length(templateDescriptor.length);
+    });
+
+
     it('should reject missing name', function() {
 
       // given

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -6285,6 +6285,203 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('update zeebe:agentDefinition', function() {
+
+      beforeEach(bootstrap(require('./agent-definition.bpmn').default));
+
+      const newTemplate = require('./agent-definition.json');
+
+
+      it('execute', inject(function(elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        // when
+        changeTemplate(serviceTask, newTemplate);
+
+        // then
+        serviceTask = elementRegistry.get('ServiceTask_1');
+        expectElementTemplate(serviceTask, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+        expect(agentDefinition).to.have.property('agentType', 'external');
+      }));
+
+
+      it('execute on ad-hoc sub-process', inject(function(elementRegistry) {
+
+        // given
+        let subProcess = elementRegistry.get('AdHocSubProcess_1');
+
+        // when
+        changeTemplate(subProcess, newTemplate);
+
+        // then
+        subProcess = elementRegistry.get('AdHocSubProcess_1');
+        expectElementTemplate(subProcess, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(subProcess, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+        expect(agentDefinition).to.have.property('agentType', 'external');
+      }));
+
+
+      it('undo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(serviceTask, newTemplate);
+
+        // when
+        commandStack.undo();
+
+        // then
+        serviceTask = elementRegistry.get('ServiceTask_1');
+        expectNoElementTemplate(serviceTask);
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(commandStack, elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(serviceTask, newTemplate);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        serviceTask = elementRegistry.get('ServiceTask_1');
+        expectElementTemplate(serviceTask, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+        expect(agentDefinition).to.have.property('agentType', 'external');
+      }));
+
+
+      it('should not override existing', inject(function(elementRegistry) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_existing');
+
+        // when
+        changeTemplate(serviceTask, newTemplate);
+
+        // then
+        expectElementTemplate(serviceTask, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+
+        // Should keep the old value, not override with newTemplate's value
+        expect(agentDefinition).to.have.property('agentType', 'aiAgentTask');
+      }));
+
+
+      it('should not override existing on ad-hoc sub-process', inject(function(elementRegistry) {
+
+        // given
+        const subProcess = elementRegistry.get('AdHocSubProcess_existing');
+
+        // when
+        changeTemplate(subProcess, newTemplate);
+
+        // then
+        expectElementTemplate(subProcess, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(subProcess, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+
+        // Should keep the old value, not override with newTemplate's value
+        expect(agentDefinition).to.have.property('agentType', 'aiAgentSubProcess');
+      }));
+
+
+      it('discards other bindings', inject(function(elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        const oldTemplate = createTemplate([
+          {
+            value: 'oldCollection',
+            binding: {
+              type: 'zeebe:adHoc',
+              property: 'outputCollection'
+            }
+          }
+        ]);
+
+        serviceTask = changeTemplate(serviceTask, oldTemplate);
+
+        // when
+        changeTemplate(serviceTask, newTemplate, oldTemplate);
+
+        // then
+        expectElementTemplate(serviceTask, 'com.camunda.example.AgentDefinition');
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+        expect(agentDefinition).to.exist;
+
+        const adHoc = findExtension(serviceTask, 'zeebe:AdHoc');
+        expect(adHoc).to.not.exist;
+      }));
+
+
+      it('should remove on template removal', inject(function(elementTemplates, elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(serviceTask, newTemplate);
+
+        // when
+        serviceTask = elementTemplates.removeTemplate(serviceTask);
+
+        // then
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.not.exist;
+      }));
+
+
+      it('should keep extension element on unlink', inject(function(elementTemplates, elementRegistry) {
+
+        // given
+        let serviceTask = elementRegistry.get('ServiceTask_1');
+
+        changeTemplate(serviceTask, newTemplate);
+
+        // when
+        serviceTask = elementTemplates.unlinkTemplate(serviceTask);
+
+        // then
+        expectNoElementTemplate(serviceTask);
+
+        const agentDefinition = findExtension(serviceTask, 'zeebe:AgentDefinition');
+
+        expect(agentDefinition).to.exist;
+        expect(agentDefinition).to.have.property('agentType', 'external');
+      }));
+
+    });
+
+
     describe('update zeebe:LinkedResource', function() {
 
       beforeEach(bootstrap(require('./linked-resource.bpmn').default));

--- a/test/spec/cloud-element-templates/cmd/agent-definition.bpmn
+++ b/test/spec/cloud-element-templates/cmd/agent-definition.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" />
+    <bpmn:serviceTask id="ServiceTask_existing">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentTask" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess_existing">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentSubProcess" />
+      </bpmn:extensionElements>
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="100" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_existing_di" bpmnElement="ServiceTask_existing">
+        <dc:Bounds x="250" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcess_1_di" bpmnElement="AdHocSubProcess_1">
+        <dc:Bounds x="400" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcess_existing_di" bpmnElement="AdHocSubProcess_existing">
+        <dc:Bounds x="650" y="100" width="200" height="100" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/cmd/agent-definition.json
+++ b/test/spec/cloud-element-templates/cmd/agent-definition.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "AgentDefinition",
+  "id": "com.camunda.example.AgentDefinition",
+  "appliesTo": [
+    "bpmn:ServiceTask",
+    "bpmn:AdHocSubProcess"
+  ],
+  "properties": [
+    {
+      "type": "Dropdown",
+      "value": "external",
+      "choices": [
+        { "name": "AI Agent Task", "value": "aiAgentTask" },
+        { "name": "AI Agent Sub Process", "value": "aiAgentSubProcess" },
+        { "name": "External Agent", "value": "external" }
+      ],
+      "binding": {
+        "type": "zeebe:agentDefinition",
+        "property": "agentType"
+      }
+    }
+  ]
+}

--- a/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
+++ b/test/spec/cloud-element-templates/create/TemplateElementFactory.spec.js
@@ -890,6 +890,26 @@ describe('provider/cloud-element-templates - TemplateElementFactory', function()
     }));
 
 
+    it('should handle <zeebe:agentDefinition>', inject(function(templateElementFactory) {
+
+      // given
+      const elementTemplate = findTemplate('agent-definition-template');
+
+      // when
+      const element = templateElementFactory.create(elementTemplate);
+
+      // then
+      const bo = getBusinessObject(element);
+      const agentDefinition = findExtension(bo, 'zeebe:AgentDefinition');
+
+      expect(agentDefinition).to.exist;
+      expect(agentDefinition).to.jsonEqual({
+        $type: 'zeebe:AgentDefinition',
+        agentType: 'external',
+      });
+    }));
+
+
     it('should handle <zeebe:taskSchedule>', inject(function(templateElementFactory) {
 
       // given

--- a/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
+++ b/test/spec/cloud-element-templates/create/TemplatesElementFactory.json
@@ -819,6 +819,26 @@
   },
   {
     "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Agent Definition Template",
+    "id": "agent-definition-template",
+    "appliesTo": [
+      "bpmn:ServiceTask",
+      "bpmn:AdHocSubProcess"
+    ],
+    "version": 1,
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "external",
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
     "name": "TaskSchedule",
     "id": "com.camunda.example.TaskSchedule",
     "appliesTo": [

--- a/test/spec/cloud-element-templates/fixtures/agent-definition.json
+++ b/test/spec/cloud-element-templates/fixtures/agent-definition.json
@@ -1,0 +1,23 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AgentDefinition",
+    "id": "com.camunda.example.AgentDefinition",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aiAgentTask",
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/fixtures/ai-agent-sub-process.json
+++ b/test/spec/cloud-element-templates/fixtures/ai-agent-sub-process.json
@@ -1,0 +1,61 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AI Agent Sub Process",
+    "id": "io.camunda.example.AgentSubProcess",
+    "description": "Marks an ad-hoc sub-process as an AI Agent Sub Process.",
+    "appliesTo": [
+      "bpmn:AdHocSubProcess"
+    ],
+    "elementType": {
+      "value": "bpmn:AdHocSubProcess"
+    },
+    "properties": [
+      {
+        "id": "widgetType",
+        "label": "Widget Type",
+        "description": "Demo toggle: switch the Agent Type property below between Hidden and Dropdown.",
+        "type": "Dropdown",
+        "value": "dropdown",
+        "choices": [
+          { "name": "Hidden", "value": "hidden" },
+          { "name": "Dropdown", "value": "dropdown" }
+        ],
+        "binding": {
+          "type": "zeebe:property",
+          "name": "agentTypeWidget"
+        }
+      },
+      {
+        "label": "Agent Type",
+        "type": "Hidden",
+        "value": "aiAgentSubProcess",
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        },
+        "condition": {
+          "property": "widgetType",
+          "equals": "hidden"
+        }
+      },
+      {
+        "label": "Agent Type",
+        "type": "Dropdown",
+        "value": "aiAgentSubProcess",
+        "choices": [
+          { "name": "AI Agent Sub Process", "value": "aiAgentSubProcess" },
+          { "name": "External Agent", "value": "external" }
+        ],
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        },
+        "condition": {
+          "property": "widgetType",
+          "equals": "dropdown"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/fixtures/ai-agent-task.json
+++ b/test/spec/cloud-element-templates/fixtures/ai-agent-task.json
@@ -1,0 +1,61 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AI Agent Task",
+    "id": "io.camunda.example.AgentTask",
+    "description": "Marks a service task as an AI Agent Task.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "id": "widgetType",
+        "label": "Widget Type",
+        "description": "Demo toggle: switch the Agent Type property below between Hidden and Dropdown.",
+        "type": "Dropdown",
+        "value": "dropdown",
+        "choices": [
+          { "name": "Hidden", "value": "hidden" },
+          { "name": "Dropdown", "value": "dropdown" }
+        ],
+        "binding": {
+          "type": "zeebe:property",
+          "name": "agentTypeWidget"
+        }
+      },
+      {
+        "label": "Agent Type",
+        "type": "Hidden",
+        "value": "aiAgentTask",
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        },
+        "condition": {
+          "property": "widgetType",
+          "equals": "hidden"
+        }
+      },
+      {
+        "label": "Agent Type",
+        "type": "Dropdown",
+        "value": "aiAgentTask",
+        "choices": [
+          { "name": "AI Agent Task", "value": "aiAgentTask" },
+          { "name": "External Agent", "value": "external" }
+        ],
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        },
+        "condition": {
+          "property": "widgetType",
+          "equals": "dropdown"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bpmn
@@ -151,6 +151,12 @@
         <zeebe:taskSchedule dueDate="=someDate" followUpDate="2023-02-05T12:00:00Z" />
       </bpmn:extensionElements>
     </bpmn:userTask>
+    <bpmn:serviceTask id="ServiceTask_agentDefinition" name="zeebe:agentDefinition" zeebe:modelerTemplate="com.camunda.example.AgentDefinition">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentTask" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_agentDefinition_empty" name="ServiceTask" />
   </bpmn:process>
   <bpmn:message id="Message" name="name">
     <bpmn:extensionElements>
@@ -303,6 +309,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_13u3ox2_di" bpmnElement="UserTask_schedule">
         <dc:Bounds x="290" y="1130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_agentDefinition_di" bpmnElement="ServiceTask_agentDefinition">
+        <dc:Bounds x="610" y="1030" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_agentDefinition_empty_di" bpmnElement="ServiceTask_agentDefinition_empty">
+        <dc:Bounds x="750" y="1030" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.json
@@ -1194,6 +1194,31 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "AgentDefinition",
+    "id": "com.camunda.example.AgentDefinition",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "elementType": {
+      "value": "bpmn:ServiceTask"
+    },
+    "properties": [
+      {
+        "type": "Dropdown",
+        "value": "aiAgentTask",
+        "choices": [
+          { "name": "AI Agent Task", "value": "aiAgentTask" },
+          { "name": "External Agent", "value": "external" }
+        ],
+        "binding": {
+          "type": "zeebe:agentDefinition",
+          "property": "agentType"
+        }
+      }
+    ]
   }
 
 ]

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -561,6 +561,89 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
   });
 
 
+  describe('zeebe:AgentDefinition', function() {
+
+    it('should display', async function() {
+
+      // when
+      await expectSelected('ServiceTask_agentDefinition');
+
+      // then
+      const entry = findEntry('custom-entry-com.camunda.example.AgentDefinition-0', container),
+            select = findSelect(entry);
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(select.value).to.equal('aiAgentTask');
+    });
+
+
+    it('should change, setting `agentType`', async function() {
+
+      // given
+      const element = await expectSelected('ServiceTask_agentDefinition'),
+            businessObject = getBusinessObject(element);
+
+      // when
+      const entry = findEntry('custom-entry-com.camunda.example.AgentDefinition-0', container),
+            select = findSelect(entry);
+
+      changeInput(select, 'external');
+
+      // then
+      const agentDefinition = findExtension(businessObject, 'zeebe:AgentDefinition');
+      expect(agentDefinition).to.exist;
+      expect(agentDefinition).to.have.property('agentType', 'external');
+    });
+
+
+    it('should change, creating zeebe:AgentDefinition if non-existing', inject(async function(elementTemplates, elementRegistry) {
+
+      // given
+      const element = await expectSelected('ServiceTask_agentDefinition_empty'),
+            businessObject = getBusinessObject(element);
+      const template = templates.find(t => t.id === 'com.camunda.example.AgentDefinition');
+      const serviceTask = elementRegistry.get('ServiceTask_agentDefinition_empty');
+
+      // when
+      await act(() => {
+        elementTemplates.applyTemplate(serviceTask, template);
+      });
+
+      const entry = findEntry('custom-entry-com.camunda.example.AgentDefinition-0', container),
+            select = findSelect(entry);
+
+      // then
+      const agentDefinition = findExtension(businessObject, 'zeebe:AgentDefinition');
+
+      expect(entry).to.exist;
+      expect(select).to.exist;
+      expect(select.value).to.equal('aiAgentTask');
+
+      expect(agentDefinition).to.exist;
+      expect(agentDefinition).to.have.property('agentType', 'aiAgentTask');
+    }));
+
+
+    it('should remove on template removal', inject(async function(elementTemplates) {
+
+      // given
+      let element = await expectSelected('ServiceTask_agentDefinition');
+
+      // when
+      await act(() => {
+        elementTemplates.removeTemplate(element);
+      });
+      element = await expectSelected('ServiceTask_agentDefinition');
+
+      // then
+      const agentDefinition = findExtension(getBusinessObject(element), 'zeebe:AgentDefinition');
+      expect(agentDefinition).to.not.exist;
+    }));
+
+  });
+
+
   describe('zeebe:taskDefinition', function() {
 
     it('should display', async function() {

--- a/test/spec/cloud-element-templates/util/bindingPath.spec.js
+++ b/test/spec/cloud-element-templates/util/bindingPath.spec.js
@@ -565,6 +565,30 @@ describe('cloud-element-templates/util - bindingPath', function() {
     });
 
 
+    describe('zeebe:agentDefinition', function() {
+
+      it('should resolve agentType', function() {
+
+        // given
+        const agentDefinition = create('zeebe:AgentDefinition', { agentType: 'aiAgentSubProcess' });
+
+        const adHocSubProcess = create('bpmn:AdHocSubProcess', {
+          id: 'AdHocSubProcess_1',
+          extensionElements: withExtensionElements([ agentDefinition ])
+        });
+
+        const binding = { type: 'zeebe:agentDefinition', property: 'agentType' };
+
+        // when
+        const path = getBindingPath(adHocSubProcess, binding);
+
+        // then
+        expect(path).to.eql([ 'extensionElements', 'values', 0, 'agentType' ]);
+      });
+
+    });
+
+
     describe('zeebe:jobPriorityDefinition', function() {
 
       it('should resolve priority', function() {


### PR DESCRIPTION
### Proposed Changes



https://github.com/user-attachments/assets/1a1c9c54-036f-4de5-9641-50204c187439



Adds properties-panel/element-templates application logic for the new `zeebe:agentDefinition` binding (mirrors `zeebe:adHoc` — single extension element, restricted element type, no `bindingType` sibling):

* `zeebe:AgentDefinition` extension element created/updated/removed via `AgentDefinitionBindingProvider`, `ChangeElementTemplateHandler`, `propertyUtil`, `bindingPath`
* Unlink preserves the extension, template removal strips it
* Two new `npm start` (cloud-templates) playground templates, "AI Agent Task" / "AI Agent Sub Process", each demoing a `condition`-driven toggle between a `Hidden` and `Dropdown` widget for `agentType`
* Bumps `zeebe-bpmn-moddle` to `^1.18.0` and `@bpmn-io/element-templates-validator` to `^2.26.0`, both now published with `zeebe:agentDefinition` support

Related to https://github.com/camunda/camunda-modeler/issues/6094

### Steps to try out

```
npm start
```

Apply the "AI Agent Task" template to a Service Task, or "AI Agent Sub Process" to an Ad-Hoc Sub-Process, via the element template chooser. Toggle "Widget Type" between `Hidden` and `Dropdown` to see the `agentType` entry switch widgets.

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)