### PR TITLE
fix: keep explicitly configured properties on template (re-)application

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -2529,6 +2529,27 @@ function propertyChanged(element, oldProperty) {
 }
 
 function getPropertyValue(element, property) {
+  const holder = getPropertyHolder(element, property);
+
+  if (!holder) {
+    return;
+  }
+
+  const { businessObject, name } = holder;
+
+  return businessObject.get(name);
+}
+
+/**
+ * Resolve the moddle element and attribute name that back a given property
+ * binding, i.e. where its value is actually stored.
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {Object} property
+ *
+ * @returns {{ businessObject: ModdleElement, name: string }|undefined}
+ */
+function getPropertyHolder(element, property) {
   const businessObject = getBusinessObject(element);
 
   if (!businessObject) {
@@ -2542,98 +2563,72 @@ function getPropertyValue(element, property) {
 
 
   if (bindingType === 'property') {
-    return businessObject.get(bindingName);
+    return { businessObject, name: bindingName };
   }
 
   if (TASK_DEFINITION_TYPES.includes(bindingType)) {
-    return businessObject.get(getTaskDefinitionPropertyName(binding));
+    return { businessObject, name: getTaskDefinitionPropertyName(binding) };
   }
 
   if (bindingType === 'zeebe:input') {
-    return businessObject.get('zeebe:source');
+    return { businessObject, name: 'zeebe:source' };
   }
 
   if (bindingType === 'zeebe:output') {
-    return businessObject.get('zeebe:target');
+    return { businessObject, name: 'zeebe:target' };
   }
 
   if (bindingType === 'zeebe:taskHeader') {
-    return businessObject.get('zeebe:value');
+    return { businessObject, name: 'zeebe:value' };
   }
 
   if (bindingType === 'zeebe:property') {
-    return businessObject.get('zeebe:value');
+    return { businessObject, name: 'zeebe:value' };
   }
 
   if (bindingType === MESSAGE_PROPERTY_TYPE) {
-    return businessObject.get(bindingName);
+    return { businessObject, name: bindingName };
   }
 
   if (bindingType === MESSAGE_ZEEBE_SUBSCRIPTION_PROPERTY_TYPE) {
-    return businessObject.get(bindingName);
+    return { businessObject, name: bindingName };
   }
 
   if (bindingType === SIGNAL_PROPERTY_TYPE) {
-    return businessObject.get(bindingName);
+    return { businessObject, name: bindingName };
   }
 
-  if (bindingType === ZEEBE_LINKED_RESOURCE_PROPERTY) {
-    return businessObject.get(bindingProperty);
+  if ([
+    ZEEBE_LINKED_RESOURCE_PROPERTY,
+    ZEEBE_CALLED_DECISION,
+    ZEEBE_CALLED_ELEMENT,
+    ZEEBE_FORM_DEFINITION,
+    ZEEBE_SCRIPT_TASK,
+    ZEEBE_ASSIGNMENT_DEFINITION,
+    ZEEBE_PRIORITY_DEFINITION,
+    ZEEBE_JOB_PRIORITY_DEFINITION,
+    ZEEBE_AD_HOC,
+    ZEEBE_AGENT_DEFINITION,
+    ZEEBE_TASK_SCHEDULE
+  ].includes(bindingType)) {
+    return { businessObject, name: bindingProperty };
   }
 
-  if (bindingType === ZEEBE_CALLED_DECISION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_CALLED_ELEMENT) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_FORM_DEFINITION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_SCRIPT_TASK) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_ASSIGNMENT_DEFINITION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_PRIORITY_DEFINITION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_JOB_PRIORITY_DEFINITION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_AD_HOC) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_AGENT_DEFINITION) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === ZEEBE_TASK_SCHEDULE) {
-    return businessObject.get(bindingProperty);
-  }
-
-  if (bindingType === TIMER_EVENT_DEFINITION_PROPERTY_TYPE) {
+  if (
+    bindingType === TIMER_EVENT_DEFINITION_PROPERTY_TYPE ||
+    bindingType === CONDITIONAL_EVENT_DEFINITION_PROPERTY
+  ) {
 
     // the actual value is nested in an Expression
-    return businessObject.get(bindingName)?.get('body');
-  }
+    const expression = businessObject.get(bindingName);
 
-  if (bindingType === CONDITIONAL_EVENT_DEFINITION_PROPERTY) {
-    return businessObject.get(bindingName)?.get('body');
+    return expression && { businessObject: expression, name: 'body' };
   }
 
   if (bindingType === CONDITIONAL_EVENT_DEFINITION_ZEEBE_CONDITIONAL_FILTER_PROPERTY) {
     const conditionalFilter = findExtension(businessObject, 'zeebe:ConditionalFilter');
-    return conditionalFilter?.get(bindingName);
+
+    return conditionalFilter && { businessObject: conditionalFilter, name: bindingName };
   }
 }
 

