### PR TITLE
fix: keep configured Boolean property values on unlink and reapply

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -2464,6 +2464,25 @@ export function findOldProperty(oldTemplate, newProperty) {
 }
 
 /**
+ * Check whether a binding stores its value in a dedicated container element
+ * (zeebe:Property, zeebe:Header, zeebe:Input, zeebe:Output) rather than as a
+ * plain moddle attribute. Such containers have no schema default, so their
+ * presence always reflects an explicitly configured value.
+ *
+ * @param {Object} binding
+ *
+ * @returns {boolean}
+ */
+function isValueContainerBinding(binding) {
+  return [
+    'zeebe:property',
+    'zeebe:taskHeader',
+    'zeebe:input',
+    'zeebe:output'
+  ].includes(binding.type);
+}
+
+/**
  * Check whether the existing property should be kept. This is the case if
  *  - an old template was set and the value differs from the default
  *  - no template was set but the property was set manually
@@ -2504,9 +2523,12 @@ function shouldKeepValue(element, oldProperty, newProperty) {
     return propertyChanged(element, oldProperty);
   }
 
-  // For Boolean type `!!value` check below would keep moddle schema defaults
-  // (e.g. propagateAllParentVariables=true), preventing the template from overriding.
-  if (newProperty.type === 'Boolean') {
+  // For Boolean properties bound directly to a moddle attribute, `!!value` would
+  // keep moddle schema defaults (e.g. propagateAllParentVariables=true), preventing
+  // the template from overriding. Properties stored in a dedicated container element
+  // (zeebe:Property, zeebe:Header, zeebe:Input, zeebe:Output) have no such schema
+  // default, so an existing container unambiguously reflects a configured value.
+  if (newProperty.type === 'Boolean' && !isValueContainerBinding(newProperty.binding)) {
     return false;
   }
 

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -4033,6 +4033,69 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
     });
 
+
+    describe('unlink and reapply Boolean property', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+
+      it('should keep zeebe:property value', inject(function(elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        const template = require('./boolean-property-static-feel.json');
+
+        task = changeTemplate(task, template);
+
+        updateBusinessObject('Task_1', getZeebeProperty(task, 'BooleanProperty'), {
+          value: '=true'
+        });
+
+        // unlink template, keeping properties
+        task = changeTemplate(task, null, template);
+
+        // when
+        task = changeTemplate(task, template);
+
+        // then
+        expect(getZeebeProperty(task, 'BooleanProperty').get('value')).to.equal('=true');
+      }));
+
+
+      it('should keep zeebe:input value', inject(function(elementRegistry) {
+
+        // given
+        let task = elementRegistry.get('Task_1');
+
+        const template = createTemplate({
+          value: false,
+          type: 'Boolean',
+          feel: 'static',
+          binding: {
+            type: 'zeebe:input',
+            name: 'IncludeAgentContext'
+          }
+        });
+
+        task = changeTemplate(task, template);
+
+        updateBusinessObject('Task_1', getInputParameter(task, 'IncludeAgentContext'), {
+          source: '=true'
+        });
+
+        // unlink template, keeping properties
+        task = changeTemplate(task, null, template);
+
+        // when
+        task = changeTemplate(task, template);
+
+        // then
+        expect(getInputParameter(task, 'IncludeAgentContext').get('source')).to.equal('=true');
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/cloud-element-templates/cmd/boolean-property-static-feel.json
+++ b/test/spec/cloud-element-templates/cmd/boolean-property-static-feel.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "FEEL static",
+  "id": "booleanField.feel.static",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "label": "BooleanProperty",
+      "type": "Boolean",
+      "feel": "static",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "BooleanProperty"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6174

Unlinking and reapplying an element template (even the exact same template/version) reset any `Boolean`-typed property back to the template's default value, discarding the user's configuration.

`shouldKeepValue()` in `ChangeElementTemplateHandler.js` forced any `Boolean` property to the new template's default whenever there was no `oldTemplate` to diff against. Unlinking drops the `oldTemplate` reference entirely, so this branch fired unconditionally on reapply.

This behavior was originally introduced to stop a moddle schema Boolean default (only `zeebe:CalledElement#propagateAllParentVariables` declares one) from shadowing a template's own default for **direct attribute bindings**. It has no schema-default ambiguity for properties stored in a **dedicated container element** (`zeebe:Property`, `zeebe:Header`, `zeebe:Input`, `zeebe:Output`) — if such a container exists, its value is unambiguously a configured one, not a phantom default.

The fix scopes the override to direct-attribute Boolean bindings only, so container-based bindings keep their existing value on unlink + reapply.

No UI/UX visible change beyond the described checkbox behavior, so no screenshots/videos are attached.

Steps to try out:
1. Apply an element template with a Boolean property bound via `zeebe:property` (or `zeebe:input`/`zeebe:output`/`zeebe:taskHeader`) to a task.
2. Tick the checkbox.
3. Unlink the template from the properties panel.
4. Reapply the same (or a newer) template version.
5. Before the fix: checkbox resets to the template default. After the fix: the configured value is kept.

Note: direct-attribute Boolean bindings (e.g. `propagateAllParentVariables`) still reset on unlink + reapply — an explicit attribute value equal to the schema default is genuinely indistinguishable from an unset one at the moddle level, so this case is left as-is and out of scope here.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
