### PR TITLE
fix: use WCAG AA compliant primary accent color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: use WCAG AA compliant accent color for applied template badge ([#290](https://github.com/bpmn-io/bpmn-js-element-templates/pull/290))
+
 ## 2.34.0
 
 * `FIX`: use standard warning color for incompatible template indicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [bpmn-js-element-templates](https://github.com/bpmn-io/bp
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: use WCAG AA compliant accent color for applied template badge ([#290](https://github.com/bpmn-io/bpmn-js-element-templates/pull/290))
+* `DEPS`: update to `@bpmn-io/properties-panel@3.53.0` for accent theming tokens
 
 ## 2.34.0
 

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -1,10 +1,10 @@
 .bio-properties-panel {
   --color-grey-225-10-50: hsl(225, 10%, 50%);
 
-  --select-template-background-color: var(--color-blue-205-100-50);
-  --select-template-hover-background-color: var(--color-blue-205-100-45);
-  --select-template-fill-color: var(--color-white);
-  --select-template-label-color: var(--color-white);
+  --select-template-background-color: var(--accent-badge-background-color);
+  --select-template-hover-background-color: var(--accent-badge-hover-background-color);
+  --select-template-fill-color: var(--accent-badge-fill-color);
+  --select-template-label-color: var(--accent-badge-color);
 
   --unknown-template-background-color: var(--error-badge-background-color);
   --unknown-template-hover-background-color: var(--error-badge-hover-background-color);

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@babel/plugin-transform-react-jsx": "^7.29.7",
         "@bpmn-io/element-template-chooser": "^3.0.0",
         "@bpmn-io/element-template-icon-renderer": "^1.0.0",
-        "@bpmn-io/properties-panel": "^3.52.0",
+        "@bpmn-io/properties-panel": "^3.53.0",
         "@camunda/linting": "^3.55.0",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-babel": "^7.1.0",
@@ -79,7 +79,7 @@
         "node": "*"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": ">= 3.52.0",
+        "@bpmn-io/properties-panel": ">= 3.53.0",
         "bpmn-js": ">= 11.5",
         "bpmn-js-properties-panel": ">= 2",
         "camunda-bpmn-js-behaviors": ">= 1.2.1",
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.52.0.tgz",
-      "integrity": "sha512-P3RGoh3K3Nt9dPlbnqd8Hgy21PsVIGxxNbOAi89WyTppUn2xtbsHXXRjk100oGaQDowi/GMaAJ5gRafnqtf1xg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.53.0.tgz",
+      "integrity": "sha512-me695Qey27A4noskVBNcpG3jlW//2DZ6c2ajMMZpQET3QTZO5M8tnaXwbrroY4wYXEbVbchTAyyPU3uvb1mFjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "^6.2.2",
         "copy-webpack-plugin": "^14.0.0",
         "cross-env": "^10.1.0",
-        "diagram-js": "^15.24.1",
+        "diagram-js": "^15.25.0",
         "downloadjs": "^1.4.7",
         "eslint": "^9.39.5",
         "eslint-plugin-bpmn-io": "^2.3.1",
@@ -4205,9 +4205,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.24.1",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.24.1.tgz",
-      "integrity": "sha512-0zlPffk8pGdbUmt0RQH32N7dIbgYuLwkFlZTCi28kRSkb37GdEjONjXKs+NluZvWeLsY1hqSyq4le19ZeFE19Q==",
+      "version": "15.25.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.25.0.tgz",
+      "integrity": "sha512-2TKn4hBy1rHf5/6jVubiLdq09BivmhPq3QexH40YXIOnszYGVx0HKP4bW03bTQzrh7GIqMFbNYDkSXlFREWgmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "assert": "^2.1.0",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
-        "bpmn-js": "^18.25.1",
+        "bpmn-js": "^18.26.0",
         "bpmn-js-create-append-anything": "^2.0.0",
         "bpmn-js-properties-panel": "^5.65.0",
         "bpmn-moddle": "^10.1.0",
@@ -3354,14 +3354,14 @@
       "dev": true
     },
     "node_modules/bpmn-js": {
-      "version": "18.25.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.25.1.tgz",
-      "integrity": "sha512-wT/TjzUQw3o5vU6nI2tytOhOm9atf2tOgCdCKF6sQUvokZ0nOEH7yfE9IvwKXclfdUxvdawgU80h909hvQJ9hw==",
+      "version": "18.26.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.26.0.tgz",
+      "integrity": "sha512-bK/dCoOhukbWuSIUbH43GTrcLakJX0pZ+K9UBzByPTqoyN6b7X5hVpZJa09nPyfft99LsBDa0jN83pW1JnOixA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.24.0",
+        "bpmn-moddle": "^10.2.0",
+        "diagram-js": "^15.25.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "assert": "^2.1.0",
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
-    "bpmn-js": "^18.25.1",
+    "bpmn-js": "^18.26.0",
     "bpmn-js-create-append-anything": "^2.0.0",
     "bpmn-js-properties-panel": "^5.65.0",
     "bpmn-moddle": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "chai": "^6.2.2",
     "copy-webpack-plugin": "^14.0.0",
     "cross-env": "^10.1.0",
-    "diagram-js": "^15.24.1",
+    "diagram-js": "^15.25.0",
     "downloadjs": "^1.4.7",
     "eslint": "^9.39.5",
     "eslint-plugin-bpmn-io": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/plugin-transform-react-jsx": "^7.29.7",
     "@bpmn-io/element-template-chooser": "^3.0.0",
     "@bpmn-io/element-template-icon-renderer": "^1.0.0",
-    "@bpmn-io/properties-panel": "^3.52.0",
+    "@bpmn-io/properties-panel": "^3.53.0",
     "@camunda/linting": "^3.55.0",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-babel": "^7.1.0",
@@ -128,7 +128,7 @@
     "zeebe-bpmn-moddle": "^2.0.0"
   },
   "peerDependencies": {
-    "@bpmn-io/properties-panel": ">= 3.52.0",
+    "@bpmn-io/properties-panel": ">= 3.53.0",
     "bpmn-js": ">= 11.5",
     "bpmn-js-properties-panel": ">= 2",
     "camunda-bpmn-js-behaviors": ">= 1.2.1",


### PR DESCRIPTION
### Proposed Changes

The "Applied" template badge (`--select-template-*`) is the direct offender in camunda/camunda-modeler#6135: at `--color-blue-205-100-50` it is **3.12:1** on white and fails WCAG AA [1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) for its white label - this PR fixes it, re-using the properties provided `--accent-*` tokens:

<img width="1209" height="848" alt="image" src="https://github.com/user-attachments/assets/18076626-ae93-4daa-b9ea-0f925d640674" />

Alias the badge onto the shared `--accent-badge-*` tokens introduced in properties-panel, so it inherits the accessible `-40` accent (**4.66:1**) and its `-35` hover:

- `--select-template-background-color` → `--accent-badge-background-color`
- `--select-template-hover-background-color` → `--accent-badge-hover-background-color`
- `--select-template-fill-color` → `--accent-badge-fill-color`
- `--select-template-label-color` → `--accent-badge-color`

This mirrors the existing `--unknown-template-*` → `--error-badge-*` and `--incompatible-template-*` → `--warning-badge-*` aliasing, keeping all template badges on shared, themeable properties-panel tokens.

Related to https://github.com/camunda/camunda-modeler/issues/6135

Depends on bpmn-io/properties-panel#549 (introduces `--accent-badge-*`). Part of a coordinated cross-repo rollout, released bottom-up: diagram-js → bpmn-js → properties-panel → element-templates.

### Steps to try out

```
npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates#accessible-primary-accent
```

Apply an element template and inspect the "Applied" badge in the properties panel group header.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