--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -2465,8 +2465,8 @@ export function findOldProperty(oldTemplate, newProperty) {
 
 /**
  * Check whether the existing property should be kept. This is the case if
- *  - an old template was set and the value differs from the default
- *  - no template was set but the property was set manually
+ *  - an old template was set and the value was explicitly changed from the default
+ *  - no template was set but the property was explicitly set manually
  *
  * @param {djs.model.Base|ModdleElement} element
  * @param {Object} oldProperty
@@ -2492,8 +2492,9 @@ function shouldKeepValue(element, oldProperty, newProperty) {
 
     const currentValue = getPropertyValue(element, newProperty);
 
-    // only keep value if old value is a valid option
-    return newProperty.choices && newProperty.choices.some(
+    // only keep value if explicitly set and a valid option
+    return hasExplicitValue(element, newProperty) &&
+      newProperty.choices && newProperty.choices.some(
       (choice) => choice.value === currentValue
     );
   }
@@ -2504,14 +2505,10 @@ function shouldKeepValue(element, oldProperty, newProperty) {
     return propertyChanged(element, oldProperty);
   }
 
-  // For Boolean type `!!value` check below would keep moddle schema defaults
-  // (e.g. propagateAllParentVariables=true), preventing the template from overriding.
-  if (newProperty.type === 'Boolean') {
-    return false;
-  }
-
-  // keep existing property value
-  return !!(getPropertyValue(element, newProperty));
+  // moddle schema defaults (e.g. propagateAllParentVariables=true,
+  // bindingType="latest") must not be treated as user data
+  // cf. https://github.com/camunda/camunda-modeler/issues/6174
+  return hasExplicitValue(element, newProperty);
 }
 
 /**
@@ -2523,6 +2520,10 @@ function shouldKeepValue(element, oldProperty, newProperty) {
  * @returns {boolean}
  */
 function propertyChanged(element, oldProperty) {
+  if (!hasExplicitValue(element, oldProperty)) {
+    return false;
+  }
+
   const oldPropertyValue = getDefaultFixedValue(oldProperty);
 
   return getPropertyValue(element, oldProperty) !== oldPropertyValue;
@@ -2630,6 +2631,43 @@ function getPropertyHolder(element, property) {
 
     return conditionalFilter && { businessObject: conditionalFilter, name: bindingName };
   }
+}
+
+/**
+ * Check whether a property's current value was explicitly set, as opposed
+ * to a moddle schema default returned by get() for an attribute that was
+ * never written (e.g. absent from the BPMN XML).
+ *
+ * @param {djs.model.Base|ModdleElement} element
+ * @param {Object} property
+ *
+ * @returns {boolean}
+ */
+function hasExplicitValue(element, property) {
+  const holder = getPropertyHolder(element, property);
+
+  if (!holder) {
+    return false;
+  }
+
+  const { businessObject, name } = holder;
+
+  // own properties are keyed by their local name, not the namespaced
+  // binding name (e.g. "value" rather than "zeebe:value")
+  const descriptor = businessObject.$descriptor
+    && businessObject.$descriptor.propertiesByName[name];
+
+  // properties not declared in the moddle schema (e.g. custom `property`
+  // bindings) are stored in `$attrs` rather than as an own property
+  if (!descriptor) {
+    return hasOwnProperty(businessObject.$attrs, name);
+  }
+
+  return hasOwnProperty(businessObject, descriptor.name);
+}
+
+function hasOwnProperty(obj, key) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
 function remove(array, item) {

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2644,26 +2644,112 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
 
     describe('apply zeebe:calledElement Boolean binding', function() {
 
-      beforeEach(bootstrap(require('./called-element-propagate.bpmn').default));
-
       const newTemplate = require('./called-element-propagate.json');
 
 
-      it('should override moddle default <propagateAllParentVariables=true> with template <false>',
+      describe('attribute absent', function() {
+
+        beforeEach(bootstrap(require('./called-element-propagate-absent.bpmn').default));
+
+        it('should override moddle default <propagateAllParentVariables=true> with template <false>',
+          inject(function(elementRegistry) {
+
+            // given
+            let callActivity = elementRegistry.get('CallActivity_1');
+
+            // when
+            changeTemplate(callActivity, newTemplate);
+
+            // then
+            callActivity = elementRegistry.get('CallActivity_1');
+            const calledElement = findExtension(callActivity, 'zeebe:CalledElement');
+
+            expect(calledElement).to.have.property('propagateAllParentVariables', false);
+          }));
+
+      });
+
+
+      describe('attribute explicitly set', function() {
+
+        beforeEach(bootstrap(require('./called-element-propagate.bpmn').default));
+
+        it('should keep explicitly set <propagateAllParentVariables=true>',
+          inject(function(elementRegistry) {
+
+            // given
+            let callActivity = elementRegistry.get('CallActivity_1');
+
+            // when
+            changeTemplate(callActivity, newTemplate);
+
+            // then
+            callActivity = elementRegistry.get('CallActivity_1');
+            const calledElement = findExtension(callActivity, 'zeebe:CalledElement');
+
+            expect(calledElement).to.have.property('propagateAllParentVariables', true);
+          }));
+
+      });
+
+    });
+
+
+    describe('Boolean binding upgrade (old template known)', function() {
+
+      beforeEach(bootstrap(require('./task.bpmn').default));
+
+      it('should apply new default when old template had no default and attribute is absent',
         inject(function(elementRegistry) {
 
           // given
-          let callActivity = elementRegistry.get('CallActivity_1');
+          const oldTemplate = createTemplate({
+            type: 'Boolean',
+            binding: { type: 'property', name: 'isForCompensation' }
+          });
+
+          const newTemplate = createTemplate({
+            type: 'Boolean',
+            value: true,
+            binding: { type: 'property', name: 'isForCompensation' }
+          });
+
+          let task = elementRegistry.get('Task_1');
+          task = changeTemplate(task, oldTemplate);
 
           // when
-          changeTemplate(callActivity, newTemplate);
+          task = changeTemplate(task, newTemplate, oldTemplate);
 
           // then
-          callActivity = elementRegistry.get('CallActivity_1');
-          const calledElement = findExtension(callActivity, 'zeebe:CalledElement');
-
-          expect(calledElement).to.have.property('propagateAllParentVariables', false);
+          expect(getBusinessObject(task).get('isForCompensation')).to.eql(true);
         }));
+
+
+      it('should replace a value that mirrors the old template default', inject(function(elementRegistry) {
+
+        // given
+        const oldTemplate = createTemplate({
+          type: 'Boolean',
+          value: true,
+          binding: { type: 'property', name: 'isForCompensation' }
+        });
+
+        const newTemplate = createTemplate({
+          type: 'Boolean',
+          value: false,
+          binding: { type: 'property', name: 'isForCompensation' }
+        });
+
+        let task = elementRegistry.get('Task_1');
+        task = changeTemplate(task, oldTemplate);
+
+        // when
+        task = changeTemplate(task, newTemplate, oldTemplate);
+
+        // then
+        expect(getBusinessObject(task).get('isForCompensation')).to.eql(false);
+      }));
+
     });
 
 
@@ -4009,6 +4095,27 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
           expect(getZeebeProperty(task, 'StaticBooleanProperty').value).to.eql('=true');
           expect(getZeebeProperty(task, 'OptionalBooleanProperty').value).to.eql('=true');
         }));
