### PR TITLE
Compare `zeebe:calledElement` against old template value

### DIFF
--- a/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
+++ b/src/cloud-element-templates/cmd/ChangeElementTemplateHandler.js
@@ -2306,6 +2306,19 @@ export function findOldProperty(oldTemplate, newProperty) {
     });
   }
 
+  if (newBindingType === ZEEBE_CALLED_ELEMENT) {
+    return oldProperties.find(oldProperty => {
+      const oldBinding = oldProperty.binding,
+            oldBindingType = oldBinding.type;
+
+      if (oldBindingType !== ZEEBE_CALLED_ELEMENT) {
+        return;
+      }
+
+      return oldBindingType === newBindingType && oldBinding.property === newBinding.property;
+    });
+  }
+
   if (newBindingType === ZEEBE_CALLED_DECISION) {
     return oldProperties.find(oldProperty => {
       const oldBinding = oldProperty.binding,

--- a/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
+++ b/test/spec/cloud-element-templates/cmd/ChangeElementTemplateHandler.spec.js
@@ -2753,6 +2753,148 @@ describe('cloud-element-templates/cmd - ChangeElementTemplateHandler', function(
     });
 
 
+    describe('zeebe:calledElement binding upgrade (old template known)', function() {
+
+      describe('String binding', function() {
+
+        beforeEach(bootstrap(require('./task.bpmn').default));
+
+        it('should replace a value that mirrors the old template default', inject(function(elementRegistry) {
+
+          // given
+          const oldTemplate = createTemplate({
+            type: 'String',
+            value: 'oldProcess',
+            binding: { type: 'zeebe:calledElement', property: 'processId' }
+          });
+
+          const newTemplate = createTemplate({
+            type: 'String',
+            value: 'newProcess',
+            binding: { type: 'zeebe:calledElement', property: 'processId' }
+          });
+
+          let task = elementRegistry.get('Task_1');
+          task = changeTemplate(task, oldTemplate);
+
+          // when
+          task = changeTemplate(task, newTemplate, oldTemplate);
+
+          // then
+          const calledElement = findExtension(task, 'zeebe:CalledElement');
+
+          expect(calledElement).to.exist;
+          expect(calledElement).to.have.property('processId', 'newProcess');
+        }));
+
+
+        it('should keep a value that does not mirror the old template default', inject(function(elementRegistry) {
+
+          // given
+          const oldTemplate = createTemplate({
+            type: 'String',
+            value: 'oldProcess',
+            binding: { type: 'zeebe:calledElement', property: 'processId' }
+          });
+
+          const newTemplate = createTemplate({
+            type: 'String',
+            value: 'newProcess',
+            binding: { type: 'zeebe:calledElement', property: 'processId' }
+          });
+
+          let task = elementRegistry.get('Task_1');
+          task = changeTemplate(task, oldTemplate);
+
+          // user changed the value
+          const businessObject = getBusinessObject(task);
+          const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+          calledElement.set('processId', 'userDefinedProcess');
+
+          // when
+          task = changeTemplate(task, newTemplate, oldTemplate);
+
+          // then
+          const newCalledElement = findExtension(task, 'zeebe:CalledElement');
+
+          expect(newCalledElement).to.exist;
+          expect(newCalledElement).to.have.property('processId', 'userDefinedProcess');
+        }));
+
+      });
+
+
+      describe('Boolean binding', function() {
+
+        beforeEach(bootstrap(require('./called-element-propagate.bpmn').default));
+
+        it('should replace a value that mirrors the old template default', inject(function(elementRegistry) {
+
+          // given
+          const oldTemplate = createTemplate({
+            type: 'Boolean',
+            value: true,
+            binding: { type: 'zeebe:calledElement', property: 'propagateAllParentVariables' }
+          });
+
+          const newTemplate = createTemplate({
+            type: 'Boolean',
+            value: false,
+            binding: { type: 'zeebe:calledElement', property: 'propagateAllParentVariables' }
+          });
+
+          let callActivity = elementRegistry.get('CallActivity_1');
+          callActivity = changeTemplate(callActivity, oldTemplate);
+
+          // when
+          callActivity = changeTemplate(callActivity, newTemplate, oldTemplate);
+
+          // then
+          const calledElement = findExtension(callActivity, 'zeebe:CalledElement');
+
+          expect(calledElement).to.exist;
+          expect(calledElement).to.have.property('propagateAllParentVariables', false);
+        }));
+
+
+        it('should keep a value that does not mirror the old template default', inject(function(elementRegistry) {
+
+          // given
+          const oldTemplate = createTemplate({
+            type: 'Boolean',
+            value: true,
+            binding: { type: 'zeebe:calledElement', property: 'propagateAllParentVariables' }
+          });
+
+          const newTemplate = createTemplate({
+            type: 'Boolean',
+            value: true,
+            binding: { type: 'zeebe:calledElement', property: 'propagateAllParentVariables' }
+          });
+
+          let callActivity = elementRegistry.get('CallActivity_1');
+          callActivity = changeTemplate(callActivity, oldTemplate);
+
+          // user changed the value
+          const businessObject = getBusinessObject(callActivity);
+          const calledElement = findExtension(businessObject, 'zeebe:CalledElement');
+          calledElement.set('propagateAllParentVariables', false);
+
+          // when
+          callActivity = changeTemplate(callActivity, newTemplate, oldTemplate);
+
+          // then
+          const newCalledElement = findExtension(callActivity, 'zeebe:CalledElement');
+
+          expect(newCalledElement).to.exist;
+          expect(newCalledElement).to.have.property('propagateAllParentVariables', false);
+        }));
+
+      });
+
+    });
+
+
     describe('create message with zeebe:modelerTemplate', function() {
 
       beforeEach(bootstrap(require('./event.bpmn').default));


### PR DESCRIPTION
### Proposed Changes

Closes #296

`findOldProperty()` had no branch for `zeebe:calledElement` bindings, so on a genuine template upgrade/replace (old template known) `shouldKeepValue()` always fell through to the "no old template" path for `processId`, `propagateAllParentVariables`, `propagateAllChildVariables`, `bindingType`, and `versionTag`. A value that merely mirrored the old template's default was kept instead of being replaced by the new template's differing default — unlike every other zeebe binding type.

The fix adds the missing branch, matching by the bound `property` name, following the exact pattern of the other single extension element bindings (e.g. `zeebe:calledDecision`).

Regression tests cover the upgrade path for String (`processId`) and Boolean (`propagateAllParentVariables`) bindings: a value mirroring the old default is replaced by the new default, while a user-changed value is kept. Both mirror-replace tests fail without the fix.

No UI/UX changes.

### Steps to try out

`npm test` — see `zeebe:calledElement binding upgrade (old template known)` specs

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->