### PR TITLE
fix(cloud-element-templates): wire `$parent` on task header and property setters

### DIFF
--- a/src/cloud-element-templates/util/propertyUtil.js
+++ b/src/cloud-element-templates/util/propertyUtil.js
@@ -752,6 +752,8 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
     } else {
       const newTaskHeader = createTaskHeader(binding, value, bpmnFactory);
 
+      newTaskHeader.$parent = taskHeaders;
+
       commands.push({
         cmd: 'element.updateModdleProperties',
         context: {
@@ -788,6 +790,8 @@ export function setPropertyValue(bpmnFactory, commandStack, element, property, v
 
     if (shouldUpdate(value, property)) {
       const newZeebeProperty = createZeebeProperty(binding, value, bpmnFactory, additionalProperties);
+
+      newZeebeProperty.$parent = zeebeProperties;
 
       properties.push(newZeebeProperty);
     }

--- a/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/cloud-element-templates/properties/CustomProperties.spec.js
@@ -989,6 +989,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         key: 'header-1-key',
         value: 'foo@bar'
       });
+      expect(header.$parent).to.equal(taskHeaders);
     }));
 
 
@@ -1015,6 +1016,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         key: 'header-1-key',
         value: 'foo@bar'
       });
+      expect(header.$parent).to.equal(taskHeaders);
     });
 
 
@@ -1079,6 +1081,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         name: 'property-1-name',
         value: 'property-1-changed-value'
       });
+      expect(zeebeProperty.$parent).to.equal(zeebeProperties);
     }));
 
 
@@ -1105,6 +1108,7 @@ describe('provider/cloud-element-templates - CustomProperties', function() {
         name: 'property-1-name',
         value: 'property-1-changed-value'
       });
+      expect(zeebeProperty.$parent).to.equal(zeebeProperties);
     });
 
 


### PR DESCRIPTION
### Proposed Changes

Editing a template-bound `zeebe:taskHeader` (e.g. a connector's `resultExpression`) or `zeebe:property` value through the properties panel created a replacement `zeebe:Header` / `zeebe:Property` and committed it into its parent collection **without setting the `$parent` moddle back-reference**. The result is a node that is present in its parent's `values` yet detached — `header.$parent === undefined`.

This breaks the moddle parent-chain invariant that the apply-template and change-template paths already uphold, and silently defeats any consumer that walks `$parent` upward. The symptom that surfaced it: `@camunda/linting`'s `agent-tool-output-key` rule computes its report path via `getPath(headerNode, element)`; for the detached header that returns `null`, so the lint warning loses its anchor and silently doesn't render beside the field.

The fix wires `$parent` on creation in both setter branches, consistent with the in-file `zeebe:taskDefinition` branch (`newTaskDefinition.$parent = businessObject`) and with `_updateZeebeTaskHeaderProperties` in the change handler (`newHeader.$parent = taskHeaders`). This is the direct sibling of #264 (Input/Output, already fixed via `createElement`) for the header/property binding types. I audited the remaining `setPropertyValue` create-paths — expression, task definition, io-mapping, subscription, called element, linked resources — all already wire `$parent`.

Before (after a panel edit):

```js
header.$parent // => undefined  (yet header is in taskHeaders.get('values'))
```

After:

```js
header.$parent === taskHeaders // => true
```

Closes #298
Related to #264

**Steps to try out**

1. `npm install && npm start`
2. Apply a connector/template that binds a field to a `zeebe:taskHeader` (or `zeebe:property`) to a task.
3. Edit that field's value in the properties panel and commit it.
4. Inspect the model: the header is in `zeebe:TaskHeaders.values` and now has `.$parent` set to its owning `zeebe:TaskHeaders` (previously `undefined`). Note `$parent` is non-enumerable — check via direct access, not `JSON.stringify`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)