+
+
+        // cf. https://github.com/camunda/camunda-modeler/issues/6174
+        describe('existing user-configured value', function() {
+
+          beforeEach(bootstrap(require('./boolean-zeebe-property-existing.bpmn').default));
+
+          it('should keep existing value', inject(function(elementRegistry) {
+
+            // given
+            let task = elementRegistry.get('Task_1');
+
+            // when
+            task = changeTemplate(task, template);
+
+            // then
+            expect(getZeebeProperty(task, 'StaticBooleanProperty').value).to.eql('=false');
+            expect(getZeebeProperty(task, 'OptionalBooleanProperty').value).to.eql('=false');
+          }));
+
+        });
 
       });
 

--- a/test/spec/cloud-element-templates/cmd/boolean-zeebe-property-existing.bpmn
+++ b/test/spec/cloud-element-templates/cmd/boolean-zeebe-property-existing.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="StaticBooleanProperty" value="=false" />
+          <zeebe:property name="OptionalBooleanProperty" value="=false" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/cmd/called-element-propagate-absent.bpmn
+++ b/test/spec/cloud-element-templates/cmd/called-element-propagate-absent.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="paymentProcess" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.bindingType.spec.js
@@ -206,9 +206,12 @@ describe('provider/cloud-element-templates - CustomProperties - binding type pro
 
       expect(entry).to.exist;
       expect(select).to.exist;
+
+      // bindingType is absent from the XML; the template default (deployment)
+      // applies instead of the moddle schema default (latest)
       expect(options).to.eql([
-        { value: 'latest', selected: true },
-        { value: 'deployment', selected: false },
+        { value: 'latest', selected: false },
+        { value: 'deployment', selected: true },
         { value: 'versionTag', selected: false }
       ]);
     }));


### PR DESCRIPTION
### Proposed Changes

Related to camunda/camunda-modeler#6174.

`shouldKeepValue()` had a blanket `return false` for Boolean properties when no old template was known (unlink + reapply), discarding explicitly configured values on reapplication. Fix: a value is user data only if explicitly set on the moddle element (own property, or `$attrs` for custom bindings) — never a schema default. Applied consistently for all property types:

* No old template: keep if explicitly present.
* Old template known (upgrade): keep if explicitly present **and** differs from the *old* default.
* Dropdown: keep if explicitly present and a valid choice.

`CustomProperties.bindingType.spec.js` expectation updated: `calledElement` dropdown now selects the template default instead of the moddle schema default (attribute absent from fixture XML) — same bug class as camunda/camunda-modeler#5969, now caught on a Dropdown property.

Follow-up filed: #296 (`findOldProperty()` missing a `zeebe:calledElement` case, out of scope here).

No UI/UX changes - just [alignment with our "preserve user defined valid" semantics](https://github.com/bpmn-io/element-templates/blob/main/docs/LIFE_CYCLE.md#upgrade-behavior).

### Try out

* apply a template with a Boolean/Dropdown/String property, unlink it, reapply (or apply a new version) — the configured value is kept instead of reset to the template default.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
