### PR TITLE
fix(cloud-element-templates): render configuration tooltip as hover tooltip

### DIFF
--- a/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
+++ b/src/cloud-element-templates/properties-panel/properties/custom-properties/ConfigurationProperty.js
@@ -1,7 +1,7 @@
 import { useService } from 'bpmn-js-properties-panel';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
-import { CreateIcon, useError, useShowEntryEvent } from '@bpmn-io/properties-panel';
+import { CreateIcon, TooltipEntry, useError, useShowEntryEvent } from '@bpmn-io/properties-panel';
 
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -634,14 +634,13 @@ export function ConfigurationProperty(props) {
       <label
         class="bio-properties-panel-label"
         htmlFor={ controlId }>
-        { configurationLabel }
+        <TooltipEntry
+          value={ tooltip ? PropertyTooltip({ tooltip }) : null }
+          forId={ controlId }
+          element={ element }>
+          { configurationLabel }
+        </TooltipEntry>
       </label>
-
-      {
-        tooltip
-          ? <PropertyTooltip tooltip={ tooltip } />
-          : null
-      }
 
       <div class="bio-properties-panel-configuration-chooser-control">
         { renderConfiguration() }

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -5302,6 +5302,27 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
     });
 
 
+    it('should display tooltip for configuration property', async function() {
+
+      // given
+      await expectSelected('Task');
+
+      const entry = findEntry('custom-entry-com.zeebe.example.tooltip-group-6', container);
+      const tooltipWrapper = domQuery('.bio-properties-panel-tooltip-wrapper', entry);
+
+      // assume not rendered inline
+      expect(entry.textContent).to.not.contain('CONFIGURATION_TOOLTIP');
+
+      // when
+      await openTooltip(tooltipWrapper);
+      const tooltip = domQuery('.bio-properties-panel-tooltip', entry);
+
+      // then
+      expect(tooltip).to.exist;
+      expect(tooltip.textContent).to.contain('CONFIGURATION_TOOLTIP');
+    });
+
+
     it('should display tooltip for groups', async function() {
 
       // given

--- a/test/spec/cloud-element-templates/properties/CustomProperties.tooltip.json
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.tooltip.json
@@ -94,6 +94,26 @@
           "name": "string"
         },
         "group": "group"
+      },
+      {
+        "label": "configuration",
+        "tooltip": "CONFIGURATION_TOOLTIP",
+        "type": "Configuration",
+        "configurationTemplate": "io.camunda:example-configuration:1",
+        "binding": {
+          "type": "zeebe:property",
+          "name": "configuration"
+        },
+        "group": "group"
+      }
+    ],
+    "configurationTemplates": [
+      {
+        "id": "io.camunda:example-configuration:1",
+        "kind": "CREDENTIAL",
+        "name": "Example configuration",
+        "version": 1,
+        "properties": []
       }
     ]
   }


### PR DESCRIPTION
### Proposed Changes

Fixes the tooltip of element template properties of `type=Configuration`, which was rendered inline in the properties panel instead of as a hover tooltip on the label (unlike all other property types):

<img width="771" height="765" alt="image" src="https://github.com/user-attachments/assets/a0e20ded-d50b-4cdc-a435-14d40f795c19" />

The configuration chooser label is now wrapped with `TooltipEntry` from `@bpmn-io/properties-panel`, matching how all other custom property entries consume tooltips. Added a test mirroring the existing tooltip tests for the other property types.

Related to https://github.com/camunda/camunda-modeler/issues/6176

### Steps to try out:

* `it.only` "should display tooltip for configuration property" spec for above screenshot

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
