### PR TITLE
fix(cloud-element-templates): hide template group if only incompatible templates apply

### DIFF
--- a/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
+++ b/src/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.js
@@ -103,7 +103,7 @@ export default class ElementTemplatesPropertiesProvider {
   }
 
   _shouldShowTemplateProperties(element) {
-    return getTemplateId(element) || this._elementTemplates.getAll(element).length;
+    return getTemplateId(element) || this._elementTemplates.getLatest(element).length;
   }
 
   /**

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.bpmn
@@ -5,6 +5,7 @@
     <bpmn:task id="Task_2" zeebe:modelerTemplate="foo" zeebe:modelerTemplateVersion="1" />
     <bpmn:task id="Task_3" />
     <bpmn:task id="Task_4" zeebe:modelerTemplate="engines" zeebe:modelerTemplateVersion="2" />
+    <bpmn:callActivity id="CallActivity_1" />
     <bpmn:task id="UnknownTemplateTask" zeebe:modelerTemplate="unknown" />
     <bpmn:serviceTask id="ServiceTask" zeebe:modelerTemplate="default" />
     <bpmn:serviceTask id="Deprecated" name="Deprecated" zeebe:modelerTemplate="deprecated" />
@@ -63,6 +64,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1m5dd19_di" bpmnElement="Task_4">
         <dc:Bounds x="500" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="620" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.json
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.json
@@ -147,5 +147,16 @@
       "camunda": "^8.6"
     },
     "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "engines-call-activity",
+    "name":"Engines Call Activity",
+    "version": 1,
+    "appliesTo": [ "bpmn:CallActivity" ],
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "properties": []
   }
 ]

--- a/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/cloud-element-templates/properties-panel/ElementTemplatesPropertiesProvider.spec.js
@@ -683,6 +683,53 @@ describe('provider/cloud-element-templates - ElementTemplatesPropertiesProvider'
       })
     );
 
+
+    it('should display template group if compatible templates are available for element', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        const element = elementRegistry.get('CallActivity_1');
+
+        // when
+        elementTemplates.setEngines({
+          camunda: '8.6'
+        });
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-ElementTemplates__Template"]', container);
+        expect(group).to.exist;
+
+        const selectButton = domQuery('.bio-properties-panel-select-template-button', group);
+        expect(selectButton).to.exist;
+      })
+    );
+
+
+    it('should NOT display template group if only incompatible templates are available for element', inject(
+      async function(elementRegistry, selection, elementTemplates) {
+
+        // given
+        const element = elementRegistry.get('CallActivity_1');
+
+        // when
+        elementTemplates.setEngines({
+          camunda: '8.0'
+        });
+
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-ElementTemplates__Template"]', container);
+        expect(group).not.to.exist;
+      })
+    );
+
   });
 
 


### PR DESCRIPTION
Related to camunda/camunda-modeler#6175

### What

When an element has no template applied and the only templates matching it are incompatible with the configured engines, the properties panel still rendered the `Template` group with a `Select` button — but there is nothing selectable, since the chooser only lists compatible (`getLatest`) templates.

### Fix

`_shouldShowTemplateProperties` used `getAll(element)`, which includes engine-incompatible templates. Switched it to `getLatest(element)`, which is the same engine-aware lookup the chooser uses. Elements that already carry a template (`modelerTemplate` set) are unaffected — the group still shows for applied / unknown / outdated / incompatible states.

The Camunda 7 (`element-templates`) provider is untouched: it has no engine compatibility concept.

### Tests

Added a `bpmn:CallActivity` fixture element with a single template requiring `camunda ^8.6`, plus two tests under `engines`:

- group shown (with the `Select` button) when engines are compatible (`8.6`)
- group hidden when only incompatible templates apply (`8.0`)

Verified RED→GREEN: with the source change reverted, the second test fails with `expected <div …> to not exist`; with the fix, it passes.

Full suite locally (`karma`, ChromeHeadless): 1564 tests, 0 failures. ESLint clean on changed files.

Happy to adjust (e.g. if you'd rather keep the group visible with a disabled/explanatory state instead of hiding it).
