### PR TITLE
feat(configuration-chooser): unify state representation on panel infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: surface configuration state via standard warnings / descriptions ([#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
+* `FEAT`: align menu select/hover states to muted gray ([#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
+* `FEAT`: drop configuration card loading state ([#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
+* `FEAT`: unify configuration cluster unavailable messages ([#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
+* `FEAT`: show the identity logo instead of a warning glyph on configuration cards ([#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
 * `DEPS`: update to `@bpmn-io/properties-panel@3.51.1`
 
 ## 2.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `DEPS`: update to `@bpmn-io/properties-panel@3.51.1`
+
 ## 2.32.0
 
 * `FEAT`: support `zeebe:agentDefinition` binding for `bpmn:ServiceTask` and `bpmn:AdHocSubProcess` element templates ([#286](https://github.com/bpmn-io/bpmn-js-element-templates/pull/286))

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -132,17 +132,31 @@
   gap: 10px;
   margin-top: 4px;
   padding: 10px 12px;
-  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border: 1px solid var(--input-border-color);
   border-radius: 4px;
-  background-color: var(--color-white, #fff);
+  background-color: var(--group-background-color);
   cursor: default;
   outline: none;
 }
 
-/* constraint violation, cf. .bio-properties-panel-entry.has-error */
+/* severity mirrors the standard entry states; .has-warning first so error wins
+   when both are set (matching @bpmn-io/properties-panel) */
+.bio-properties-panel-configuration-chooser.has-warning .bio-properties-panel-configuration-chooser-card {
+  border-color: var(--input-warning-border-color);
+  background-color: var(--input-warning-background-color);
+}
+
 .bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-card {
   border-color: var(--input-error-border-color);
   background-color: var(--input-error-background-color);
+}
+
+/* focus adds the standard input focus treatment; placed after hover so it wins
+   when a card is both hovered and focused */
+.bio-properties-panel-configuration-chooser-card--selected:focus-within,
+.bio-properties-panel-configuration-chooser-card--missing:focus-within {
+  border-color: var(--input-focus-border-color);
+  background-color: var(--input-focus-background-color);
 }
 
 /* placeholder trigger (no selection): a dashed action button */
@@ -151,7 +165,7 @@
   gap: 6px;
   width: 100%;
   border-style: dashed;
-  color: var(--color-grey-225-10-35, #4d5258);
+  color: var(--description-color);
   font-size: 13px;
   cursor: pointer;
 }
@@ -166,14 +180,9 @@
   opacity: 0.5;
 }
 
-.bio-properties-panel-configuration-chooser-unavailable {
-  margin-top: 4px;
-  color: var(--color-grey-225-10-55, #7d8186);
-  font-size: 12px;
-}
-
-.bio-properties-panel-configuration-chooser-unavailable--error {
-  color: #a66b00;
+/* control wrapper: anchors the popover / actions menu directly below the card */
+.bio-properties-panel-configuration-chooser-control {
+  position: relative;
 }
 
 .bio-properties-panel-configuration-chooser-create-icon {
@@ -227,27 +236,7 @@
   border-bottom: 1px solid var(--color-grey-225-10-85, #e5e6e7);
 }
 
-/* missing configuration state */
-.bio-properties-panel-configuration-chooser-card--missing {
-  border-color: #f0ad4e;
-  background-color: #fff8ed;
-}
-
-.bio-properties-panel-configuration-chooser-card--missing:hover {
-  border-color: #e09730;
-  background-color: #fef3e0;
-}
-
-.bio-properties-panel-configuration-chooser-card--error {
-  cursor: default;
-}
-
-.bio-properties-panel-configuration-chooser-card--missing .bio-properties-panel-configuration-chooser-subtitle {
-  overflow: visible;
-  overflow-wrap: anywhere;
-  text-overflow: clip;
-  white-space: normal;
-}
+/* missing configuration state carries the standard warning severity */
 
 /* logo */
 .bio-properties-panel-configuration-chooser-logo {
@@ -263,13 +252,13 @@
   align-items: center;
   justify-content: center;
   background-color: var(--color-grey-225-10-90, #e6e8ea);
-  color: var(--color-grey-225-10-35, #4d5258);
+  color: var(--description-color);
   font-weight: 600;
 }
 
 .bio-properties-panel-configuration-chooser-logo--warning {
   background-color: #fce4bc;
-  color: #a66b00;
+  color: var(--text-warning-color);
 }
 
 /* text block */
@@ -305,7 +294,7 @@
   padding: 0 6px;
   border: none;
   background: none;
-  color: var(--color-grey-225-10-35, #4d5258);
+  color: var(--description-color);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
@@ -325,12 +314,13 @@
 .bio-properties-panel-configuration-chooser-popover {
   position: absolute;
   z-index: 100;
+  top: 100%;
   left: 0;
   right: 0;
   margin-top: 4px;
-  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border: 1px solid var(--input-border-color);
   border-radius: 4px;
-  background-color: var(--color-white, #fff);
+  background-color: var(--group-background-color);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   overflow: hidden;
 }
@@ -372,7 +362,7 @@
   border: none;
   border-top: 1px solid var(--color-grey-225-10-90, #e6e8ea);
   background: none;
-  color: var(--color-blue-205-100-50, #1a75ff);
+  color: var(--link-color);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -399,12 +389,13 @@
 .bio-properties-panel-configuration-chooser-context-menu {
   position: absolute;
   z-index: 11;
+  top: 100%;
   right: 0;
   margin-top: 4px;
   min-width: 150px;
-  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border: 1px solid var(--input-border-color);
   border-radius: 4px;
-  background-color: var(--color-white, #fff);
+  background-color: var(--group-background-color);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   overflow: hidden;
 }
@@ -415,7 +406,7 @@
   padding: 8px 12px;
   border: none;
   background: none;
-  color: var(--color-grey-225-10-15, #1a1d20);
+  color: var(--text-base-color);
   font-size: 13px;
   text-align: left;
   cursor: pointer;

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -135,8 +135,8 @@
 }
 
 /* one card box shared across every state via .…-chooser-card; state modifiers
-   (--placeholder / --selected / --missing / --loading / --offline / --error)
-   carry only their deltas */
+   (--placeholder / --selected / --missing / --offline / --error) carry only
+   their deltas. Mirrors the .bio-properties-panel-entry + .has-error convention. */
 .bio-properties-panel-configuration-chooser-card {
   display: flex;
   align-items: center;
@@ -177,7 +177,7 @@
   background-color: var(--input-focus-background-color);
 }
 
-/* placeholder trigger (no selection): a dashed action button */
+/* placeholder (no selection): a dashed action button */
 .bio-properties-panel-configuration-chooser-card--placeholder {
   justify-content: center;
   gap: 6px;
@@ -224,19 +224,12 @@
   cursor: default;
 }
 
-/* loading state */
-.bio-properties-panel-configuration-chooser-card--loading {
-  background-color: var(--color-grey-225-10-97, #f7f8f8);
-}
-
 .bio-properties-panel-configuration-chooser-refreshing {
   display: flex;
   align-items: center;
   padding: 8px 12px;
   border-bottom: 1px solid var(--configuration-chooser-separator-color);
 }
-
-/* missing configuration state carries the standard warning severity */
 
 /* logo */
 .bio-properties-panel-configuration-chooser-logo {

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -151,6 +151,13 @@
   background-color: var(--input-error-background-color);
 }
 
+/* interactive cards get the standard panel-button hover; loading opts out */
+.bio-properties-panel-configuration-chooser-card--placeholder:hover:not(:disabled),
+.bio-properties-panel-configuration-chooser-card--selected:hover,
+.bio-properties-panel-configuration-chooser-card--missing:hover {
+  background-color: var(--arrow-hover-background-color);
+}
+
 /* focus adds the standard input focus treatment; placed after hover so it wins
    when a card is both hovered and focused */
 .bio-properties-panel-configuration-chooser-card--selected:focus-within,
@@ -168,11 +175,6 @@
   color: var(--description-color);
   font-size: 13px;
   cursor: pointer;
-}
-
-.bio-properties-panel-configuration-chooser-card--placeholder:hover:not(:disabled) {
-  border-color: var(--color-grey-225-10-55, #7d8186);
-  background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
 .bio-properties-panel-configuration-chooser-card--placeholder:disabled {
@@ -209,19 +211,6 @@
 
 .bio-properties-panel-configuration-chooser-trigger:disabled {
   cursor: default;
-}
-
-/* selected configuration card */
-.bio-properties-panel-configuration-chooser-card--selected:hover {
-  border-color: var(--color-blue-205-100-50, #1a75ff);
-  background-color: var(--color-blue-205-100-95, #eef4ff);
-}
-
-.bio-properties-panel-configuration-chooser-card--offline,
-.bio-properties-panel-configuration-chooser-card--offline:hover {
-  cursor: default;
-  border-color: var(--color-grey-225-10-75, #ccced0);
-  background-color: var(--color-white, #fff);
 }
 
 /* loading state */
@@ -345,11 +334,7 @@
 
 .bio-properties-panel-configuration-chooser-popover-row:hover,
 .bio-properties-panel-configuration-chooser-popover-row--active {
-  background-color: var(--color-blue-205-100-95, #eef4ff);
-}
-
-.bio-properties-panel-configuration-chooser-popover-row--selected {
-  background-color: var(--color-blue-205-100-95, #eef4ff);
+  background-color: var(--input-background-color);
 }
 
 /* create configuration footer */
@@ -372,7 +357,7 @@
 .bio-properties-panel-configuration-chooser-create:hover,
 .bio-properties-panel-configuration-chooser-create--active,
 .bio-properties-panel-configuration-chooser-create:focus-visible {
-  background-color: var(--color-blue-205-100-95, #eef4ff);
+  background-color: var(--input-background-color);
 }
 
 .bio-properties-panel-configuration-chooser-empty {
@@ -415,6 +400,6 @@
 
 .bio-properties-panel-configuration-chooser-context-menu-item:hover,
 .bio-properties-panel-configuration-chooser-context-menu-item:focus-visible {
-  background-color: var(--color-grey-225-10-97, #f7f8f8);
+  background-color: var(--input-background-color);
 }
 

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -128,7 +128,6 @@
   --configuration-chooser-option-hover-background-color: var(--input-background-color);
   --configuration-chooser-menu-button-hover-background-color: var(--color-grey-225-10-90);
   --configuration-chooser-logo-background-color: var(--color-grey-225-10-90);
-  --configuration-chooser-logo-warning-background-color: var(--dot-color-warning);
   --configuration-chooser-subtitle-color: var(--color-grey-225-10-55);
   --configuration-chooser-status-color: var(--color-grey-225-10-45);
   --configuration-chooser-separator-color: var(--color-grey-225-10-85);
@@ -247,11 +246,6 @@
   background-color: var(--configuration-chooser-logo-background-color);
   color: var(--description-color);
   font-weight: 600;
-}
-
-.bio-properties-panel-configuration-chooser-logo--warning {
-  background-color: var(--configuration-chooser-logo-warning-background-color);
-  color: var(--text-warning-color);
 }
 
 /* text block */

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -123,39 +123,45 @@
   padding-bottom: 10px;
 }
 
+/* one card box shared across every state via .…-chooser-card; state modifiers
+   (--placeholder / --selected / --missing / --loading / --offline / --error)
+   carry only their deltas */
+.bio-properties-panel-configuration-chooser-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-grey-225-10-75, #ccced0);
+  border-radius: 4px;
+  background-color: var(--color-white, #fff);
+  cursor: default;
+  outline: none;
+}
+
 /* constraint violation, cf. .bio-properties-panel-entry.has-error */
-.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-placeholder,
-.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-selected,
-.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-loading,
-.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-missing {
+.bio-properties-panel-configuration-chooser.has-error .bio-properties-panel-configuration-chooser-card {
   border-color: var(--input-error-border-color);
   background-color: var(--input-error-background-color);
 }
 
-/* placeholder trigger (no selection) */
-.bio-properties-panel-configuration-chooser-placeholder {
-  display: flex;
-  align-items: center;
+/* placeholder trigger (no selection): a dashed action button */
+.bio-properties-panel-configuration-chooser-card--placeholder {
   justify-content: center;
   gap: 6px;
   width: 100%;
-  margin-top: 4px;
-  padding: 10px 12px;
-  border: 1px dashed var(--color-grey-225-10-75, #ccced0);
-  border-radius: 4px;
-  background-color: var(--color-white, #fff);
+  border-style: dashed;
   color: var(--color-grey-225-10-35, #4d5258);
   font-size: 13px;
   cursor: pointer;
-  outline: none;
 }
 
-.bio-properties-panel-configuration-chooser-placeholder:hover:not(:disabled) {
+.bio-properties-panel-configuration-chooser-card--placeholder:hover:not(:disabled) {
   border-color: var(--color-grey-225-10-55, #7d8186);
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
-.bio-properties-panel-configuration-chooser-placeholder:disabled {
+.bio-properties-panel-configuration-chooser-card--placeholder:disabled {
   cursor: default;
   opacity: 0.5;
 }
@@ -174,20 +180,6 @@
   width: 16px;
   height: 16px;
   fill: currentColor;
-}
-
-/* selected configuration card */
-.bio-properties-panel-configuration-chooser-selected {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 4px;
-  padding: 10px 12px;
-  border: 1px solid var(--color-grey-225-10-75, #ccced0);
-  border-radius: 4px;
-  background-color: var(--color-white, #fff);
-  cursor: default;
-  outline: none;
 }
 
 .bio-properties-panel-configuration-chooser-trigger {
@@ -210,27 +202,21 @@
   cursor: default;
 }
 
-.bio-properties-panel-configuration-chooser-selected:hover {
+/* selected configuration card */
+.bio-properties-panel-configuration-chooser-card--selected:hover {
   border-color: var(--color-blue-205-100-50, #1a75ff);
   background-color: var(--color-blue-205-100-95, #eef4ff);
 }
 
-.bio-properties-panel-configuration-chooser-selected--offline,
-.bio-properties-panel-configuration-chooser-selected--offline:hover {
+.bio-properties-panel-configuration-chooser-card--offline,
+.bio-properties-panel-configuration-chooser-card--offline:hover {
   cursor: default;
   border-color: var(--color-grey-225-10-75, #ccced0);
   background-color: var(--color-white, #fff);
 }
 
 /* loading state */
-.bio-properties-panel-configuration-chooser-loading {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 4px;
-  padding: 10px 12px;
-  border: 1px solid var(--color-grey-225-10-75, #ccced0);
-  border-radius: 4px;
+.bio-properties-panel-configuration-chooser-card--loading {
   background-color: var(--color-grey-225-10-97, #f7f8f8);
 }
 
@@ -242,29 +228,21 @@
 }
 
 /* missing configuration state */
-.bio-properties-panel-configuration-chooser-missing {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 4px;
-  padding: 10px 12px;
-  border: 1px solid #f0ad4e;
-  border-radius: 4px;
+.bio-properties-panel-configuration-chooser-card--missing {
+  border-color: #f0ad4e;
   background-color: #fff8ed;
-  cursor: default;
-  outline: none;
 }
 
-.bio-properties-panel-configuration-chooser-missing:hover {
+.bio-properties-panel-configuration-chooser-card--missing:hover {
   border-color: #e09730;
   background-color: #fef3e0;
 }
 
-.bio-properties-panel-configuration-chooser-error {
+.bio-properties-panel-configuration-chooser-card--error {
   cursor: default;
 }
 
-.bio-properties-panel-configuration-chooser-missing .bio-properties-panel-configuration-chooser-subtitle {
+.bio-properties-panel-configuration-chooser-card--missing .bio-properties-panel-configuration-chooser-subtitle {
   overflow: visible;
   overflow-wrap: anywhere;
   text-overflow: clip;

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -116,11 +116,22 @@
   width: 216px;
 }
 
-/* configuration chooser */
+/* configuration chooser; spacing comes from the standard .bio-properties-panel-entry.
+   Component-scoped semantic tokens give themers one seam to re-skin the chooser.
+   They exist only for roles without a semantically fitting properties-panel token
+   (a mismatch, e.g. the collapse-arrow or input-fill token borrowed for a value);
+   where a panel token already matches the meaning it is used directly. */
 .bio-properties-panel-configuration-chooser {
   position: relative;
-  margin: 2px 32px 6px 12px;
-  padding-bottom: 10px;
+
+  --configuration-chooser-card-hover-background-color: var(--arrow-hover-background-color);
+  --configuration-chooser-option-hover-background-color: var(--input-background-color);
+  --configuration-chooser-menu-button-hover-background-color: var(--color-grey-225-10-90);
+  --configuration-chooser-logo-background-color: var(--color-grey-225-10-90);
+  --configuration-chooser-logo-warning-background-color: var(--dot-color-warning);
+  --configuration-chooser-subtitle-color: var(--color-grey-225-10-55);
+  --configuration-chooser-status-color: var(--color-grey-225-10-45);
+  --configuration-chooser-separator-color: var(--color-grey-225-10-85);
 }
 
 /* one card box shared across every state via .…-chooser-card; state modifiers
@@ -155,7 +166,7 @@
 .bio-properties-panel-configuration-chooser-card--placeholder:hover:not(:disabled),
 .bio-properties-panel-configuration-chooser-card--selected:hover,
 .bio-properties-panel-configuration-chooser-card--missing:hover {
-  background-color: var(--arrow-hover-background-color);
+  background-color: var(--configuration-chooser-card-hover-background-color);
 }
 
 /* focus adds the standard input focus treatment; placed after hover so it wins
@@ -222,7 +233,7 @@
   display: flex;
   align-items: center;
   padding: 8px 12px;
-  border-bottom: 1px solid var(--color-grey-225-10-85, #e5e6e7);
+  border-bottom: 1px solid var(--configuration-chooser-separator-color);
 }
 
 /* missing configuration state carries the standard warning severity */
@@ -240,13 +251,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--color-grey-225-10-90, #e6e8ea);
+  background-color: var(--configuration-chooser-logo-background-color);
   color: var(--description-color);
   font-weight: 600;
 }
 
 .bio-properties-panel-configuration-chooser-logo--warning {
-  background-color: #fce4bc;
+  background-color: var(--configuration-chooser-logo-warning-background-color);
   color: var(--text-warning-color);
 }
 
@@ -267,7 +278,7 @@
 
 .bio-properties-panel-configuration-chooser-subtitle {
   font-size: 12px;
-  color: var(--color-grey-225-10-55, #7d8186);
+  color: var(--configuration-chooser-subtitle-color);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -291,7 +302,7 @@
 }
 
 .bio-properties-panel-configuration-chooser-menu:hover:not(:disabled) {
-  background-color: var(--color-grey-225-10-90, #e6e8ea);
+  background-color: var(--configuration-chooser-menu-button-hover-background-color);
 }
 
 .bio-properties-panel-configuration-chooser-menu:disabled {
@@ -334,7 +345,7 @@
 
 .bio-properties-panel-configuration-chooser-popover-row:hover,
 .bio-properties-panel-configuration-chooser-popover-row--active {
-  background-color: var(--input-background-color);
+  background-color: var(--configuration-chooser-option-hover-background-color);
 }
 
 /* create configuration footer */
@@ -345,7 +356,7 @@
   width: 100%;
   padding: 10px 12px;
   border: none;
-  border-top: 1px solid var(--color-grey-225-10-90, #e6e8ea);
+  border-top: 1px solid var(--configuration-chooser-separator-color);
   background: none;
   color: var(--link-color);
   font-size: 13px;
@@ -357,7 +368,7 @@
 .bio-properties-panel-configuration-chooser-create:hover,
 .bio-properties-panel-configuration-chooser-create--active,
 .bio-properties-panel-configuration-chooser-create:focus-visible {
-  background-color: var(--input-background-color);
+  background-color: var(--configuration-chooser-option-hover-background-color);
 }
 
 .bio-properties-panel-configuration-chooser-empty {
@@ -366,7 +377,7 @@
 
 .bio-properties-panel-configuration-chooser-refreshing,
 .bio-properties-panel-configuration-chooser-empty {
-  color: var(--color-grey-225-10-45, #70757a);
+  color: var(--configuration-chooser-status-color);
   font-size: 13px;
 }
 
@@ -400,6 +411,6 @@
 
 .bio-properties-panel-configuration-chooser-context-menu-item:hover,
 .bio-properties-panel-configuration-chooser-context-menu-item:focus-visible {
-  background-color: var(--input-background-color);
+  background-color: var(--configuration-chooser-option-hover-background-color);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@babel/plugin-transform-react-jsx": "^7.29.7",
         "@bpmn-io/element-template-chooser": "^3.0.0",
         "@bpmn-io/element-template-icon-renderer": "^1.0.0",
-        "@bpmn-io/properties-panel": "^3.49.0",
+        "@bpmn-io/properties-panel": "^3.51.1",
         "@camunda/linting": "^3.54.0",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-babel": "^7.1.0",
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.49.0.tgz",
-      "integrity": "sha512-KXA4D/rLsaXqPGC0IMBWPpc+8Yv+PYVhwkwkUB5VKIojf62egKNKXEFnnh850AT9aaIL5eq3ZqTYKOzocEQ9bA==",
+      "version": "3.51.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.51.1.tgz",
+      "integrity": "sha512-8hVIiF1GxB+YwvY0205kWqxhg+VRa7PMWsN9fEK+3BjSKU12KluoTTY59f2XqPyj/2sM6xmQhkYBxzKM3cZugg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:build": "mocha --reporter=spec --recursive test/distro/*.spec.js",
     "start": "cross-env SINGLE_START=cloud-templates npm run dev",
     "start:templates": "cross-env SINGLE_START=templates npm run dev",
+    "start:chooser": "cross-env SINGLE_START=chooser npm run dev",
     "prepare": "run-s bundle"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@babel/plugin-transform-react-jsx": "^7.29.7",
     "@bpmn-io/element-template-chooser": "^3.0.0",
     "@bpmn-io/element-template-icon-renderer": "^1.0.0",
-    "@bpmn-io/properties-panel": "^3.49.0",
+    "@bpmn-io/properties-panel": "^3.51.1",
     "@camunda/linting": "^3.54.0",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-babel": "^7.1.0",

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -65,6 +65,86 @@ function getConfigurationVariant(state) {
 }
 
 /**
+ * Build the status note shown below the identity-only card, or `null` when there
+ * is nothing to report. `note` reuses the neutral description styling, `warning`
+ * the standard warning field.
+ *
+ * @param {Object} options
+ * @returns {{ id: string, severity: string, message: string }|null}
+ */
+function getConfigurationStatus(options) {
+  const {
+    variant,
+    error,
+    available,
+    incompatible,
+    typeIncompatible,
+    instanceVersion,
+    minimumVersion,
+    hasCachedName,
+    unavailableMessage,
+    translate,
+    id
+  } = options;
+
+  const statusId = `${ id }-status`;
+
+  if (variant === VARIANT.ERROR || (variant === VARIANT.PLACEHOLDER && error)) {
+    return {
+      id: statusId,
+      severity: 'warning',
+      message: translate('Could not load configurations')
+    };
+  }
+
+  if (variant === VARIANT.MISSING) {
+    if (incompatible) {
+      return {
+        id: statusId,
+        severity: 'warning',
+        message: typeIncompatible
+          ? translate('Incompatible configuration type')
+          : translate('Version {version} · Requires version {minimumVersion}+', {
+            version: instanceVersion == null ? '?' : instanceVersion,
+            minimumVersion
+          })
+      };
+    }
+
+    return {
+      id: statusId,
+      severity: 'warning',
+      message: hasCachedName
+        ? translate('Not found on cluster')
+        : translate('Configuration not found')
+    };
+  }
+
+  if (variant === VARIANT.OFFLINE) {
+    return {
+      id: statusId,
+      severity: 'note',
+      message: unavailableMessage || translate('Cluster unavailable')
+    };
+  }
+
+  if (variant === VARIANT.PLACEHOLDER && !available) {
+    return {
+      id: statusId,
+      severity: 'note',
+      message: unavailableMessage || translate('Cluster unavailable')
+    };
+  }
+
+  return null;
+}
+
+const STATUS_CLASS = {
+  note: 'bio-properties-panel-description',
+  warning: 'bio-properties-panel-warning'
+};
+
+/**
  * FEEL expression referencing a configuration instance as a cluster variable.
  *
  * @param {string} name
@@ -455,6 +535,20 @@ export function ConfigurationProperty(props) {
 
   const variant = getConfigurationVariant({ value, error, selected, loading, available });
 
+  const status = getConfigurationStatus({
+    variant,
+    error,
+    available,
+    incompatible,
+    typeIncompatible,
+    instanceVersion: boundInstance?.metadata?.configurationTemplateVersion,
+    minimumVersion: configurationTemplateVersion,
+    hasCachedName: !!cachedName,
+    unavailableMessage,
+    translate,
+    id
+  });
+
   const renderConfiguration = () => {
     switch (variant) {
     case VARIANT.ERROR:
@@ -493,8 +587,6 @@ export function ConfigurationProperty(props) {
           cachedName={ cachedName }
           instance={ incompatible ? boundInstance : null }
           controlId={ controlId }
-          minimumVersion={ configurationTemplateVersion }
-          typeIncompatible={ typeIncompatible }
           disabled={ disabled }
           menuId={ menuId }
           menuOpen={ menuOpen }
@@ -509,7 +601,6 @@ export function ConfigurationProperty(props) {
         <OfflineConfiguration
           value={ value }
           cachedName={ cachedName }
-          unavailableMessage={ unavailableMessage }
           disabled={ disabled }
           menuId={ menuId }
           menuOpen={ menuOpen }
@@ -525,7 +616,6 @@ export function ConfigurationProperty(props) {
           disabled={ disabled }
           error={ error }
           available={ available }
-          unavailableMessage={ unavailableMessage }
           open={ popoverOpen }
           listboxId={ listboxId }
           chooserLabel={ chooserLabel }
@@ -542,6 +632,7 @@ export function ConfigurationProperty(props) {
       class={ classnames(
         'bio-properties-panel-entry',
         'bio-properties-panel-configuration-chooser',
+        status && status.severity === 'warning' ? 'has-warning' : '',
         validationError ? 'has-error' : ''
       ) }
       data-entry-id={ id }
@@ -553,18 +644,58 @@ export function ConfigurationProperty(props) {
       </label>
 
       {
-        description
-          ? <PropertyDescription description={ description } />
-          : null
-      }
-
-      {
         tooltip
           ? <PropertyTooltip tooltip={ tooltip } />
           : null
       }
 
-      { renderConfiguration() }
+      <div class="bio-properties-panel-configuration-chooser-control">
+        { renderConfiguration() }
+
+        {
+          popoverOpen
+            ? (
+              <ConfigurationPopover
+                listboxId={ listboxId }
+                instances={ instances }
+                selected={ selected }
+                canCreate={ canCreate }
+                onCreate={ createConfiguration }
+                onSelect={ select }
+                onClose={ closePopover }
+                onDismiss={ dismissPopover }
+                loading={ loading }
+                translate={ translate } />
+            )
+            : null
+        }
+
+        {
+          menuOpen
+            ? (
+              <ConfigurationContextMenu
+                menuId={ menuId }
+                initialFocus={ menuInitialFocus }
+                onEdit={ selected && canUpdate ? editConfiguration : null }
+                onUpgrade={ versionIncompatible && canUpdate ? upgradeConfiguration : null }
+                onRemove={ () => select(null) }
+                onClose={ closeMenu }
+                onDismiss={ dismissMenu }
+                translate={ translate } />
+            )
+            : null
+        }
+      </div>
+
+      {
+        status
+          ? (
+            <div id={ status.id } class={ STATUS_CLASS[ status.severity ] }>
+              { status.message }
+            </div>
+          )
+          : null
+      }
 
       {
         validationError
@@ -577,35 +708,11 @@ export function ConfigurationProperty(props) {
       }
 
       {
-        popoverOpen
+        description
           ? (
-            <ConfigurationPopover
-              listboxId={ listboxId }
-              instances={ instances }
-              selected={ selected }
-              canCreate={ canCreate }
-              onCreate={ createConfiguration }
-              onSelect={ select }
-              onClose={ closePopover }
-              onDismiss={ dismissPopover }
-              loading={ loading }
-              translate={ translate } />
-          )
-          : null
-      }
-
-      {
-        menuOpen
-          ? (
-            <ConfigurationContextMenu
-              menuId={ menuId }
-              initialFocus={ menuInitialFocus }
-              onEdit={ selected && canUpdate ? editConfiguration : null }
-              onUpgrade={ versionIncompatible && canUpdate ? upgradeConfiguration : null }
-              onRemove={ () => select(null) }
-              onClose={ closeMenu }
-              onDismiss={ dismissMenu }
-              translate={ translate } />
+            <div class="bio-properties-panel-description">
+              <PropertyDescription description={ description } />
+            </div>
           )
           : null
       }
@@ -885,56 +992,30 @@ function PlaceholderConfiguration(props) {
     onClick,
     open,
     showEntryRef,
-    translate,
-    unavailableMessage
+    translate
   } = props;
 
-  const describedBy = error
-    ? `${ id }-error`
-    : !available && unavailableMessage
-      ? `${ id }-unavailable`
-      : undefined;
+  const describedBy = (error || !available)
+    ? `${ id }-status`
+    : undefined;
 
   return (
-    <>
-      <button
-        id={ controlId }
-        ref={ showEntryRef }
-        type="button"
-        class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--placeholder bio-properties-panel-focus-ring"
-        disabled={ disabled || error || !available }
-        aria-haspopup="listbox"
-        aria-controls={ open ? listboxId : undefined }
-        aria-describedby={ describedBy }
-        aria-expanded={ open }
-        onClick={ onClick }>
-        <CreateIcon
-          class="bio-properties-panel-configuration-chooser-create-icon"
-          aria-hidden="true" />
-        { translate('Choose {configuration}', { configuration: chooserLabel }) }
-      </button>
-      {
-        error
-          ? (
-            <div
-              id={ `${ id }-error` }
-              class="bio-properties-panel-configuration-chooser-unavailable bio-properties-panel-configuration-chooser-unavailable--error"
-              role="status">
-              { translate('Could not load configurations') }
-            </div>
-          )
-          : !available && unavailableMessage
-            ? (
-              <div
-                id={ `${ id }-unavailable` }
-                class="bio-properties-panel-configuration-chooser-unavailable"
-                role="status">
-                { unavailableMessage }
-              </div>
-            )
-            : null
-      }
-    </>
+    <button
+      id={ controlId }
+      ref={ showEntryRef }
+      type="button"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--placeholder bio-properties-panel-focus-ring"
+      disabled={ disabled || error || !available }
+      aria-haspopup="listbox"
+      aria-controls={ open ? listboxId : undefined }
+      aria-describedby={ describedBy }
+      aria-expanded={ open }
+      onClick={ onClick }>
+      <CreateIcon
+        class="bio-properties-panel-configuration-chooser-create-icon"
+        aria-hidden="true" />
+      { translate('Choose {configuration}', { configuration: chooserLabel }) }
+    </button>
   );
 }
 
@@ -981,7 +1062,9 @@ function ErrorConfiguration(props) {
       translate={ translate }
       logo={ <ConfigurationLogo warning /> }
       title={ cachedName || refName }
-      subtitle={ translate('Could not load configurations') } />
+      subtitle={
+        <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+      } />
   );
 }
 
@@ -994,31 +1077,19 @@ function MissingConfiguration(props) {
     listboxId,
     menuId,
     menuOpen,
-    minimumVersion,
     open,
     onClick,
     onMenu,
     translate,
-    typeIncompatible,
     value
   } = props;
 
   // extract variable name from FEEL expression
   const refName = fromReference(value);
-  const instanceVersion = instance?.metadata?.configurationTemplateVersion;
 
   const title = instance
     ? getDisplayName(instance)
-    : cachedName || translate('Configuration not found');
-
-  const subtitle = instance
-    ? typeIncompatible
-      ? translate('Incompatible configuration type')
-      : translate('Version {version} · Requires version {minimumVersion}+', {
-        version: instanceVersion == null ? '?' : instanceVersion,
-        minimumVersion
-      })
-    : cachedName ? translate('Not found on cluster') : refName;
+    : cachedName || refName;
 
   return (
     <ConfigurationCard
@@ -1035,7 +1106,9 @@ function MissingConfiguration(props) {
       translate={ translate }
       logo={ <ConfigurationLogo warning /> }
       title={ title }
-      subtitle={ subtitle } />
+      subtitle={
+        <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+      } />
   );
 }
 
@@ -1048,7 +1121,6 @@ function OfflineConfiguration(props) {
     menuOpen,
     onMenu,
     translate,
-    unavailableMessage,
     value
   } = props;
 
@@ -1072,7 +1144,9 @@ function OfflineConfiguration(props) {
       translate={ translate }
       logo={ <ConfigurationLogo instance={ instance } /> }
       title={ cachedName || refName }
-      subtitle={ unavailableMessage || translate('Cluster unavailable') } />
+      subtitle={
+        <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+      } />
   );
 }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1056,6 +1056,13 @@ export function ErrorConfiguration(props) {
 
   const refName = fromReference(value);
 
+  const instance = {
+    name: refName,
+    metadata: {
+      displayName: cachedName
+    }
+  };
+
   return (
     <ConfigurationCard
       class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--missing bio-properties-panel-configuration-chooser-card--error bio-properties-panel-focus-ring"
@@ -1064,7 +1071,7 @@ export function ErrorConfiguration(props) {
       menuOpen={ menuOpen }
       onMenu={ onMenu }
       translate={ translate }
-      logo={ <ConfigurationLogo warning /> }
+      logo={ <ConfigurationLogo instance={ instance } /> }
       title={ cachedName || refName }
       subtitle={
         <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
@@ -1095,6 +1102,13 @@ export function MissingConfiguration(props) {
     ? getDisplayName(instance)
     : cachedName || refName;
 
+  const displayInstance = instance || {
+    name: refName,
+    metadata: {
+      displayName: cachedName
+    }
+  };
+
   return (
     <ConfigurationCard
       class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--missing bio-properties-panel-focus-ring"
@@ -1108,7 +1122,7 @@ export function MissingConfiguration(props) {
       menuOpen={ menuOpen }
       onMenu={ onMenu }
       translate={ translate }
-      logo={ <ConfigurationLogo warning /> }
+      logo={ <ConfigurationLogo instance={ displayInstance } /> }
       title={ title }
       subtitle={
         <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
@@ -1350,15 +1364,7 @@ function ConfigurationRow(props) {
 }
 
 function ConfigurationLogo(props) {
-  const { instance, warning } = props;
-
-  if (warning) {
-    return (
-      <span class="bio-properties-panel-configuration-chooser-logo bio-properties-panel-configuration-chooser-logo--placeholder bio-properties-panel-configuration-chooser-logo--warning">
-        !
-      </span>
-    );
-  }
+  const { instance } = props;
 
   if (instance.icon) {
     return (

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -268,7 +268,7 @@ export function ConfigurationProperty(props) {
     const node = ref.current;
 
     return node && domQuery(
-      '.bio-properties-panel-configuration-chooser-placeholder,'
+      '.bio-properties-panel-configuration-chooser-card--placeholder,'
       + '.bio-properties-panel-configuration-chooser-trigger',
       node
     );
@@ -629,7 +629,7 @@ function SelectedConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-focus-ring"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--selected bio-properties-panel-focus-ring"
       interactive
       controlId={ controlId }
       disabled={ disabled }
@@ -901,7 +901,7 @@ function PlaceholderConfiguration(props) {
         id={ controlId }
         ref={ showEntryRef }
         type="button"
-        class="bio-properties-panel-configuration-chooser-placeholder bio-properties-panel-focus-ring"
+        class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--placeholder bio-properties-panel-focus-ring"
         disabled={ disabled || error || !available }
         aria-haspopup="listbox"
         aria-controls={ open ? listboxId : undefined }
@@ -950,7 +950,7 @@ function LoadingConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-loading"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--loading"
       role="status"
       logo={ <ConfigurationLogo instance={ instance } /> }
       title={ name }
@@ -973,7 +973,7 @@ function ErrorConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-configuration-chooser-error bio-properties-panel-focus-ring"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--missing bio-properties-panel-configuration-chooser-card--error bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }
@@ -1022,7 +1022,7 @@ function MissingConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-missing bio-properties-panel-focus-ring"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--missing bio-properties-panel-focus-ring"
       interactive
       controlId={ controlId }
       disabled={ disabled }
@@ -1064,7 +1064,7 @@ function OfflineConfiguration(props) {
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-selected bio-properties-panel-configuration-chooser-selected--offline bio-properties-panel-focus-ring"
+      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--selected bio-properties-panel-configuration-chooser-card--offline bio-properties-panel-focus-ring"
       disabled={ disabled }
       menuId={ menuId }
       menuOpen={ menuOpen }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -120,19 +120,13 @@ function getConfigurationStatus(options) {
     };
   }
 
-  if (variant === VARIANT.OFFLINE) {
+  // offline (bound but unverifiable) and unavailable placeholder are the same
+  // neutral note: the cluster connection can only be restored outside the panel
+  if (variant === VARIANT.OFFLINE || (variant === VARIANT.PLACEHOLDER && !available)) {
     return {
       id: statusId,
       severity: 'note',
-      message: unavailableMessage || translate('Cluster unavailable')
-    };
-  }
-
-  if (variant === VARIANT.PLACEHOLDER && !available) {
-    return {
-      id: statusId,
-      severity: 'note',
-      message: unavailableMessage || translate('Cluster unavailable')
+      message: unavailableMessage || translate('No cluster connected')
     };
   }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -572,7 +572,7 @@ export function ConfigurationProperty(props) {
       );
     case VARIANT.LOADING:
       return (
-        <LoadingConfiguration cachedName={ cachedName } translate={ translate } />
+        <LoadingConfiguration value={ value } cachedName={ cachedName } />
       );
     case VARIANT.MISSING:
       return (
@@ -808,7 +808,6 @@ function ConfigurationCardContent(props) {
 function ConfigurationCard(props) {
   const {
     class: className,
-    role,
     logo,
     title,
     subtitle,
@@ -829,7 +828,7 @@ function ConfigurationCard(props) {
   );
 
   return (
-    <div class={ className } role={ role }>
+    <div class={ className }>
       {
         interactive
           ? (
@@ -1013,23 +1012,34 @@ function PlaceholderConfiguration(props) {
   );
 }
 
+/**
+ * A configuration card shown while the instance list is still being fetched.
+ * The list loads once for the whole panel, so this reuses the resolved identity
+ * card (from the cached name) rather than a distinct loading skin — it is
+ * indistinguishable from the resolved card; the branch only defers the
+ * "not found" warning until the list resolves.
+ */
 function LoadingConfiguration(props) {
-  const { cachedName, translate } = props;
-  const name = cachedName || translate('Configuration');
+  const { cachedName, value } = props;
+
+  const refName = fromReference(value);
+  const title = cachedName || refName;
+
   const instance = {
-    name,
+    name: refName || title,
     metadata: {
-      displayName: name
+      displayName: title
     }
   };
 
   return (
     <ConfigurationCard
-      class="bio-properties-panel-configuration-chooser-card bio-properties-panel-configuration-chooser-card--loading"
-      role="status"
+      class="bio-properties-panel-configuration-chooser-card"
       logo={ <ConfigurationLogo instance={ instance } /> }
-      title={ name }
-      subtitle={ translate('Loading configuration') } />
+      title={ title }
+      subtitle={
+        <span class="bio-properties-panel-configuration-chooser-varname">{ refName }</span>
+      } />
   );
 }
 

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1323,10 +1323,6 @@ function ConfigurationRow(props) {
 
   const classes = [ 'bio-properties-panel-configuration-chooser-popover-row' ];
 
-  if (selected) {
-    classes.push('bio-properties-panel-configuration-chooser-popover-row--selected');
-  }
-
   if (active) {
     classes.push('bio-properties-panel-configuration-chooser-popover-row--active');
   }

--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -714,7 +714,7 @@ export function ConfigurationProperty(props) {
   );
 }
 
-function SelectedConfiguration(props) {
+export function SelectedConfiguration(props) {
   const {
     controlId,
     disabled,
@@ -896,7 +896,7 @@ function ConfigurationMenuButton(props) {
   );
 }
 
-function ConfigurationContextMenu(props) {
+export function ConfigurationContextMenu(props) {
   const { initialFocus, menuId, onClose, onDismiss, onEdit, onRemove, onUpgrade, translate } = props;
 
   const menuRef = useRef(null);
@@ -973,7 +973,7 @@ function ConfigurationContextMenu(props) {
   );
 }
 
-function PlaceholderConfiguration(props) {
+export function PlaceholderConfiguration(props) {
   const {
     available,
     chooserLabel,
@@ -1019,7 +1019,7 @@ function PlaceholderConfiguration(props) {
  * indistinguishable from the resolved card; the branch only defers the
  * "not found" warning until the list resolves.
  */
-function LoadingConfiguration(props) {
+export function LoadingConfiguration(props) {
   const { cachedName, value } = props;
 
   const refName = fromReference(value);
@@ -1043,7 +1043,7 @@ function LoadingConfiguration(props) {
   );
 }
 
-function ErrorConfiguration(props) {
+export function ErrorConfiguration(props) {
   const {
     cachedName,
     disabled,
@@ -1072,7 +1072,7 @@ function ErrorConfiguration(props) {
   );
 }
 
-function MissingConfiguration(props) {
+export function MissingConfiguration(props) {
   const {
     cachedName,
     controlId,
@@ -1116,7 +1116,7 @@ function MissingConfiguration(props) {
   );
 }
 
-function OfflineConfiguration(props) {
+export function OfflineConfiguration(props) {
   const {
     cachedName,
     disabled,
@@ -1154,7 +1154,7 @@ function OfflineConfiguration(props) {
   );
 }
 
-function ConfigurationPopover(props) {
+export function ConfigurationPopover(props) {
   const {
     canCreate,
     instances,

--- a/test/spec/Example.spec.js
+++ b/test/spec/Example.spec.js
@@ -779,7 +779,7 @@ function createTestUI(modeler) {
           selectableInstances: available ? [ ...demoConfigurations ] : [],
           loading: false,
           available,
-          unavailableMessage: available ? null : 'No cluster selected'
+          unavailableMessage: null
         });
       });
 

--- a/test/spec/cloud-element-templates/ConfigurationChooser.example.spec.js
+++ b/test/spec/cloud-element-templates/ConfigurationChooser.example.spec.js
@@ -1,0 +1,667 @@
+import TestContainer from 'mocha-test-container-support';
+
+import { render } from '@bpmn-io/properties-panel/preact';
+
+import {
+  insertCoreStyles,
+  insertCSS
+} from 'test/TestHelper';
+
+import {
+  ConfigurationContextMenu,
+  ConfigurationPopover,
+  ErrorConfiguration,
+  LoadingConfiguration,
+  MissingConfiguration,
+  OfflineConfiguration,
+  PlaceholderConfiguration,
+  SelectedConfiguration
+} from 'src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty';
+
+const singleStart = window.__env__ && window.__env__.SINGLE_START;
+
+insertCoreStyles();
+
+// layout chrome for the board — not part of the component, only to arrange the
+// examples so their styling is easy to eyeball and discuss side by side
+insertCSS('configuration-chooser-example.css', `
+  /* let the page host the full board (last dropdown row is tall) */
+  html, body {
+    height: auto;
+    min-height: 100%;
+    overflow: auto;
+  }
+
+  /* the mocha test container clips overflow by default; let it grow so tall
+     sections (open menu / dropdown) are fully visible */
+  .cb-test-container {
+    position: static;
+    height: fit-content !important;
+    overflow: visible;
+  }
+
+  .cb-board {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 28px 24px;
+    padding: 24px;
+    background: var(--group-background-color, #fff);
+  }
+
+  .cb-section {
+    grid-column: 1 / -1;
+    margin: 8px 0 -8px;
+    font: 600 11px/1.4 sans-serif;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #6b6d76;
+    border-bottom: 1px solid #e5e6e7;
+    padding-bottom: 6px;
+  }
+
+  .cb-cell {
+    margin: 0;
+  }
+
+  /* overlays (popover / actions menu) are absolutely positioned off the card;
+     reserve room so they don't collide with the row below. --tall fits the
+     actions menu; --xtall fits the taller options dropdown. */
+  .cb-cell--tall {
+    min-height: 250px;
+  }
+
+  .cb-cell--xtall {
+    min-height: 430px;
+  }
+
+  .cb-caption {
+    margin-bottom: 6px;
+    font: 12px/1.4 sans-serif;
+    color: #6b6d76;
+  }
+
+  .cb-note {
+    grid-column: 1 / -1;
+    margin: 0;
+    font: 12px/1.5 sans-serif;
+    color: #6b6d76;
+  }
+`);
+
+// a translate that mirrors the properties-panel signature: `{key}` interpolation
+function translate(template, replacements = {}) {
+  return template.replace(/{([^}]+)}/g, (_, key) =>
+    replacements[key] != null ? replacements[key] : '{' + key + '}'
+  );
+}
+
+function noop() {}
+
+// a tiny inline logo so the "selected" card shows an icon rather than an initial
+const ICON = 'data:image/svg+xml;utf8,' + encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">' +
+  '<rect width="28" height="28" rx="6" fill="#4b5bd6"/>' +
+  '<circle cx="14" cy="14" r="7" fill="#fff"/>' +
+  '</svg>'
+);
+
+const INSTANCE = {
+  name: 'myConnection',
+  metadata: { displayName: 'My Connection' }
+};
+
+const INSTANCE_WITH_ICON = {
+  name: 'slackProd',
+  metadata: { displayName: 'Slack (Production)' },
+  icon: ICON
+};
+
+// a set of options for the dropdown/popover
+const INSTANCES = [
+  { name: 'slackProd', metadata: { displayName: 'Slack (Production)' }, icon: ICON },
+  { name: 'slackDev', metadata: { displayName: 'Slack (Development)' } },
+  { name: 'myConnection', metadata: { displayName: 'My Connection' } },
+  { name: 'githubMain', metadata: { displayName: 'GitHub (Main)' } }
+];
+
+// shared handlers/flags every interactive/menu card needs
+const CARD = {
+  translate,
+  onMenu: noop,
+  menuOpen: false,
+  disabled: false
+};
+
+// wraps a card in the real entry markup so severity (.has-warning / .has-error)
+// and the chooser control layout resolve exactly as they do in the panel
+function Cell(props) {
+  const {
+    label,
+    severity = '',
+    state = 'selected',
+    tall = false,
+    xtall = false,
+    status = null,
+    error = null,
+    description = null,
+    children
+  } = props;
+
+  const entryClass = [
+    'bio-properties-panel-entry',
+    'bio-properties-panel-configuration-chooser',
+    severity
+  ].filter(Boolean).join(' ');
+
+  const cellClass = [
+    'cb-cell',
+    tall ? 'cb-cell--tall' : '',
+    xtall ? 'cb-cell--xtall' : ''
+  ].filter(Boolean).join(' ');
+
+  return (
+    <figure class={ cellClass }>
+      <figcaption class="cb-caption">{ label }</figcaption>
+      <div class={ entryClass } data-configuration-state={ state }>
+        <label class="bio-properties-panel-label">Connection</label>
+        <div class="bio-properties-panel-configuration-chooser-control">
+          { children }
+        </div>
+
+        {
+          status
+            ? <div class={ 'bio-properties-panel-' + (status.severity === 'warning' ? 'warning' : 'description') }>{ status.message }</div>
+            : null
+        }
+
+        {
+          error
+            ? <div class="bio-properties-panel-error">{ error }</div>
+            : null
+        }
+
+        {
+          description
+            ? <div class="bio-properties-panel-description">{ description }</div>
+            : null
+        }
+      </div>
+    </figure>
+  );
+}
+
+function StatesSection() {
+  return (
+    <>
+      <div class="cb-section">States</div>
+
+      <Cell label="Placeholder — no selection" state="placeholder">
+        <PlaceholderConfiguration
+          id="cb-placeholder"
+          controlId="cb-placeholder-control"
+          listboxId="cb-placeholder-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ false }
+          onClick={ noop }
+          translate={ translate } />
+      </Cell>
+
+      <Cell label="Placeholder — unavailable" state="placeholder"
+        status={ { severity: 'note', message: 'No cluster connected' } }>
+        <PlaceholderConfiguration
+          id="cb-placeholder-off"
+          controlId="cb-placeholder-off-control"
+          listboxId="cb-placeholder-off-listbox"
+          chooserLabel="connection"
+          available={ false }
+          disabled={ false }
+          error={ null }
+          open={ false }
+          onClick={ noop }
+          translate={ translate } />
+      </Cell>
+
+      <Cell label="Loading" state="loading">
+        <LoadingConfiguration
+          value="=camunda.vars.env.myConnection"
+          cachedName="My Connection" />
+      </Cell>
+
+      <Cell label="Selected — with icon" state="selected">
+        <SelectedConfiguration
+          controlId="cb-selected-control"
+          listboxId="cb-selected-listbox"
+          menuId="cb-selected-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE_WITH_ICON }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="Selected — initial fallback" state="selected">
+        <SelectedConfiguration
+          controlId="cb-selected2-control"
+          listboxId="cb-selected2-listbox"
+          menuId="cb-selected2-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="Offline — cached, unreachable" state="selected">
+        <OfflineConfiguration
+          menuId="cb-offline-menu"
+          value="=camunda.vars.env.slackProd"
+          cachedName="Slack (Production)"
+          icon={ ICON }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="Missing — reference not found" state="missing" severity="has-warning"
+        status={ { severity: 'warning', message: 'Not found on cluster' } }>
+        <MissingConfiguration
+          controlId="cb-missing-control"
+          listboxId="cb-missing-listbox"
+          menuId="cb-missing-menu"
+          open={ false }
+          onClick={ noop }
+          value="=camunda.vars.env.oldConnection"
+          cachedName="Old Connection"
+          instance={ null }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="Error — configurations could not be loaded" state="missing" severity="has-warning"
+        status={ { severity: 'warning', message: 'Could not load configurations' } }>
+        <ErrorConfiguration
+          menuId="cb-error-menu"
+          value="=camunda.vars.env.brokenRef"
+          cachedName="Broken Connection"
+          { ...CARD } />
+      </Cell>
+    </>
+  );
+}
+
+function SeveritySection() {
+  return (
+    <>
+      <div class="cb-section">Severity on a data card</div>
+
+      <Cell label="Neutral" state="selected">
+        <SelectedConfiguration
+          controlId="cb-sev-neutral-control"
+          listboxId="cb-sev-neutral-listbox"
+          menuId="cb-sev-neutral-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="has-warning" state="selected" severity="has-warning">
+        <SelectedConfiguration
+          controlId="cb-sev-warning-control"
+          listboxId="cb-sev-warning-listbox"
+          menuId="cb-sev-warning-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE }
+          { ...CARD } />
+      </Cell>
+
+      <Cell label="has-error" state="selected" severity="has-error">
+        <SelectedConfiguration
+          controlId="cb-sev-error-control"
+          listboxId="cb-sev-error-listbox"
+          menuId="cb-sev-error-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE }
+          { ...CARD } />
+      </Cell>
+
+      <p class="cb-note">
+        Hover and keyboard-focus (Tab) the cards to inspect the interactive
+        states: grey mouse-over on interactive cards, blue focus fill + focus
+        ring on the data cards, and the standalone <code>…</code> menu button.
+      </p>
+    </>
+  );
+}
+
+function MessagesSection() {
+  return (
+    <>
+      <div class="cb-section">Description &amp; validation messages</div>
+
+      <Cell
+        label="Selected + description"
+        state="selected"
+        description="Connection used to authenticate the task.">
+        <SelectedConfiguration
+          controlId="cb-desc-control"
+          listboxId="cb-desc-listbox"
+          menuId="cb-desc-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE_WITH_ICON }
+          { ...CARD } />
+      </Cell>
+
+      <Cell
+        label="Selected + validation error"
+        state="selected"
+        severity="has-error"
+        error="Connection is required."
+        description="Connection used to authenticate the task.">
+        <SelectedConfiguration
+          controlId="cb-err-control"
+          listboxId="cb-err-listbox"
+          menuId="cb-err-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE }
+          { ...CARD } />
+      </Cell>
+
+      <Cell
+        label="Missing + warning status + description"
+        state="missing"
+        severity="has-warning"
+        status={ { severity: 'warning', message: 'Referenced connection was not found in the cluster.' } }
+        description="Connection used to authenticate the task.">
+        <MissingConfiguration
+          controlId="cb-missdesc-control"
+          listboxId="cb-missdesc-listbox"
+          menuId="cb-missdesc-menu"
+          open={ false }
+          onClick={ noop }
+          value="=camunda.vars.env.oldConnection"
+          cachedName="Old Connection"
+          instance={ null }
+          { ...CARD } />
+      </Cell>
+
+      <Cell
+        label="Placeholder + validation error"
+        state="placeholder"
+        severity="has-error"
+        error="Connection is required.">
+        <PlaceholderConfiguration
+          id="cb-pherr"
+          controlId="cb-pherr-control"
+          listboxId="cb-pherr-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ false }
+          onClick={ noop }
+          translate={ translate } />
+      </Cell>
+
+      <Cell
+        label="Placeholder + validation error + description"
+        state="placeholder"
+        severity="has-error"
+        error="Connection is required."
+        description="Connection used to authenticate the task.">
+        <PlaceholderConfiguration
+          id="cb-pherrdesc"
+          controlId="cb-pherrdesc-control"
+          listboxId="cb-pherrdesc-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ false }
+          onClick={ noop }
+          translate={ translate } />
+      </Cell>
+    </>
+  );
+}
+
+function ActionsMenuSection() {
+  return (
+    <>
+      <div class="cb-section">Actions menu (open)</div>
+
+      <Cell label="Menu — edit / upgrade / unset" state="selected" tall={ true }>
+        <SelectedConfiguration
+          controlId="cb-menufull-control"
+          listboxId="cb-menufull-listbox"
+          menuId="cb-menufull-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE_WITH_ICON }
+          { ...CARD }
+          menuOpen={ true } />
+        <ConfigurationContextMenu
+          menuId="cb-menufull-menu"
+          initialFocus={ null }
+          onEdit={ noop }
+          onUpgrade={ noop }
+          onRemove={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          translate={ translate } />
+      </Cell>
+
+      <Cell label="Menu — unset only" state="missing" severity="has-warning" tall={ true }>
+        <MissingConfiguration
+          controlId="cb-menumin-control"
+          listboxId="cb-menumin-listbox"
+          menuId="cb-menumin-menu"
+          open={ false }
+          onClick={ noop }
+          value="=camunda.vars.env.oldConnection"
+          cachedName="Old Connection"
+          instance={ null }
+          { ...CARD }
+          menuOpen={ true } />
+        <ConfigurationContextMenu
+          menuId="cb-menumin-menu"
+          initialFocus={ null }
+          onEdit={ null }
+          onUpgrade={ null }
+          onRemove={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          translate={ translate } />
+      </Cell>
+
+      <Cell
+        label="Menu — with description"
+        state="selected"
+        tall={ true }
+        description="Connection used to authenticate the task.">
+        <SelectedConfiguration
+          controlId="cb-menudesc-control"
+          listboxId="cb-menudesc-listbox"
+          menuId="cb-menudesc-menu"
+          open={ false }
+          onClick={ noop }
+          instance={ INSTANCE_WITH_ICON }
+          { ...CARD }
+          menuOpen={ true } />
+        <ConfigurationContextMenu
+          menuId="cb-menudesc-menu"
+          initialFocus={ null }
+          onEdit={ noop }
+          onUpgrade={ noop }
+          onRemove={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          translate={ translate } />
+      </Cell>
+    </>
+  );
+}
+
+function DropdownSection() {
+  return (
+    <>
+      <div class="cb-section">Dropdown (open)</div>
+
+      <Cell label="Dropdown — options + create" state="placeholder" xtall={ true }>
+        <PlaceholderConfiguration
+          id="cb-dd"
+          controlId="cb-dd-control"
+          listboxId="cb-dd-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ true }
+          onClick={ noop }
+          translate={ translate } />
+        <ConfigurationPopover
+          listboxId="cb-dd-listbox"
+          instances={ INSTANCES }
+          selected={ INSTANCES[1] }
+          canCreate={ true }
+          onCreate={ noop }
+          onSelect={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          loading={ false }
+          translate={ translate } />
+      </Cell>
+
+      <Cell label="Dropdown — refreshing" state="placeholder" xtall={ true }>
+        <PlaceholderConfiguration
+          id="cb-ddload"
+          controlId="cb-ddload-control"
+          listboxId="cb-ddload-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ true }
+          onClick={ noop }
+          translate={ translate } />
+        <ConfigurationPopover
+          listboxId="cb-ddload-listbox"
+          instances={ INSTANCES }
+          selected={ null }
+          canCreate={ true }
+          onCreate={ noop }
+          onSelect={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          loading={ true }
+          translate={ translate } />
+      </Cell>
+
+      <Cell label="Dropdown — empty" state="placeholder" xtall={ true }>
+        <PlaceholderConfiguration
+          id="cb-ddempty"
+          controlId="cb-ddempty-control"
+          listboxId="cb-ddempty-listbox"
+          chooserLabel="connection"
+          available={ true }
+          disabled={ false }
+          error={ null }
+          open={ true }
+          onClick={ noop }
+          translate={ translate } />
+        <ConfigurationPopover
+          listboxId="cb-ddempty-listbox"
+          instances={ [] }
+          selected={ null }
+          canCreate={ true }
+          onCreate={ noop }
+          onSelect={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          loading={ false }
+          translate={ translate } />
+      </Cell>
+
+      <Cell
+        label="Dropdown — with description"
+        state="selected"
+        xtall={ true }
+        description="Connection used to authenticate the task.">
+        <SelectedConfiguration
+          controlId="cb-ddsel-control"
+          listboxId="cb-ddsel-listbox"
+          menuId="cb-ddsel-menu"
+          open={ true }
+          onClick={ noop }
+          instance={ INSTANCE_WITH_ICON }
+          { ...CARD } />
+        <ConfigurationPopover
+          listboxId="cb-ddsel-listbox"
+          instances={ INSTANCES }
+          selected={ INSTANCES[0] }
+          canCreate={ true }
+          onCreate={ noop }
+          onSelect={ noop }
+          onClose={ noop }
+          onDismiss={ noop }
+          loading={ false }
+          translate={ translate } />
+      </Cell>
+    </>
+  );
+}
+
+// renders one section into the test's own container, wrapped in the panel +
+// board chrome. Each `it` gets a fresh container, so a single `it.only` shows
+// just that section (no scrolling) while running the whole suite stacks them.
+function renderSection(ctx, section) {
+  const container = TestContainer.get(ctx);
+
+  // TestContainer.get returns the inner content element; the element that clips
+  // (fixed height + overflow:hidden) is the outer .test-container. Mark that one
+  // so our stylesheet lets it grow and tall sections are not cut off.
+  const testContainer = container.closest('.test-container') || container;
+  testContainer.classList.add('cb-test-container');
+
+  render(
+    <div class="bio-properties-panel">
+      <div class="cb-board">
+        { section }
+      </div>
+    </div>,
+    container
+  );
+}
+
+// Visual, human-only test bed. It does not assert; it renders the chooser
+// variations so the styling can be reviewed and discussed. Run it in isolation
+// with `SINGLE_START=chooser npm run dev` (or `npm run start:chooser`); it is
+// skipped in the regular headless suite.
+//
+// Focus a single section (renders without scrolling) by changing its `it` below
+// to `it.only`; leave them all to stack every section down the page.
+(singleStart === 'chooser' ? describe.only : describe.skip)('configuration chooser (visual)', function() {
+
+  it('states', function() {
+    renderSection(this, <StatesSection />);
+  });
+
+  it('severity on a data card', function() {
+    renderSection(this, <SeveritySection />);
+  });
+
+  it('description & validation messages', function() {
+    renderSection(this, <MessagesSection />);
+  });
+
+  it('actions menu (open)', function() {
+    renderSection(this, <ActionsMenuSection />);
+  });
+
+  it('dropdown (open)', function() {
+    renderSection(this, <DropdownSection />);
+  });
+
+});

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -3002,13 +3002,17 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      const loading = domQuery('.bio-properties-panel-configuration-chooser-card--loading', entry);
+      // loading reuses the plain identity card (no distinct loading skin and no
+      // screen-reader-only busy signal) showing the cached identity — it is
+      // indistinguishable from the resolved card
+      const loading = domQuery('.bio-properties-panel-configuration-chooser-card', entry);
 
       expect(loading).to.exist;
-      expect(loading.getAttribute('role')).to.equal('status');
       expect(loading.textContent).to.contain('Slack Production');
-      expect(loading.textContent).to.contain('Loading configuration');
-      expect(domQuery('.bio-properties-panel-configuration-chooser-loading-shimmer', entry)).not.to.exist;
+      expect(loading.textContent).to.contain('slackProduction');
+      expect(loading.getAttribute('aria-busy')).not.to.exist;
+      expect(loading.getAttribute('role')).not.to.exist;
+      expect(domQuery('.bio-properties-panel-configuration-chooser-card--loading', entry)).not.to.exist;
     }));
 
 

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -3082,6 +3082,56 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     }));
 
 
+    it('should fall back to a default unavailable message when the host omits one', inject(async function(elementTemplates, configurationInstances) {
+
+      // given
+      const element = await expectSelected('RestTask_noData');
+      const template = {
+        id: 'configuration-property',
+        appliesTo: [ 'bpmn:ServiceTask' ],
+        elementType: {
+          value: 'bpmn:ServiceTask'
+        },
+        properties: [ {
+          id: 'configuration',
+          label: 'Configuration',
+          type: 'Configuration',
+          configurationTemplate: 'io.camunda:slack-connection:1',
+          configurationTemplateVersion: 2,
+          binding: {
+            type: 'zeebe:property',
+            name: 'configuration'
+          }
+        } ]
+      };
+
+      elementTemplates.set([ ...templates, template ]);
+
+      await act(() => {
+        elementTemplates.applyTemplate(element, template);
+      });
+
+      const entry = findEntry('custom-entry-configuration-property-0', container),
+            placeholder = getConfigurationPlaceholder(entry);
+
+      // when
+      await act(() => {
+        configurationInstances.setState({
+          available: false,
+          unavailableMessage: null
+        });
+      });
+
+      // then
+      const status = getConfigurationStatus(entry);
+
+      expect(placeholder.disabled).to.be.true;
+      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-status');
+      expect(domClasses(status).contains('bio-properties-panel-description')).to.be.true;
+      expect(status.textContent).to.equal('No cluster connected');
+    }));
+
+
     it('should show an error message for an unselected configuration when loading fails', inject(async function(elementTemplates, configurationInstances) {
 
       // given

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1517,7 +1517,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const optionalPropertyEntry = findEntry('custom-entry-configuration-metadata-cleanup-2', container);
 
       await act(() => {
-        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-placeholder', optionalPropertyEntry));
+        fireEvent.click(domQuery('.bio-properties-panel-configuration-chooser-card--placeholder', optionalPropertyEntry));
       });
       clickConfigurationOption(optionalPropertyEntry, 'Slack Production');
 
@@ -1569,7 +1569,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const select = async (entry, name) => {
         await act(() => {
           fireEvent.click(domQuery(
-            '.bio-properties-panel-configuration-chooser-placeholder, .bio-properties-panel-configuration-chooser-trigger',
+            '.bio-properties-panel-configuration-chooser-card--placeholder, .bio-properties-panel-configuration-chooser-trigger',
             entry
           ));
         });
@@ -2916,7 +2916,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       await waitFor(() => {
         expect(getConfigurationSelected(entry)).to.exist;
-        expect(domQuery('.bio-properties-panel-configuration-chooser-selected--offline', entry)).to.exist;
+        expect(domQuery('.bio-properties-panel-configuration-chooser-card--offline', entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-logo', entry).getAttribute('src')).to.equal('data:image/svg+xml;base64,offline-icon');
         expect(domQuery('.bio-properties-panel-configuration-chooser-subtitle', entry).textContent).to.equal('No cluster selected');
         expect(getConfigurationMissing(entry)).not.to.exist;
@@ -2992,7 +2992,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      const loading = domQuery('.bio-properties-panel-configuration-chooser-loading', entry);
+      const loading = domQuery('.bio-properties-panel-configuration-chooser-card--loading', entry);
 
       expect(loading).to.exist;
       expect(loading.getAttribute('role')).to.equal('status');
@@ -3204,7 +3204,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      const error = domQuery('.bio-properties-panel-configuration-chooser-error', entry);
+      const error = domQuery('.bio-properties-panel-configuration-chooser-card--error', entry);
 
       expect(error).to.exist;
       expect(error.textContent).to.contain('Slack Production');
@@ -6271,7 +6271,7 @@ function openConfigurationMenu(entry) {
 
 
 function getConfigurationPlaceholder(entry) {
-  const placeholder = domQuery('.bio-properties-panel-configuration-chooser-placeholder', entry);
+  const placeholder = domQuery('.bio-properties-panel-configuration-chooser-card--placeholder', entry);
 
   expect(placeholder, 'configuration chooser placeholder').to.exist;
 
@@ -6295,11 +6295,11 @@ function getConfigurationCreate(entry) {
 }
 
 function getConfigurationSelected(entry) {
-  return domQuery('.bio-properties-panel-configuration-chooser-selected', entry);
+  return domQuery('.bio-properties-panel-configuration-chooser-card--selected', entry);
 }
 
 function getConfigurationMissing(entry) {
-  return domQuery('.bio-properties-panel-configuration-chooser-missing', entry);
+  return domQuery('.bio-properties-panel-configuration-chooser-card--missing', entry);
 }
 
 function getConfigurationContextMenu(entry) {

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -1362,7 +1362,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const typeMismatch = getConfigurationMissing(fallbackEntry);
 
       expect(typeMismatch.textContent).to.contain('AWS Production');
-      expect(typeMismatch.textContent).to.contain('Incompatible configuration type');
+      expect(getConfigurationStatus(fallbackEntry).textContent).to.contain('Incompatible configuration type');
       expect(typeMismatch.textContent).not.to.contain('AWS Credential');
       expect(typeMismatch.textContent).not.to.contain('io.camunda:other-credential:1');
 
@@ -2918,7 +2918,17 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         expect(getConfigurationSelected(entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-card--offline', entry)).to.exist;
         expect(domQuery('.bio-properties-panel-configuration-chooser-logo', entry).getAttribute('src')).to.equal('data:image/svg+xml;base64,offline-icon');
-        expect(domQuery('.bio-properties-panel-configuration-chooser-subtitle', entry).textContent).to.equal('No cluster selected');
+
+        // card keeps the stable identity (variable name), not the transient message
+        expect(domQuery('.bio-properties-panel-configuration-chooser-subtitle', entry).textContent).to.equal('slackProduction');
+
+        // the cluster status is surfaced as a standard note (description) below the card
+        const status = getConfigurationStatus(entry);
+
+        expect(domClasses(entry).contains('has-warning')).to.be.false;
+        expect(domClasses(status).contains('bio-properties-panel-description')).to.be.true;
+        expect(status.textContent).to.equal('No cluster selected');
+
         expect(getConfigurationMissing(entry)).not.to.exist;
       });
 
@@ -3062,12 +3072,12 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       });
 
       // then
-      const unavailable = domQuery('.bio-properties-panel-configuration-chooser-unavailable', entry);
+      const status = getConfigurationStatus(entry);
 
       expect(placeholder.disabled).to.be.true;
-      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-unavailable');
-      expect(unavailable.getAttribute('role')).to.equal('status');
-      expect(unavailable.textContent).to.equal('No cluster selected');
+      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-status');
+      expect(domClasses(status).contains('bio-properties-panel-description')).to.be.true;
+      expect(status.textContent).to.equal('No cluster selected');
       expect(getConfigurationPopover(entry)).not.to.exist;
     }));
 
@@ -3107,13 +3117,14 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       const entry = findEntry('custom-entry-configuration-property-0', container),
             placeholder = getConfigurationPlaceholder(entry),
-            error = domQuery('.bio-properties-panel-configuration-chooser-unavailable--error', entry);
+            status = getConfigurationStatus(entry);
 
       // then
       expect(placeholder.disabled).to.be.true;
-      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-error');
-      expect(error.getAttribute('role')).to.equal('status');
-      expect(error.textContent).to.equal('Could not load configurations');
+      expect(placeholder.getAttribute('aria-describedby')).to.equal('custom-entry-configuration-property-0-status');
+      expect(domClasses(entry).contains('has-warning')).to.be.true;
+      expect(domClasses(status).contains('bio-properties-panel-warning')).to.be.true;
+      expect(status.textContent).to.equal('Could not load configurations');
 
       // when
       await act(() => {
@@ -3124,7 +3135,8 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
 
       // then
       expect(placeholder.disabled).to.be.false;
-      expect(domQuery('.bio-properties-panel-configuration-chooser-unavailable--error', entry)).not.to.exist;
+      expect(domClasses(entry).contains('has-warning')).to.be.false;
+      expect(getConfigurationStatus(entry)).not.to.exist;
     }));
 
 
@@ -3207,8 +3219,17 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const error = domQuery('.bio-properties-panel-configuration-chooser-card--error', entry);
 
       expect(error).to.exist;
+
+      // the card keeps the configuration identity
       expect(error.textContent).to.contain('Slack Production');
-      expect(error.textContent).to.contain('Could not load configurations');
+
+      // the load error is surfaced as a standard error field below the card
+      const errorStatus = getConfigurationStatus(entry);
+
+      expect(errorStatus).to.exist;
+      expect(domClasses(errorStatus).contains('bio-properties-panel-warning')).to.be.true;
+      expect(errorStatus.textContent).to.contain('Could not load configurations');
+
       expect(entry.textContent).not.to.contain('Not found on cluster');
       expect(getConfigurationContextMenu(entry)).not.to.exist;
 
@@ -3565,7 +3586,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
       const missing = getConfigurationMissing(entry);
 
       expect(missing).to.exist;
-      expect(missing.textContent).to.contain('Version 1 · Requires version 2+');
+      expect(getConfigurationStatus(entry).textContent).to.contain('Version 1 · Requires version 2+');
 
       fireEvent.click(getConfigurationTrigger(missing));
 
@@ -6300,6 +6321,10 @@ function getConfigurationSelected(entry) {
 
 function getConfigurationMissing(entry) {
   return domQuery('.bio-properties-panel-configuration-chooser-card--missing', entry);
+}
+
+function getConfigurationStatus(entry) {
+  return domQuery('[id$="-status"]', entry);
 }
 
 function getConfigurationContextMenu(entry) {


### PR DESCRIPTION
### Proposed Changes

Follow up to https://github.com/bpmn-io/bpmn-js-element-templates/pull/263, this PR polishes the configuration chooser so its state representation is consistent, themeable, and built on standard properties-panel infrastructure instead of bespoke, in-card messaging.

#### What & why

- **Unified state messaging** — every transient message (missing, incompatible, load error, cluster unavailable) now renders as a standard note/warning field *below* the identity-only card, driven by a single `getConfigurationStatus()` helper. This replaces the nested in-card message that clipped long text, and lets messages wrap. Cards reuse the panel `.has-warning` severity and pick up the standard input focus treatment.
- **Unified cluster-unavailable message** — offline and unavailable-placeholder describe the same situation (only fixable outside the panel), so they collapse into one neutral note defaulting to *"No cluster connected"*.
- **Consistent muted-grey hover/selected** — replaces per-state blue/orange highlights with one shared muted-grey treatment across card, popover rows, create action and context menu.
- **Themeable semantic tokens** — introduces a `--configuration-chooser-*` token layer over the panel tokens, giving downstream consumers a single seam to re-skin the component; panel tokens that already fit are used directly.
- **No distinct loading state** — the instance list loads once for the whole panel, so the per-card loading skin added noise without conveying anything card-specific; loading now reuses the resolved identity card.
- **CSS restructured to BEM** and de-duplicated in the process.
- **Depends on** `@bpmn-io/properties-panel@3.51.1` (warning/description tokens) — bumped in this PR.

The change is semantically structured into separate refactor / feature / test commits.

#### Steps to try out

Inspect the styles using the new visual test bed:

```
npm run start:chooser
```

Renders the chooser across all states (placeholder, selected, missing, offline, error, loading, description, open popover/menu) for visual review.

<img width="1314" height="739" alt="image" src="https://github.com/user-attachments/assets/b162d56d-2531-4466-b857-00f0c10e4852" />

<img width="1312" height="620" alt="image" src="https://github.com/user-attachments/assets/46c70e39-3b34-4d34-9db4-ed25523278b4" />

<img width="1313" height="447" alt="image" src="https://github.com/user-attachments/assets/c4ad9c75-8fc1-4d98-8a19-4c584995e7f0" />

<img width="1313" height="679" alt="image" src="https://github.com/user-attachments/assets/78295c64-767e-495a-9d74-fd75548d9746" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__