### PR TITLE
feat: add template replace action

### DIFF
--- a/src/cloud-element-templates/index.js
+++ b/src/cloud-element-templates/index.js
@@ -1,9 +1,11 @@
 import coreModule from './core';
 import propertiesProviderModule from './properties-panel';
+import popupMenuModule from 'bpmn-js/lib/features/popup-menu';
 
 export default {
   __depends__: [
     coreModule,
     propertiesProviderModule,
+    popupMenuModule
   ]
 };

--- a/src/cloud-element-templates/index.js
+++ b/src/cloud-element-templates/index.js
@@ -1,11 +1,11 @@
 import coreModule from './core';
 import propertiesProviderModule from './properties-panel';
-import popupMenuModule from 'bpmn-js/lib/features/popup-menu';
+import contextPadModule from 'bpmn-js/lib/features/context-pad';
 
 export default {
   __depends__: [
     coreModule,
     propertiesProviderModule,
-    popupMenuModule
+    contextPadModule
   ]
 };

--- a/src/components/ElementTemplatesGroup.js
+++ b/src/components/ElementTemplatesGroup.js
@@ -181,20 +181,12 @@ function SelectEntryTemplate({ element }) {
 function AppliedTemplate({ element }) {
   const translate = useService('translate'),
         elementTemplates = useService('elementTemplates'),
-        canvas = useService('canvas'),
-        popupMenu = useService('popupMenu');
+        contextPad = useService('contextPad');
 
   const openReplaceMenu = () => {
-    const bounds = canvas.getGraphics(element).getBoundingClientRect();
+    contextPad.open(element);
 
-    popupMenu.open(element, 'bpmn-replace', {
-      x: bounds.right,
-      y: bounds.bottom + 5
-    }, {
-      title: translate('Change element'),
-      width: 'var(--bpmn-replace-popup-width, 300px)',
-      search: true
-    });
+    contextPad.triggerEntry('replace', 'click', new MouseEvent('click'));
   };
 
   const menuItems = [

--- a/src/components/ElementTemplatesGroup.js
+++ b/src/components/ElementTemplatesGroup.js
@@ -180,9 +180,25 @@ function SelectEntryTemplate({ element }) {
 
 function AppliedTemplate({ element }) {
   const translate = useService('translate'),
-        elementTemplates = useService('elementTemplates');
+        elementTemplates = useService('elementTemplates'),
+        canvas = useService('canvas'),
+        popupMenu = useService('popupMenu');
+
+  const openReplaceMenu = () => {
+    const bounds = canvas.getGraphics(element).getBoundingClientRect();
+
+    popupMenu.open(element, 'bpmn-replace', {
+      x: bounds.right,
+      y: bounds.bottom + 5
+    }, {
+      title: translate('Change element'),
+      width: 'var(--bpmn-replace-popup-width, 300px)',
+      search: true
+    });
+  };
 
   const menuItems = [
+    { entry: translate('Replace'), action: openReplaceMenu },
     { entry: translate('Unlink'), action: () => elementTemplates.unlinkTemplate(element) },
     { entry: <RemoveTemplate />, action: () => elementTemplates.removeTemplate(element) }
   ];

--- a/src/element-templates/index.js
+++ b/src/element-templates/index.js
@@ -1,9 +1,11 @@
 import coreModule from './core';
 import propertiesProviderModule from './properties-panel';
+import popupMenuModule from 'bpmn-js/lib/features/popup-menu';
 
 export default {
   __depends__: [
     coreModule,
     propertiesProviderModule,
+    popupMenuModule
   ]
 };

--- a/src/element-templates/index.js
+++ b/src/element-templates/index.js
@@ -1,11 +1,11 @@
 import coreModule from './core';
 import propertiesProviderModule from './properties-panel';
-import popupMenuModule from 'bpmn-js/lib/features/popup-menu';
+import contextPadModule from 'bpmn-js/lib/features/context-pad';
 
 export default {
   __depends__: [
     coreModule,
     propertiesProviderModule,
-    popupMenuModule
+    contextPadModule
   ]
 };

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -35,6 +35,15 @@ import templates from '../fixtures/simple.json';
 import entriesVisibleDiagramXML from '../fixtures/entries-visible.bpmn';
 import entriesVisibleTemplates from '../fixtures/entries-visible.json';
 
+const knownTemplates = [
+  {
+    id: 'foo',
+    name: 'Foo',
+    appliesTo: [ 'bpmn:Task' ],
+    properties: []
+  }
+];
+
 
 describe('provider/element-templates - ElementTemplates', function() {
 
@@ -491,6 +500,52 @@ describe('provider/element-templates - ElementTemplates', function() {
   });
 
 
+  describe('template#replace', function() {
+
+    beforeEach(bootstrapPropertiesPanel(diagramXML, {
+      container,
+      modules: [
+        BpmnPropertiesPanel,
+        coreModule,
+        BpmnPropertiesProvider,
+        elementTemplatesModule,
+        modelingModule
+      ],
+      moddleExtensions: {
+        camunda: camundaModdlePackage
+      },
+      debounceInput: false,
+      elementTemplates: knownTemplates
+    }));
+
+    it('should open BPMN replace menu', inject(
+      async function(elementRegistry, selection, popupMenu) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+        const openSpy = spy(popupMenu, 'open');
+
+        await act(() => selection.select(task));
+
+        const menuItems = map(
+          domQueryAll('.bio-properties-panel-dropdown-button__menu-item', container),
+          item => item.textContent
+        );
+
+        expect(menuItems).to.deep.equal([ 'Replace', 'Unlink', 'Remove' ]);
+
+        // when
+        await replaceElement(container);
+
+        // then
+        expect(openSpy).to.have.been.calledOnce;
+        expect(openSpy).to.have.been.calledWith(task, 'bpmn-replace');
+        expect(popupMenu.isOpen()).to.be.true;
+      })
+    );
+  });
+
+
   describe('template#update', function() {
 
     it('should update template', inject(
@@ -582,6 +637,15 @@ function removeTemplate(container) {
  */
 function unlinkTemplate(container) {
   return clickDropdownItemWhere(container, element => element.textContent === 'Unlink');
+}
+
+/**
+ * Replace element via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function replaceElement(container) {
+  return clickDropdownItemWhere(container, element => element.textContent === 'Replace');
 }
 
 /**

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -1,7 +1,7 @@
 import TestContainer from 'mocha-test-container-support';
 
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { match, spy } from 'sinon';
 
 import {
   act
@@ -519,10 +519,11 @@ describe('provider/element-templates - ElementTemplates', function() {
     }));
 
     it('should open BPMN replace menu', inject(
-      async function(elementRegistry, selection, popupMenu) {
+      async function(elementRegistry, selection, contextPad, popupMenu) {
 
         // given
         const task = elementRegistry.get('Task_1');
+        const triggerSpy = spy(contextPad, 'triggerEntry');
         const openSpy = spy(popupMenu, 'open');
 
         await act(() => selection.select(task));
@@ -538,6 +539,11 @@ describe('provider/element-templates - ElementTemplates', function() {
         await replaceElement(container);
 
         // then
+        expect(triggerSpy).to.have.been.calledWithMatch(
+          'replace',
+          'click',
+          match.any
+        );
         expect(openSpy).to.have.been.calledOnce;
         expect(openSpy).to.have.been.calledWith(task, 'bpmn-replace');
         expect(popupMenu.isOpen()).to.be.true;


### PR DESCRIPTION
### Proposed Changes

Prototyped implementation of a rejected solution approach - the bpmn-replace popup should also filter by compatible templates

Add **Replace** to the known Applied template menu, before Unlink and Remove. It opens bpmn-js's unchanged `bpmn-replace` / Change element popup at the selected element by reusing the existing context-pad `replace` action, so title, width, and position stay in lock-step with the native behavior.

The context-pad module is now a dependency of both the Camunda 7 and Camunda 8 template provider modules, so the action is available whenever either module is installed.

https://github.com/user-attachments/assets/8796b6e8-0317-4206-9643-eda200e8adc7

Related to https://github.com/camunda/camunda-modeler/issues/6177

**Try it out**

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates#hanselides-template-replace-prototype
npm start
```

Apply a known template to a task, open its **Applied** dropdown in the properties panel, and click **Replace**.

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

