### PR TITLE
feat: add `Change template` action

### DIFF
--- a/src/components/ElementTemplatesGroup.js
+++ b/src/components/ElementTemplatesGroup.js
@@ -180,9 +180,13 @@ function SelectEntryTemplate({ element }) {
 
 function AppliedTemplate({ element }) {
   const translate = useService('translate'),
-        elementTemplates = useService('elementTemplates');
+        elementTemplates = useService('elementTemplates'),
+        eventBus = useService('eventBus');
+
+  const changeTemplate = () => eventBus.fire('elementTemplates.select', { element });
 
   const menuItems = [
+    { entry: translate('Change'), action: changeTemplate },
     { entry: translate('Unlink'), action: () => elementTemplates.unlinkTemplate(element) },
     { entry: <RemoveTemplate />, action: () => elementTemplates.removeTemplate(element) }
   ];

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -422,6 +422,35 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
   });
 
 
+  describe('template#change', function() {
+
+    it('should emit `elementTemplates.select` when change is requested', inject(
+      async function(elementRegistry, selection, elementTemplates, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+        const selectSpy = spy();
+
+        eventBus.on('elementTemplates.select', selectSpy);
+
+        const template = elementTemplates.getLatest('foo')[0];
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, template);
+          selection.select(task);
+        });
+
+        // when
+        await changeTemplate(container);
+
+        // then
+        expect(selectSpy).to.have.been.calledOnce;
+        expect(selectSpy).to.have.been.calledWithMatch({ element: task });
+      })
+    );
+  });
+
+
   describe('template#remove', function() {
 
     it('should remove applied template', inject(
@@ -1419,6 +1448,15 @@ function removeTemplate(container) {
  */
 function unlinkTemplate(container) {
   return clickDropdownItemWhere(container, element => element.textContent === 'Unlink');
+}
+
+/**
+ * Change template via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function changeTemplate(container) {
+  return clickDropdownItemWhere(container, element => element.textContent === 'Change');
 }
 
 /**

--- a/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -491,6 +491,35 @@ describe('provider/element-templates - ElementTemplates', function() {
   });
 
 
+  describe('template#change', function() {
+
+    it('should emit `elementTemplates.select` when change is requested', inject(
+      async function(elementRegistry, selection, elementTemplates, eventBus) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+        const selectSpy = spy();
+
+        eventBus.on('elementTemplates.select', selectSpy);
+
+        const template = elementTemplates.getLatest('foo')[0];
+
+        await act(() => {
+          elementTemplates.applyTemplate(task, template);
+          selection.select(task);
+        });
+
+        // when
+        await changeTemplate(container);
+
+        // then
+        expect(selectSpy).to.have.been.calledOnce;
+        expect(selectSpy).to.have.been.calledWithMatch({ element: task });
+      })
+    );
+  });
+
+
   describe('template#update', function() {
 
     it('should update template', inject(
@@ -582,6 +611,15 @@ function removeTemplate(container) {
  */
 function unlinkTemplate(container) {
   return clickDropdownItemWhere(container, element => element.textContent === 'Unlink');
+}
+
+/**
+ * Change template via dropdown menu.
+ *
+ * @param {Element} container
+ */
+function changeTemplate(container) {
+  return clickDropdownItemWhere(container, element => element.textContent === 'Change');
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes

Adds a **Change** entry to the applied template menu that opens the element template chooser via the standard `elementTemplates.select` integration:

<img width="1603" height="724" alt="capture cYVZHo_optimized" src="https://github.com/user-attachments/assets/aa996d80-c57b-434a-ac80-bf19781360cc" />

Related to camunda/camunda-modeler#6177

#### Try out

```sh
npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates#nikku-pr-292-element-template-chooser
npm start
```

Apply a template to a task, open its **Applied** dropdown in the properties panel, and click **Change**.


### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)